### PR TITLE
server/commands: add missing grpc reflection to server

### DIFF
--- a/core/server/commands/assessment.go
+++ b/core/server/commands/assessment.go
@@ -24,7 +24,6 @@ import (
 	"confirmate.io/core/service/assessment"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/grpcreflect"
 	"github.com/urfave/cli/v3"
 )
 
@@ -48,14 +47,6 @@ var AssessmentCommand = &cli.Command{
 	Name:  "assessment",
 	Usage: "Launches the assessment service",
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		var (
-			reflector         *grpcreflect.Reflector
-			reflectionV1Path  string
-			reflectionV1      http.Handler
-			reflectionV1APath string
-			reflectionV1A     http.Handler
-		)
-
 		svc, err := assessment.NewService(
 			assessment.WithConfig(assessment.Config{
 				OrchestratorAddress: cmd.String("assessment-orchestrator-address"),
@@ -66,13 +57,6 @@ var AssessmentCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-
-		// Add reflector for gRPC reflection, which allows clients to query the server for its supported services and methods.
-		reflector = grpcreflect.NewStaticReflector(
-			assessmentconnect.AssessmentName,
-		)
-		reflectionV1Path, reflectionV1 = grpcreflect.NewHandlerV1(reflector)
-		reflectionV1APath, reflectionV1A = grpcreflect.NewHandlerV1Alpha(reflector)
 
 		return server.RunConnectServer(
 			server.WithConfig(server.Config{
@@ -89,8 +73,7 @@ var AssessmentCommand = &cli.Command{
 				svc,
 				connect.WithInterceptors(&server.LoggingInterceptor{}),
 			)),
-			server.WithHTTPHandler(reflectionV1Path, reflectionV1),
-			server.WithHTTPHandler(reflectionV1APath, reflectionV1A),
+			server.WithReflection(),
 		)
 	},
 	Flags: joinFlagSlices(

--- a/core/server/commands/confirmate.go
+++ b/core/server/commands/confirmate.go
@@ -30,7 +30,6 @@ import (
 	"confirmate.io/core/service/orchestrator"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/grpcreflect"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -95,11 +94,6 @@ var ConfirmateCommand = &cli.Command{
 			credentials        *clientcredentials.Config
 			authorizer         api.Authorizer
 			serverOpts         []server.Option
-			reflector          *grpcreflect.Reflector
-			reflectionV1Path   string
-			reflectionV1       http.Handler
-			reflectionV1APath  string
-			reflectionV1A      http.Handler
 		)
 
 		if cmd.Bool("auth-enabled") {
@@ -175,13 +169,6 @@ var ConfirmateCommand = &cli.Command{
 			return err
 		}
 
-		reflector = grpcreflect.NewStaticReflector(
-			orchestratorconnect.OrchestratorName,
-			assessmentconnect.AssessmentName,
-		)
-		reflectionV1Path, reflectionV1 = grpcreflect.NewHandlerV1(reflector)
-		reflectionV1APath, reflectionV1A = grpcreflect.NewHandlerV1Alpha(reflector)
-
 		serverOpts = []server.Option{
 			server.WithConfig(server.Config{
 				Port:     apiPort,
@@ -201,8 +188,7 @@ var ConfirmateCommand = &cli.Command{
 				assessmentSvc,
 				connect.WithInterceptors(interceptors...),
 			)),
-			server.WithHTTPHandler(reflectionV1Path, reflectionV1),
-			server.WithHTTPHandler(reflectionV1APath, reflectionV1A),
+			server.WithReflection(),
 		}
 
 		if cmd.Bool("oauth2-embedded") {

--- a/core/server/commands/evidence_store.go
+++ b/core/server/commands/evidence_store.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/grpcreflect"
 	"github.com/urfave/cli/v3"
 )
 
@@ -52,14 +51,6 @@ var EvidenceCommand = &cli.Command{
 	Name:  "evidence",
 	Usage: "Launches the evidence store service",
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		var (
-			reflector         *grpcreflect.Reflector
-			reflectionV1Path  string
-			reflectionV1      http.Handler
-			reflectionV1APath string
-			reflectionV1A     http.Handler
-		)
-
 		slog.Info("Starting Evidence Store",
 			slog.Uint64("api_port", uint64(cmd.Uint16("api-port"))),
 			slog.String("log_level", cmd.String("log-level")),
@@ -100,13 +91,6 @@ var EvidenceCommand = &cli.Command{
 			return err
 		}
 
-		// Add reflector for gRPC reflection, which allows clients to query the server for its supported services and methods.
-		reflector = grpcreflect.NewStaticReflector(
-			evidenceconnect.EvidenceStoreName,
-		)
-		reflectionV1Path, reflectionV1 = grpcreflect.NewHandlerV1(reflector)
-		reflectionV1APath, reflectionV1A = grpcreflect.NewHandlerV1Alpha(reflector)
-
 		return server.RunConnectServer(
 			server.WithConfig(server.Config{
 				Port:     cmd.Uint16("api-port"),
@@ -122,8 +106,7 @@ var EvidenceCommand = &cli.Command{
 				svc,
 				connect.WithInterceptors(&server.LoggingInterceptor{}),
 			)),
-			server.WithHTTPHandler(reflectionV1Path, reflectionV1),
-			server.WithHTTPHandler(reflectionV1APath, reflectionV1A),
+			server.WithReflection(),
 		)
 	},
 	Flags: joinFlagSlices(

--- a/core/server/commands/orchestrator.go
+++ b/core/server/commands/orchestrator.go
@@ -18,7 +18,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"confirmate.io/core/api/orchestrator/orchestratorconnect"
 	"confirmate.io/core/persistence"
@@ -27,7 +26,6 @@ import (
 	"confirmate.io/core/service/orchestrator"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/grpcreflect"
 	"github.com/urfave/cli/v3"
 )
 
@@ -71,17 +69,12 @@ var OrchestratorCommand = &cli.Command{
 	Usage: "Launches the orchestrator service",
 	Action: func(ctx context.Context, cmd *cli.Command) (err error) {
 		var (
-			interceptors      []connect.Interceptor
-			svcOptions        []service.Option[orchestrator.Service]
-			jwksURL           string
-			opts              []service.Option[orchestrator.Service]
-			svc               orchestratorconnect.OrchestratorHandler
-			serverOpts        []server.Option
-			reflector         *grpcreflect.Reflector
-			reflectionV1Path  string
-			reflectionV1      http.Handler
-			reflectionV1APath string
-			reflectionV1A     http.Handler
+			interceptors []connect.Interceptor
+			svcOptions   []service.Option[orchestrator.Service]
+			jwksURL      string
+			opts         []service.Option[orchestrator.Service]
+			svc          orchestratorconnect.OrchestratorHandler
+			serverOpts   []server.Option
 		)
 
 		if cmd.Bool("auth-enabled") {
@@ -126,13 +119,6 @@ var OrchestratorCommand = &cli.Command{
 			return err
 		}
 
-		// Add reflector for gRPC reflection, which allows clients to query the server for its supported services and methods.
-		reflector = grpcreflect.NewStaticReflector(
-			orchestratorconnect.OrchestratorName,
-		)
-		reflectionV1Path, reflectionV1 = grpcreflect.NewHandlerV1(reflector)
-		reflectionV1APath, reflectionV1A = grpcreflect.NewHandlerV1Alpha(reflector)
-
 		serverOpts = []server.Option{
 			server.WithConfig(server.Config{
 				Port:     cmd.Uint16("api-port"),
@@ -148,8 +134,7 @@ var OrchestratorCommand = &cli.Command{
 				svc,
 				connect.WithInterceptors(interceptors...),
 			)),
-			server.WithHTTPHandler(reflectionV1Path, reflectionV1),
-			server.WithHTTPHandler(reflectionV1APath, reflectionV1A),
+			server.WithReflection(),
 		}
 
 		err = server.RunConnectServer(serverOpts...)

--- a/core/server/connect.go
+++ b/core/server/connect.go
@@ -20,8 +20,10 @@ import (
 	"log/slog"
 	"net/http"
 
+	"connectrpc.com/grpcreflect"
 	"connectrpc.com/vanguard"
 
+	"confirmate.io/core/api/assessment/assessmentconnect"
 	"confirmate.io/core/log"
 )
 
@@ -51,12 +53,26 @@ func WithHandler(path string, handler http.Handler) Option {
 	}
 }
 
-// WithHTTPHandler adds an [http.Handler] at the specified path directly to the
-// underlying HTTP mux, bypassing vanguard transcoding.
-// Multiple handlers can be registered by calling WithHTTPHandler multiple times.
-func WithHTTPHandler(path string, handler http.Handler) Option {
+// WithReflection adds gRPC reflection support to the server, which allows clients to query the
+// server for its supported services and methods.
+func WithReflection() Option {
 	return func(svr *Server) {
-		svr.httpHandlers[path] = handler
+		var (
+			reflector         *grpcreflect.Reflector
+			reflectionV1Path  string
+			reflectionV1      http.Handler
+			reflectionV1APath string
+			reflectionV1A     http.Handler
+		)
+
+		reflector = grpcreflect.NewStaticReflector(
+			assessmentconnect.AssessmentName,
+		)
+		reflectionV1Path, reflectionV1 = grpcreflect.NewHandlerV1(reflector)
+		reflectionV1APath, reflectionV1A = grpcreflect.NewHandlerV1Alpha(reflector)
+
+		svr.httpHandlers[reflectionV1Path] = reflectionV1
+		svr.httpHandlers[reflectionV1APath] = reflectionV1A
 	}
 }
 

--- a/core/server/connect_test.go
+++ b/core/server/connect_test.go
@@ -26,24 +26,20 @@ import (
 func TestNewConnectServer_WithHTTPHandler(t *testing.T) {
 	tests := []struct {
 		name         string
-		pattern      string
 		requestPath  string
 		wantHTTPCode int
 	}{
 		{
 			name:         "Reflection-like route is served directly",
-			pattern:      "/grpc.reflection.v1.ServerReflection/",
 			requestPath:  "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
-			wantHTTPCode: http.StatusNoContent,
+			wantHTTPCode: http.StatusOK,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			srv, err := NewConnectServer([]Option{
-				WithHTTPHandler(tt.pattern, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusNoContent)
-				})),
+				WithReflection(),
 			})
 			assert.NoError(t, err)
 			assert.NotNil(t, srv)
@@ -53,6 +49,11 @@ func TestNewConnectServer_WithHTTPHandler(t *testing.T) {
 
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, tt.requestPath, nil)
+			req.Proto = "HTTP/2.0"
+			req.ProtoMajor = 2
+			req.ProtoMinor = 0
+			req.Header.Set("Content-Type", "application/connect+proto")
+			req.Header.Set("Connect-Protocol-Version", "1")
 			srv.Handler.ServeHTTP(rec, req)
 
 			assert.Equal(t, tt.wantHTTPCode, rec.Code)


### PR DESCRIPTION
This PR adds the missing grpc reflection to the following servers:
- assessment
- evidence store
- orchestrator