### PR TITLE
Orchestrator: Revise .proto regarding Certificates

### DIFF
--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -329,8 +329,6 @@ components:
                     type: boolean
                 monitoringLogDataEnabled:
                     type: boolean
-                name:
-                    type: string
                 retentionPeriod:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
@@ -479,8 +477,6 @@ components:
                     type: boolean
                 monitoringLogDataEnabled:
                     type: boolean
-                name:
-                    type: string
                 retentionPeriod:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
@@ -694,8 +690,6 @@ components:
                     type: boolean
                 monitoringLogDataEnabled:
                     type: boolean
-                name:
-                    type: string
                 retentionPeriod:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
@@ -3973,8 +3967,6 @@ components:
                     type: boolean
                 monitoringLogDataEnabled:
                     type: boolean
-                name:
-                    type: string
                 retentionPeriod:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
@@ -4886,8 +4878,6 @@ components:
                     type: boolean
                 monitoringLogDataEnabled:
                     type: boolean
-                name:
-                    type: string
                 retentionPeriod:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
@@ -5664,8 +5654,6 @@ components:
                     items:
                         type: string
                 description:
-                    type: string
-                name:
                     type: string
                 url:
                     type: string

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -793,30 +793,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-        post:
-            tags:
-                - Orchestrator
-            description: Creates a new compliance attestation
-            operationId: Orchestrator_CreateComplianceAttestation
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ComplianceAttestation'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ComplianceAttestation'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
     /v1/orchestrator/compliance_attestations/{complianceAttestationId}:
         get:
             tags:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -730,6 +730,39 @@ paths:
             description: Lists all compliance attestations
             operationId: Orchestrator_ListComplianceAttestations
             parameters:
+                - name: filter.auditScopeId
+                  in: query
+                  description: Optional. List only compliance attestations for a specific audit scope.
+                  schema:
+                    type: string
+                - name: filter.attestationType
+                  in: query
+                  description: Optional. List only compliance attestations of the specified type.
+                  schema:
+                    enum:
+                        - COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+                        - COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE
+                        - COMPLIANCE_ATTESTATION_TYPE_ATTESTATION
+                        - COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION
+                    type: string
+                    format: enum
+                - name: filter.complianceStatus
+                  in: query
+                  description: Optional. List only compliance attestations in the specified lifecycle state.
+                  schema:
+                    enum:
+                        - ATTESTATION_STATE_UNSPECIFIED
+                        - ATTESTATION_STATE_IN_PROGRESS
+                        - ATTESTATION_STATE_ACTIVE
+                        - ATTESTATION_STATE_ISSUED
+                        - ATTESTATION_STATE_SUSPENDED
+                        - ATTESTATION_STATE_WITHDRAWN
+                        - ATTESTATION_STATE_EXPIRED
+                        - ATTESTATION_STATE_APPLIED
+                        - ATTESTATION_STATE_UNDER_REVIEW
+                        - ATTESTATION_STATE_REJECTED
+                    type: string
+                    format: enum
                 - name: pageSize
                   in: query
                   schema:
@@ -1122,6 +1155,39 @@ paths:
             description: Lists all public compliance attestations without state history
             operationId: Orchestrator_ListPublicComplianceAttestations
             parameters:
+                - name: filter.auditScopeId
+                  in: query
+                  description: Optional. List only compliance attestations for a specific audit scope.
+                  schema:
+                    type: string
+                - name: filter.attestationType
+                  in: query
+                  description: Optional. List only compliance attestations of the specified type.
+                  schema:
+                    enum:
+                        - COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+                        - COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE
+                        - COMPLIANCE_ATTESTATION_TYPE_ATTESTATION
+                        - COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION
+                    type: string
+                    format: enum
+                - name: filter.complianceStatus
+                  in: query
+                  description: Optional. List only compliance attestations in the specified lifecycle state.
+                  schema:
+                    enum:
+                        - ATTESTATION_STATE_UNSPECIFIED
+                        - ATTESTATION_STATE_IN_PROGRESS
+                        - ATTESTATION_STATE_ACTIVE
+                        - ATTESTATION_STATE_ISSUED
+                        - ATTESTATION_STATE_SUSPENDED
+                        - ATTESTATION_STATE_WITHDRAWN
+                        - ATTESTATION_STATE_EXPIRED
+                        - ATTESTATION_STATE_APPLIED
+                        - ATTESTATION_STATE_UNDER_REVIEW
+                        - ATTESTATION_STATE_REJECTED
+                    type: string
+                    format: enum
                 - name: pageSize
                   in: query
                   schema:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -461,7 +461,7 @@ paths:
         put:
             tags:
                 - Orchestrator
-            description: Updates an existing certificate
+            description: Updates an existing catalog
             operationId: Orchestrator_UpdateCatalog
             parameters:
                 - name: catalog.id
@@ -1803,7 +1803,9 @@ components:
                         - COMPLIANCE_ATTESTATION_TYPE_ATTESTATION
                         - COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION
                     type: string
-                    description: Type of compliance attestation, e.g. certificate or attestation.
+                    description: |-
+                        Type of compliance attestation, e.g. formal certificate or third-party
+                         attestation.
                     format: enum
                 issuedAt:
                     type: string
@@ -1840,8 +1842,8 @@ components:
                          in states. When states are present, this should mirror the latest entry.
                     format: enum
             description: |-
-                ComplianceAttestation is the unified API resource for certificates, third-party
-                 attestations, and internal compliance declarations.
+                ComplianceAttestation is the unified API resource for formal compliance
+                 certificates, third-party attestations, and internal compliance declarations.
         ComplianceAttestationState:
             type: object
             properties:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -1666,14 +1666,12 @@ components:
             required:
                 - id
                 - name
-                - targetOfEvaluationId
+                - auditScopeId
             type: object
             properties:
                 id:
                     type: string
                 name:
-                    type: string
-                targetOfEvaluationId:
                     type: string
                 issueDate:
                     type: string
@@ -1692,7 +1690,54 @@ components:
                     items:
                         $ref: '#/components/schemas/State'
                     description: A list of states at specific times
-            description: An ISO17021-based certificate
+                auditScopeId:
+                    type: string
+                    description: |-
+                        Audit scope this attestation belongs to. This binds the attestation to a
+                         specific target of evaluation and catalog combination.
+                attestationType:
+                    enum:
+                        - COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+                        - COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE
+                        - COMPLIANCE_ATTESTATION_TYPE_ATTESTATION
+                        - COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION
+                    type: string
+                    description: Type of compliance attestation, e.g. certificate or attestation.
+                    format: enum
+                issuedAt:
+                    type: string
+                    description: Structured validity timestamps for lifecycle-aware consumers.
+                    format: date-time
+                validFrom:
+                    type: string
+                    format: date-time
+                validUntil:
+                    type: string
+                    format: date-time
+                certificationBody:
+                    type: string
+                    description: Optional auditor / certification body information.
+                auditor:
+                    type: string
+                complianceStatus:
+                    enum:
+                        - ATTESTATION_STATE_UNSPECIFIED
+                        - ATTESTATION_STATE_IN_PROGRESS
+                        - ATTESTATION_STATE_ACTIVE
+                        - ATTESTATION_STATE_ISSUED
+                        - ATTESTATION_STATE_SUSPENDED
+                        - ATTESTATION_STATE_WITHDRAWN
+                        - ATTESTATION_STATE_EXPIRED
+                        - ATTESTATION_STATE_APPLIED
+                        - ATTESTATION_STATE_UNDER_REVIEW
+                        - ATTESTATION_STATE_REJECTED
+                    type: string
+                    description: Current summarized compliance state. Detailed transitions live in states.
+                    format: enum
+            description: |-
+                Certificate is the legacy API name for a compliance attestation.
+                 It represents an assertion that a target of evaluation complies with a catalog
+                 in the scope of a specific audit scope.
         ComparisonResult:
             required:
                 - property
@@ -2040,16 +2085,33 @@ components:
                 id:
                     type: string
                 state:
+                    enum:
+                        - ATTESTATION_STATE_UNSPECIFIED
+                        - ATTESTATION_STATE_IN_PROGRESS
+                        - ATTESTATION_STATE_ACTIVE
+                        - ATTESTATION_STATE_ISSUED
+                        - ATTESTATION_STATE_SUSPENDED
+                        - ATTESTATION_STATE_WITHDRAWN
+                        - ATTESTATION_STATE_EXPIRED
+                        - ATTESTATION_STATE_APPLIED
+                        - ATTESTATION_STATE_UNDER_REVIEW
+                        - ATTESTATION_STATE_REJECTED
                     type: string
-                    description: An EUCS-defined state, e.g. `new`, `suspended` or `withdrawn`
+                    description: An EUCS-defined or platform-defined attestation lifecycle state.
+                    format: enum
                 treeId:
                     type: string
+                    description: Optional transparency log or external evidence tree reference.
                 timestamp:
                     type: string
+                    format: date-time
                 certificateId:
                     type: string
-                    description: Reference to the certificate
-            description: A state of a certificate at a given time
+                    description: Reference to the certificate / compliance attestation.
+                reason:
+                    type: string
+                    description: Optional human-readable reason for the state transition.
+            description: State is the legacy API name for a compliance attestation state transition.
         Status:
             type: object
             properties:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -723,12 +723,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/orchestrator/certificates:
+    /v1/orchestrator/compliance_attestations:
         get:
             tags:
                 - Orchestrator
-            description: Lists all target certificates
-            operationId: Orchestrator_ListCertificates
+            description: Lists all compliance attestations
+            operationId: Orchestrator_ListComplianceAttestations
             parameters:
                 - name: pageSize
                   in: query
@@ -753,7 +753,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ListCertificatesResponse'
+                                $ref: '#/components/schemas/ListComplianceAttestationsResponse'
                 default:
                     description: Default error response
                     content:
@@ -763,13 +763,13 @@ paths:
         post:
             tags:
                 - Orchestrator
-            description: Creates a new certificate
-            operationId: Orchestrator_CreateCertificate
+            description: Creates a new compliance attestation
+            operationId: Orchestrator_CreateComplianceAttestation
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Certificate'
+                            $ref: '#/components/schemas/ComplianceAttestation'
                 required: true
             responses:
                 "200":
@@ -777,52 +777,21 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/Certificate'
+                                $ref: '#/components/schemas/ComplianceAttestation'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/orchestrator/certificates/{certificate.id}:
-        put:
-            tags:
-                - Orchestrator
-            description: Updates an existing certificate
-            operationId: Orchestrator_UpdateCertificate
-            parameters:
-                - name: certificate.id
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/Certificate'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Certificate'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/orchestrator/certificates/{certificateId}:
+    /v1/orchestrator/compliance_attestations/{complianceAttestationId}:
         get:
             tags:
                 - Orchestrator
-            description: Retrieves a certificate
-            operationId: Orchestrator_GetCertificate
+            description: Retrieves a compliance attestation
+            operationId: Orchestrator_GetComplianceAttestation
             parameters:
-                - name: certificateId
+                - name: complianceAttestationId
                   in: path
                   required: true
                   schema:
@@ -833,7 +802,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/Certificate'
+                                $ref: '#/components/schemas/ComplianceAttestation'
                 default:
                     description: Default error response
                     content:
@@ -843,10 +812,10 @@ paths:
         delete:
             tags:
                 - Orchestrator
-            description: Removes a certificate
-            operationId: Orchestrator_RemoveCertificate
+            description: Removes a compliance attestation
+            operationId: Orchestrator_RemoveComplianceAttestation
             parameters:
-                - name: certificateId
+                - name: complianceAttestationId
                   in: path
                   required: true
                   schema:
@@ -855,6 +824,37 @@ paths:
                 "200":
                     description: OK
                     content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/orchestrator/compliance_attestations/{compliance_attestation.id}:
+        put:
+            tags:
+                - Orchestrator
+            description: Updates an existing compliance attestation
+            operationId: Orchestrator_UpdateComplianceAttestation
+            parameters:
+                - name: compliance_attestation.id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ComplianceAttestation'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ComplianceAttestation'
                 default:
                     description: Default error response
                     content:
@@ -1115,12 +1115,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/orchestrator/public/certificates:
+    /v1/orchestrator/public/compliance_attestations:
         get:
             tags:
                 - Orchestrator
-            description: Lists all target certificates without state history
-            operationId: Orchestrator_ListPublicCertificates
+            description: Lists all public compliance attestations without state history
+            operationId: Orchestrator_ListPublicComplianceAttestations
             parameters:
                 - name: pageSize
                   in: query
@@ -1145,7 +1145,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ListPublicCertificatesResponse'
+                                $ref: '#/components/schemas/ListPublicComplianceAttestationsResponse'
                 default:
                     description: Default error response
                     content:
@@ -1662,7 +1662,34 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Control'
-        Certificate:
+        ComparisonResult:
+            required:
+                - property
+                - value
+                - operator
+                - targetValue
+                - success
+            type: object
+            properties:
+                property:
+                    type: string
+                    description: Property is the property that was compared
+                value:
+                    allOf:
+                        - $ref: '#/components/schemas/GoogleProtobufValue'
+                    description: Value is the value in the property
+                operator:
+                    type: string
+                    description: Operator is the operator used in the comparison
+                targetValue:
+                    allOf:
+                        - $ref: '#/components/schemas/GoogleProtobufValue'
+                    description: TargetValue is the target value used in the comparison
+                success:
+                    type: boolean
+                    description: Success is true, if the comparison was successful
+            description: An optional structure containing more details how a comparison inside an assessment result was done and if it was successful.
+        ComplianceAttestation:
             required:
                 - id
                 - name
@@ -1688,7 +1715,7 @@ components:
                 states:
                     type: array
                     items:
-                        $ref: '#/components/schemas/State'
+                        $ref: '#/components/schemas/ComplianceAttestationState'
                     description: A list of states at specific times
                 auditScopeId:
                     type: string
@@ -1735,36 +1762,41 @@ components:
                     description: Current summarized compliance state. Detailed transitions live in states.
                     format: enum
             description: |-
-                Certificate is the legacy API name for a compliance attestation.
-                 It represents an assertion that a target of evaluation complies with a catalog
-                 in the scope of a specific audit scope.
-        ComparisonResult:
-            required:
-                - property
-                - value
-                - operator
-                - targetValue
-                - success
+                ComplianceAttestation is the unified API resource for certificates, third-party
+                 attestations, and internal compliance declarations.
+        ComplianceAttestationState:
             type: object
             properties:
-                property:
+                id:
                     type: string
-                    description: Property is the property that was compared
-                value:
-                    allOf:
-                        - $ref: '#/components/schemas/GoogleProtobufValue'
-                    description: Value is the value in the property
-                operator:
+                state:
+                    enum:
+                        - ATTESTATION_STATE_UNSPECIFIED
+                        - ATTESTATION_STATE_IN_PROGRESS
+                        - ATTESTATION_STATE_ACTIVE
+                        - ATTESTATION_STATE_ISSUED
+                        - ATTESTATION_STATE_SUSPENDED
+                        - ATTESTATION_STATE_WITHDRAWN
+                        - ATTESTATION_STATE_EXPIRED
+                        - ATTESTATION_STATE_APPLIED
+                        - ATTESTATION_STATE_UNDER_REVIEW
+                        - ATTESTATION_STATE_REJECTED
                     type: string
-                    description: Operator is the operator used in the comparison
-                targetValue:
-                    allOf:
-                        - $ref: '#/components/schemas/GoogleProtobufValue'
-                    description: TargetValue is the target value used in the comparison
-                success:
-                    type: boolean
-                    description: Success is true, if the comparison was successful
-            description: An optional structure containing more details how a comparison inside an assessment result was done and if it was successful.
+                    description: An EUCS-defined or platform-defined attestation lifecycle state.
+                    format: enum
+                treeId:
+                    type: string
+                    description: Optional transparency log or external evidence tree reference.
+                timestamp:
+                    type: string
+                    format: date-time
+                complianceAttestationId:
+                    type: string
+                    description: Reference to the compliance attestation.
+                reason:
+                    type: string
+                    description: Optional human-readable reason for the state transition.
+            description: ComplianceAttestationState records a lifecycle transition of a compliance attestation.
         Control:
             required:
                 - id
@@ -1890,13 +1922,13 @@ components:
                         $ref: '#/components/schemas/Catalog'
                 nextPageToken:
                     type: string
-        ListCertificatesResponse:
+        ListComplianceAttestationsResponse:
             type: object
             properties:
-                certificates:
+                complianceAttestations:
                     type: array
                     items:
-                        $ref: '#/components/schemas/Certificate'
+                        $ref: '#/components/schemas/ComplianceAttestation'
                 nextPageToken:
                     type: string
         ListControlsResponse:
@@ -1929,13 +1961,13 @@ components:
                         $ref: '#/components/schemas/Metric'
                 nextPageToken:
                     type: string
-        ListPublicCertificatesResponse:
+        ListPublicComplianceAttestationsResponse:
             type: object
             properties:
-                certificates:
+                complianceAttestations:
                     type: array
                     items:
-                        $ref: '#/components/schemas/Certificate'
+                        $ref: '#/components/schemas/ComplianceAttestation'
                 nextPageToken:
                     type: string
         ListTargetsOfEvaluationResponse:
@@ -2079,39 +2111,6 @@ components:
                     items:
                         $ref: '#/components/schemas/Dependency'
                     description: dependency is a list of used runtime dependencies
-        State:
-            type: object
-            properties:
-                id:
-                    type: string
-                state:
-                    enum:
-                        - ATTESTATION_STATE_UNSPECIFIED
-                        - ATTESTATION_STATE_IN_PROGRESS
-                        - ATTESTATION_STATE_ACTIVE
-                        - ATTESTATION_STATE_ISSUED
-                        - ATTESTATION_STATE_SUSPENDED
-                        - ATTESTATION_STATE_WITHDRAWN
-                        - ATTESTATION_STATE_EXPIRED
-                        - ATTESTATION_STATE_APPLIED
-                        - ATTESTATION_STATE_UNDER_REVIEW
-                        - ATTESTATION_STATE_REJECTED
-                    type: string
-                    description: An EUCS-defined or platform-defined attestation lifecycle state.
-                    format: enum
-                treeId:
-                    type: string
-                    description: Optional transparency log or external evidence tree reference.
-                timestamp:
-                    type: string
-                    format: date-time
-                certificateId:
-                    type: string
-                    description: Reference to the certificate / compliance attestation.
-                reason:
-                    type: string
-                    description: Optional human-readable reason for the state transition.
-            description: State is the legacy API name for a compliance attestation state transition.
         Status:
             type: object
             properties:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -1768,8 +1768,14 @@ components:
                     type: string
                 issueDate:
                     type: string
+                    description: |-
+                        Deprecated: legacy string issue date kept for backward compatibility.
+                         Prefer issued_at for new integrations.
                 expirationDate:
                     type: string
+                    description: |-
+                        Deprecated: legacy string expiration date kept for backward compatibility.
+                         Prefer valid_until for new integrations.
                 standard:
                     type: string
                 assuranceLevel:
@@ -1801,13 +1807,15 @@ components:
                     format: enum
                 issuedAt:
                     type: string
-                    description: Structured validity timestamps for lifecycle-aware consumers.
+                    description: Preferred canonical issuance timestamp for this compliance attestation.
                     format: date-time
                 validFrom:
                     type: string
+                    description: Preferred canonical start of the attestation validity period.
                     format: date-time
                 validUntil:
                     type: string
+                    description: Preferred canonical end of the attestation validity period.
                     format: date-time
                 certificationBody:
                     type: string

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -1716,7 +1716,9 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/ComplianceAttestationState'
-                    description: A list of states at specific times
+                    description: |-
+                        Ordered lifecycle history. The newest entry should represent the current
+                         lifecycle state and should match compliance_status when both are present.
                 auditScopeId:
                     type: string
                     description: |-
@@ -1759,7 +1761,9 @@ components:
                         - ATTESTATION_STATE_UNDER_REVIEW
                         - ATTESTATION_STATE_REJECTED
                     type: string
-                    description: Current summarized compliance state. Detailed transitions live in states.
+                    description: |-
+                        Current summarized lifecycle / compliance state. Detailed transitions live
+                         in states. When states are present, this should mirror the latest entry.
                     format: enum
             description: |-
                 ComplianceAttestation is the unified API resource for certificates, third-party
@@ -1782,13 +1786,14 @@ components:
                         - ATTESTATION_STATE_UNDER_REVIEW
                         - ATTESTATION_STATE_REJECTED
                     type: string
-                    description: An EUCS-defined or platform-defined attestation lifecycle state.
+                    description: Lifecycle state after the transition.
                     format: enum
                 treeId:
                     type: string
                     description: Optional transparency log or external evidence tree reference.
                 timestamp:
                     type: string
+                    description: Time at which the transition became effective.
                     format: date-time
                 complianceAttestationId:
                     type: string

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -3593,15 +3593,23 @@ func (x *RemoveComplianceAttestationRequest) GetComplianceAttestationId() string
 // ComplianceAttestation is the unified API resource for certificates, third-party
 // attestations, and internal compliance declarations.
 type ComplianceAttestation struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name           string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	IssueDate      string                 `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
-	ExpirationDate string                 `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
-	Standard       string                 `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
-	AssuranceLevel string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
-	Cab            string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
-	Description    string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name  string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Deprecated: legacy string issue date kept for backward compatibility.
+	// Prefer issued_at for new integrations.
+	//
+	// Deprecated: Marked as deprecated in api/orchestrator/orchestrator.proto.
+	IssueDate string `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
+	// Deprecated: legacy string expiration date kept for backward compatibility.
+	// Prefer valid_until for new integrations.
+	//
+	// Deprecated: Marked as deprecated in api/orchestrator/orchestrator.proto.
+	ExpirationDate string `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
+	Standard       string `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
+	AssuranceLevel string `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
+	Cab            string `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
+	Description    string `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
 	// Ordered lifecycle history. The newest entry should represent the current
 	// lifecycle state and should match compliance_status when both are present.
 	States []*ComplianceAttestationState `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
@@ -3610,9 +3618,11 @@ type ComplianceAttestation struct {
 	AuditScopeId string `protobuf:"bytes,11,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
 	// Type of compliance attestation, e.g. certificate or attestation.
 	AttestationType ComplianceAttestationType `protobuf:"varint,12,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType" json:"attestation_type,omitempty"`
-	// Structured validity timestamps for lifecycle-aware consumers.
-	IssuedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
-	ValidFrom  *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=valid_from,json=validFrom,proto3,oneof" json:"valid_from,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Preferred canonical issuance timestamp for this compliance attestation.
+	IssuedAt *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Preferred canonical start of the attestation validity period.
+	ValidFrom *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=valid_from,json=validFrom,proto3,oneof" json:"valid_from,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Preferred canonical end of the attestation validity period.
 	ValidUntil *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=valid_until,json=validUntil,proto3,oneof" json:"valid_until,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
 	// Optional auditor / certification body information.
 	CertificationBody string `protobuf:"bytes,16,opt,name=certification_body,json=certificationBody,proto3" json:"certification_body,omitempty"`
@@ -3668,6 +3678,7 @@ func (x *ComplianceAttestation) GetName() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in api/orchestrator/orchestrator.proto.
 func (x *ComplianceAttestation) GetIssueDate() string {
 	if x != nil {
 		return x.IssueDate
@@ -3675,6 +3686,7 @@ func (x *ComplianceAttestation) GetIssueDate() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in api/orchestrator/orchestrator.proto.
 func (x *ComplianceAttestation) GetExpirationDate() string {
 	if x != nil {
 		return x.ExpirationDate
@@ -5317,15 +5329,15 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"l\n" +
 	"\"RemoveComplianceAttestationRequest\x12F\n" +
 	"\x19compliance_attestation_id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\xe0\b\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\xe8\b\n" +
 	"\x15ComplianceAttestation\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x02id\x12\x1e\n" +
 	"\x04name\x18\x02 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12\x1d\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12!\n" +
 	"\n" +
-	"issue_date\x18\x04 \x01(\tR\tissueDate\x12'\n" +
-	"\x0fexpiration_date\x18\x05 \x01(\tR\x0eexpirationDate\x12\x1a\n" +
+	"issue_date\x18\x04 \x01(\tB\x02\x18\x01R\tissueDate\x12+\n" +
+	"\x0fexpiration_date\x18\x05 \x01(\tB\x02\x18\x01R\x0eexpirationDate\x12\x1a\n" +
 	"\bstandard\x18\x06 \x01(\tR\bstandard\x12'\n" +
 	"\x0fassurance_level\x18\a \x01(\tR\x0eassuranceLevel\x12\x10\n" +
 	"\x03cab\x18\b \x01(\tR\x03cab\x12 \n" +

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -172,6 +172,131 @@ func (RequestType) EnumDescriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{1}
 }
 
+// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
+// and internal compliance declarations.
+type ComplianceAttestationType int32
+
+const (
+	ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED          ComplianceAttestationType = 0
+	ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE          ComplianceAttestationType = 1
+	ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_ATTESTATION          ComplianceAttestationType = 2
+	ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION ComplianceAttestationType = 3
+)
+
+// Enum value maps for ComplianceAttestationType.
+var (
+	ComplianceAttestationType_name = map[int32]string{
+		0: "COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED",
+		1: "COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE",
+		2: "COMPLIANCE_ATTESTATION_TYPE_ATTESTATION",
+		3: "COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION",
+	}
+	ComplianceAttestationType_value = map[string]int32{
+		"COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED":          0,
+		"COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE":          1,
+		"COMPLIANCE_ATTESTATION_TYPE_ATTESTATION":          2,
+		"COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION": 3,
+	}
+)
+
+func (x ComplianceAttestationType) Enum() *ComplianceAttestationType {
+	p := new(ComplianceAttestationType)
+	*p = x
+	return p
+}
+
+func (x ComplianceAttestationType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ComplianceAttestationType) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_orchestrator_orchestrator_proto_enumTypes[2].Descriptor()
+}
+
+func (ComplianceAttestationType) Type() protoreflect.EnumType {
+	return &file_api_orchestrator_orchestrator_proto_enumTypes[2]
+}
+
+func (x ComplianceAttestationType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ComplianceAttestationType.Descriptor instead.
+func (ComplianceAttestationType) EnumDescriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{2}
+}
+
+// AttestationState models the lifecycle of a compliance attestation.
+type AttestationState int32
+
+const (
+	AttestationState_ATTESTATION_STATE_UNSPECIFIED  AttestationState = 0
+	AttestationState_ATTESTATION_STATE_IN_PROGRESS  AttestationState = 1
+	AttestationState_ATTESTATION_STATE_ACTIVE       AttestationState = 2
+	AttestationState_ATTESTATION_STATE_ISSUED       AttestationState = 3
+	AttestationState_ATTESTATION_STATE_SUSPENDED    AttestationState = 4
+	AttestationState_ATTESTATION_STATE_WITHDRAWN    AttestationState = 5
+	AttestationState_ATTESTATION_STATE_EXPIRED      AttestationState = 6
+	AttestationState_ATTESTATION_STATE_APPLIED      AttestationState = 7
+	AttestationState_ATTESTATION_STATE_UNDER_REVIEW AttestationState = 8
+	AttestationState_ATTESTATION_STATE_REJECTED     AttestationState = 9
+)
+
+// Enum value maps for AttestationState.
+var (
+	AttestationState_name = map[int32]string{
+		0: "ATTESTATION_STATE_UNSPECIFIED",
+		1: "ATTESTATION_STATE_IN_PROGRESS",
+		2: "ATTESTATION_STATE_ACTIVE",
+		3: "ATTESTATION_STATE_ISSUED",
+		4: "ATTESTATION_STATE_SUSPENDED",
+		5: "ATTESTATION_STATE_WITHDRAWN",
+		6: "ATTESTATION_STATE_EXPIRED",
+		7: "ATTESTATION_STATE_APPLIED",
+		8: "ATTESTATION_STATE_UNDER_REVIEW",
+		9: "ATTESTATION_STATE_REJECTED",
+	}
+	AttestationState_value = map[string]int32{
+		"ATTESTATION_STATE_UNSPECIFIED":  0,
+		"ATTESTATION_STATE_IN_PROGRESS":  1,
+		"ATTESTATION_STATE_ACTIVE":       2,
+		"ATTESTATION_STATE_ISSUED":       3,
+		"ATTESTATION_STATE_SUSPENDED":    4,
+		"ATTESTATION_STATE_WITHDRAWN":    5,
+		"ATTESTATION_STATE_EXPIRED":      6,
+		"ATTESTATION_STATE_APPLIED":      7,
+		"ATTESTATION_STATE_UNDER_REVIEW": 8,
+		"ATTESTATION_STATE_REJECTED":     9,
+	}
+)
+
+func (x AttestationState) Enum() *AttestationState {
+	p := new(AttestationState)
+	*p = x
+	return p
+}
+
+func (x AttestationState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AttestationState) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_orchestrator_orchestrator_proto_enumTypes[3].Descriptor()
+}
+
+func (AttestationState) Type() protoreflect.EnumType {
+	return &file_api_orchestrator_orchestrator_proto_enumTypes[3]
+}
+
+func (x AttestationState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AttestationState.Descriptor instead.
+func (AttestationState) EnumDescriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{3}
+}
+
 // TargetType represents the type of the target of evaluation.
 type TargetOfEvaluation_TargetType int32
 
@@ -209,11 +334,11 @@ func (x TargetOfEvaluation_TargetType) String() string {
 }
 
 func (TargetOfEvaluation_TargetType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_orchestrator_orchestrator_proto_enumTypes[2].Descriptor()
+	return file_api_orchestrator_orchestrator_proto_enumTypes[4].Descriptor()
 }
 
 func (TargetOfEvaluation_TargetType) Type() protoreflect.EnumType {
-	return &file_api_orchestrator_orchestrator_proto_enumTypes[2]
+	return &file_api_orchestrator_orchestrator_proto_enumTypes[4]
 }
 
 func (x TargetOfEvaluation_TargetType) Number() protoreflect.EnumNumber {
@@ -3987,22 +4112,37 @@ func (x *RemoveCertificateRequest) GetCertificateId() string {
 	return ""
 }
 
-// An ISO17021-based certificate
+// Certificate is the legacy API name for a compliance attestation.
+// It represents an assertion that a target of evaluation complies with a catalog
+// in the scope of a specific audit scope.
 type Certificate struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	Id                   string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name                 string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	TargetOfEvaluationId string                 `protobuf:"bytes,3,opt,name=target_of_evaluation_id,json=targetOfEvaluationId,proto3" json:"target_of_evaluation_id,omitempty"`
-	IssueDate            string                 `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
-	ExpirationDate       string                 `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
-	Standard             string                 `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
-	AssuranceLevel       string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
-	Cab                  string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
-	Description          string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name           string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	IssueDate      string                 `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
+	ExpirationDate string                 `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
+	Standard       string                 `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
+	AssuranceLevel string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
+	Cab            string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
+	Description    string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
 	// A list of states at specific times
-	States        []*State `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	States []*State `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
+	// Audit scope this attestation belongs to. This binds the attestation to a
+	// specific target of evaluation and catalog combination.
+	AuditScopeId string `protobuf:"bytes,11,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
+	// Type of compliance attestation, e.g. certificate or attestation.
+	AttestationType ComplianceAttestationType `protobuf:"varint,12,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType" json:"attestation_type,omitempty"`
+	// Structured validity timestamps for lifecycle-aware consumers.
+	IssuedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	ValidFrom  *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=valid_from,json=validFrom,proto3,oneof" json:"valid_from,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	ValidUntil *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=valid_until,json=validUntil,proto3,oneof" json:"valid_until,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Optional auditor / certification body information.
+	CertificationBody string `protobuf:"bytes,16,opt,name=certification_body,json=certificationBody,proto3" json:"certification_body,omitempty"`
+	Auditor           string `protobuf:"bytes,17,opt,name=auditor,proto3" json:"auditor,omitempty"`
+	// Current summarized compliance state. Detailed transitions live in states.
+	ComplianceStatus AttestationState `protobuf:"varint,18,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"compliance_status,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Certificate) Reset() {
@@ -4045,13 +4185,6 @@ func (x *Certificate) GetId() string {
 func (x *Certificate) GetName() string {
 	if x != nil {
 		return x.Name
-	}
-	return ""
-}
-
-func (x *Certificate) GetTargetOfEvaluationId() string {
-	if x != nil {
-		return x.TargetOfEvaluationId
 	}
 	return ""
 }
@@ -4105,16 +4238,75 @@ func (x *Certificate) GetStates() []*State {
 	return nil
 }
 
-// A state of a certificate at a given time
+func (x *Certificate) GetAuditScopeId() string {
+	if x != nil {
+		return x.AuditScopeId
+	}
+	return ""
+}
+
+func (x *Certificate) GetAttestationType() ComplianceAttestationType {
+	if x != nil {
+		return x.AttestationType
+	}
+	return ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+}
+
+func (x *Certificate) GetIssuedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.IssuedAt
+	}
+	return nil
+}
+
+func (x *Certificate) GetValidFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidFrom
+	}
+	return nil
+}
+
+func (x *Certificate) GetValidUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidUntil
+	}
+	return nil
+}
+
+func (x *Certificate) GetCertificationBody() string {
+	if x != nil {
+		return x.CertificationBody
+	}
+	return ""
+}
+
+func (x *Certificate) GetAuditor() string {
+	if x != nil {
+		return x.Auditor
+	}
+	return ""
+}
+
+func (x *Certificate) GetComplianceStatus() AttestationState {
+	if x != nil {
+		return x.ComplianceStatus
+	}
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
+}
+
+// State is the legacy API name for a compliance attestation state transition.
 type State struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// An EUCS-defined state, e.g. `new`, `suspended` or `withdrawn`
-	State     string `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
-	TreeId    string `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
-	Timestamp string `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	// Reference to the certificate
+	// An EUCS-defined or platform-defined attestation lifecycle state.
+	State AttestationState `protobuf:"varint,2,opt,name=state,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"state,omitempty"`
+	// Optional transparency log or external evidence tree reference.
+	TreeId    string                 `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Reference to the certificate / compliance attestation.
 	CertificateId string `protobuf:"bytes,5,opt,name=certificate_id,json=certificateId,proto3" json:"certificate_id,omitempty"`
+	// Optional human-readable reason for the state transition.
+	Reason        string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4156,11 +4348,11 @@ func (x *State) GetId() string {
 	return ""
 }
 
-func (x *State) GetState() string {
+func (x *State) GetState() AttestationState {
 	if x != nil {
 		return x.State
 	}
-	return ""
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
 }
 
 func (x *State) GetTreeId() string {
@@ -4170,16 +4362,23 @@ func (x *State) GetTreeId() string {
 	return ""
 }
 
-func (x *State) GetTimestamp() string {
+func (x *State) GetTimestamp() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Timestamp
 	}
-	return ""
+	return nil
 }
 
 func (x *State) GetCertificateId() string {
 	if x != nil {
 		return x.CertificateId
+	}
+	return ""
+}
+
+func (x *State) GetReason() string {
+	if x != nil {
+		return x.Reason
 	}
 	return ""
 }
@@ -4995,13 +5194,12 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\vcertificate\x18\x01 \x01(\v2'.confirmate.orchestrator.v1.CertificateB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\vcertificate\"M\n" +
 	"\x18RemoveCertificateRequest\x121\n" +
 	"\x0ecertificate_id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\rcertificateId\"\xb2\x03\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\rcertificateId\"\xc1\b\n" +
 	"\vCertificate\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x02id\x12\x1e\n" +
 	"\x04name\x18\x02 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12B\n" +
-	"\x17target_of_evaluation_id\x18\x03 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x14targetOfEvaluationId\x12\x1d\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12\x1d\n" +
 	"\n" +
 	"issue_date\x18\x04 \x01(\tR\tissueDate\x12'\n" +
 	"\x0fexpiration_date\x18\x05 \x01(\tR\x0eexpirationDate\x12\x1a\n" +
@@ -5010,13 +5208,28 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x03cab\x18\b \x01(\tR\x03cab\x12 \n" +
 	"\vdescription\x18\t \x01(\tR\vdescription\x12b\n" +
 	"\x06states\x18\n" +
-	" \x03(\v2!.confirmate.orchestrator.v1.StateB'\x9a\x84\x9e\x03\"gorm:\"constraint:OnDelete:CASCADE\"R\x06states\"\x8b\x01\n" +
+	" \x03(\v2!.confirmate.orchestrator.v1.StateB'\x9a\x84\x9e\x03\"gorm:\"constraint:OnDelete:CASCADE\"R\x06states\x121\n" +
+	"\x0eaudit_scope_id\x18\v \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\fauditScopeId\x12j\n" +
+	"\x10attestation_type\x18\f \x01(\x0e25.confirmate.orchestrator.v1.ComplianceAttestationTypeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x0fattestationType\x12o\n" +
+	"\tissued_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x00R\bissuedAt\x88\x01\x01\x12q\n" +
+	"\n" +
+	"valid_from\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x01R\tvalidFrom\x88\x01\x01\x12s\n" +
+	"\vvalid_until\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x02R\n" +
+	"validUntil\x88\x01\x01\x12-\n" +
+	"\x12certification_body\x18\x10 \x01(\tR\x11certificationBody\x12\x18\n" +
+	"\aauditor\x18\x11 \x01(\tR\aauditor\x12c\n" +
+	"\x11compliance_status\x18\x12 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x10complianceStatusB\f\n" +
+	"\n" +
+	"_issued_atB\r\n" +
+	"\v_valid_fromB\x0e\n" +
+	"\f_valid_until\"\xaa\x02\n" +
 	"\x05State\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
-	"\x05state\x18\x02 \x01(\tR\x05state\x12\x17\n" +
-	"\atree_id\x18\x03 \x01(\tR\x06treeId\x12\x1c\n" +
-	"\ttimestamp\x18\x04 \x01(\tR\ttimestamp\x12%\n" +
-	"\x0ecertificate_id\x18\x05 \x01(\tR\rcertificateId*\xb0\x02\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12L\n" +
+	"\x05state\x18\x02 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05state\x12\x17\n" +
+	"\atree_id\x18\x03 \x01(\tR\x06treeId\x12k\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"R\ttimestamp\x12%\n" +
+	"\x0ecertificate_id\x18\x05 \x01(\tR\rcertificateId\x12\x16\n" +
+	"\x06reason\x18\x06 \x01(\tR\x06reason*\xb0\x02\n" +
 	"\rEventCategory\x12\x1e\n" +
 	"\x1aEVENT_CATEGORY_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15EVENT_CATEGORY_METRIC\x10\x01\x12'\n" +
@@ -5032,7 +5245,23 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x14REQUEST_TYPE_UPDATED\x10\x02\x12\x18\n" +
 	"\x14REQUEST_TYPE_DELETED\x10\x03\x12\x1b\n" +
 	"\x17REQUEST_TYPE_REGISTERED\x10\x04\x12\x17\n" +
-	"\x13REQUEST_TYPE_STORED\x10\x052\xb9A\n" +
+	"\x13REQUEST_TYPE_STORED\x10\x05*\xd8\x01\n" +
+	"\x19ComplianceAttestationType\x12+\n" +
+	"'COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED\x10\x00\x12+\n" +
+	"'COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE\x10\x01\x12+\n" +
+	"'COMPLIANCE_ATTESTATION_TYPE_ATTESTATION\x10\x02\x124\n" +
+	"0COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION\x10\x03*\xd8\x02\n" +
+	"\x10AttestationState\x12!\n" +
+	"\x1dATTESTATION_STATE_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dATTESTATION_STATE_IN_PROGRESS\x10\x01\x12\x1c\n" +
+	"\x18ATTESTATION_STATE_ACTIVE\x10\x02\x12\x1c\n" +
+	"\x18ATTESTATION_STATE_ISSUED\x10\x03\x12\x1f\n" +
+	"\x1bATTESTATION_STATE_SUSPENDED\x10\x04\x12\x1f\n" +
+	"\x1bATTESTATION_STATE_WITHDRAWN\x10\x05\x12\x1d\n" +
+	"\x19ATTESTATION_STATE_EXPIRED\x10\x06\x12\x1d\n" +
+	"\x19ATTESTATION_STATE_APPLIED\x10\a\x12\"\n" +
+	"\x1eATTESTATION_STATE_UNDER_REVIEW\x10\b\x12\x1e\n" +
+	"\x1aATTESTATION_STATE_REJECTED\x10\t2\xb9A\n" +
 	"\fOrchestrator\x12\xb0\x01\n" +
 	"\x16RegisterAssessmentTool\x129.confirmate.orchestrator.v1.RegisterAssessmentToolRequest\x1a*.confirmate.orchestrator.v1.AssessmentTool\"/\x82\xd3\xe4\x93\x02):\x04tool\"!/v1/orchestrator/assessment_tools\x12\xb1\x01\n" +
 	"\x13ListAssessmentTools\x126.confirmate.orchestrator.v1.ListAssessmentToolsRequest\x1a7.confirmate.orchestrator.v1.ListAssessmentToolsResponse\")\x82\xd3\xe4\x93\x02#\x12!/v1/orchestrator/assessment_tools\x12\xaa\x01\n" +
@@ -5095,250 +5324,259 @@ func file_api_orchestrator_orchestrator_proto_rawDescGZIP() []byte {
 	return file_api_orchestrator_orchestrator_proto_rawDescData
 }
 
-var file_api_orchestrator_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_api_orchestrator_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_api_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
 var file_api_orchestrator_orchestrator_proto_goTypes = []any{
 	(EventCategory)(0),                              // 0: confirmate.orchestrator.v1.EventCategory
 	(RequestType)(0),                                // 1: confirmate.orchestrator.v1.RequestType
-	(TargetOfEvaluation_TargetType)(0),              // 2: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
-	(*RegisterAssessmentToolRequest)(nil),           // 3: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
-	(*ListAssessmentToolsRequest)(nil),              // 4: confirmate.orchestrator.v1.ListAssessmentToolsRequest
-	(*ListAssessmentToolsResponse)(nil),             // 5: confirmate.orchestrator.v1.ListAssessmentToolsResponse
-	(*GetAssessmentToolRequest)(nil),                // 6: confirmate.orchestrator.v1.GetAssessmentToolRequest
-	(*UpdateAssessmentToolRequest)(nil),             // 7: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
-	(*DeregisterAssessmentToolRequest)(nil),         // 8: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
-	(*StoreAssessmentResultRequest)(nil),            // 9: confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	(*StoreAssessmentResultResponse)(nil),           // 10: confirmate.orchestrator.v1.StoreAssessmentResultResponse
-	(*StoreAssessmentResultsResponse)(nil),          // 11: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
-	(*CreateMetricRequest)(nil),                     // 12: confirmate.orchestrator.v1.CreateMetricRequest
-	(*UpdateMetricRequest)(nil),                     // 13: confirmate.orchestrator.v1.UpdateMetricRequest
-	(*GetMetricRequest)(nil),                        // 14: confirmate.orchestrator.v1.GetMetricRequest
-	(*ListMetricsRequest)(nil),                      // 15: confirmate.orchestrator.v1.ListMetricsRequest
-	(*RemoveMetricRequest)(nil),                     // 16: confirmate.orchestrator.v1.RemoveMetricRequest
-	(*ListMetricsResponse)(nil),                     // 17: confirmate.orchestrator.v1.ListMetricsResponse
-	(*GetTargetOfEvaluationRequest)(nil),            // 18: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
-	(*CreateTargetOfEvaluationRequest)(nil),         // 19: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
-	(*UpdateTargetOfEvaluationRequest)(nil),         // 20: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
-	(*RemoveTargetOfEvaluationRequest)(nil),         // 21: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
-	(*ListTargetsOfEvaluationRequest)(nil),          // 22: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
-	(*ListTargetsOfEvaluationResponse)(nil),         // 23: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
-	(*GetTargetOfEvaluationStatisticsRequest)(nil),  // 24: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
-	(*GetTargetOfEvaluationStatisticsResponse)(nil), // 25: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
-	(*UpdateMetricConfigurationRequest)(nil),        // 26: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
-	(*GetMetricConfigurationRequest)(nil),           // 27: confirmate.orchestrator.v1.GetMetricConfigurationRequest
-	(*ListMetricConfigurationRequest)(nil),          // 28: confirmate.orchestrator.v1.ListMetricConfigurationRequest
-	(*ListMetricConfigurationResponse)(nil),         // 29: confirmate.orchestrator.v1.ListMetricConfigurationResponse
-	(*UpdateMetricImplementationRequest)(nil),       // 30: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
-	(*GetMetricImplementationRequest)(nil),          // 31: confirmate.orchestrator.v1.GetMetricImplementationRequest
-	(*SubscribeRequest)(nil),                        // 32: confirmate.orchestrator.v1.SubscribeRequest
-	(*ChangeEvent)(nil),                             // 33: confirmate.orchestrator.v1.ChangeEvent
-	(*AssessmentTool)(nil),                          // 34: confirmate.orchestrator.v1.AssessmentTool
-	(*TargetOfEvaluation)(nil),                      // 35: confirmate.orchestrator.v1.TargetOfEvaluation
-	(*Catalog)(nil),                                 // 36: confirmate.orchestrator.v1.Catalog
-	(*Category)(nil),                                // 37: confirmate.orchestrator.v1.Category
-	(*Control)(nil),                                 // 38: confirmate.orchestrator.v1.Control
-	(*AuditScope)(nil),                              // 39: confirmate.orchestrator.v1.AuditScope
-	(*GetAssessmentResultRequest)(nil),              // 40: confirmate.orchestrator.v1.GetAssessmentResultRequest
-	(*ListAssessmentResultsRequest)(nil),            // 41: confirmate.orchestrator.v1.ListAssessmentResultsRequest
-	(*ListAssessmentResultsResponse)(nil),           // 42: confirmate.orchestrator.v1.ListAssessmentResultsResponse
-	(*CreateAuditScopeRequest)(nil),                 // 43: confirmate.orchestrator.v1.CreateAuditScopeRequest
-	(*RemoveAuditScopeRequest)(nil),                 // 44: confirmate.orchestrator.v1.RemoveAuditScopeRequest
-	(*GetAuditScopeRequest)(nil),                    // 45: confirmate.orchestrator.v1.GetAuditScopeRequest
-	(*ListAuditScopesRequest)(nil),                  // 46: confirmate.orchestrator.v1.ListAuditScopesRequest
-	(*ListAuditScopesResponse)(nil),                 // 47: confirmate.orchestrator.v1.ListAuditScopesResponse
-	(*UpdateAuditScopeRequest)(nil),                 // 48: confirmate.orchestrator.v1.UpdateAuditScopeRequest
-	(*GetCertificateRequest)(nil),                   // 49: confirmate.orchestrator.v1.GetCertificateRequest
-	(*ListCertificatesRequest)(nil),                 // 50: confirmate.orchestrator.v1.ListCertificatesRequest
-	(*ListCertificatesResponse)(nil),                // 51: confirmate.orchestrator.v1.ListCertificatesResponse
-	(*ListPublicCertificatesRequest)(nil),           // 52: confirmate.orchestrator.v1.ListPublicCertificatesRequest
-	(*ListPublicCertificatesResponse)(nil),          // 53: confirmate.orchestrator.v1.ListPublicCertificatesResponse
-	(*UpdateCertificateRequest)(nil),                // 54: confirmate.orchestrator.v1.UpdateCertificateRequest
-	(*CreateCatalogRequest)(nil),                    // 55: confirmate.orchestrator.v1.CreateCatalogRequest
-	(*RemoveCatalogRequest)(nil),                    // 56: confirmate.orchestrator.v1.RemoveCatalogRequest
-	(*GetCatalogRequest)(nil),                       // 57: confirmate.orchestrator.v1.GetCatalogRequest
-	(*ListCatalogsRequest)(nil),                     // 58: confirmate.orchestrator.v1.ListCatalogsRequest
-	(*ListCatalogsResponse)(nil),                    // 59: confirmate.orchestrator.v1.ListCatalogsResponse
-	(*UpdateCatalogRequest)(nil),                    // 60: confirmate.orchestrator.v1.UpdateCatalogRequest
-	(*GetCategoryRequest)(nil),                      // 61: confirmate.orchestrator.v1.GetCategoryRequest
-	(*GetControlRequest)(nil),                       // 62: confirmate.orchestrator.v1.GetControlRequest
-	(*ListControlsRequest)(nil),                     // 63: confirmate.orchestrator.v1.ListControlsRequest
-	(*ListControlsResponse)(nil),                    // 64: confirmate.orchestrator.v1.ListControlsResponse
-	(*CreateCertificateRequest)(nil),                // 65: confirmate.orchestrator.v1.CreateCertificateRequest
-	(*RemoveCertificateRequest)(nil),                // 66: confirmate.orchestrator.v1.RemoveCertificateRequest
-	(*Certificate)(nil),                             // 67: confirmate.orchestrator.v1.Certificate
-	(*State)(nil),                                   // 68: confirmate.orchestrator.v1.State
-	(*ListAssessmentToolsRequest_Filter)(nil),       // 69: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
-	(*ListMetricsRequest_Filter)(nil),               // 70: confirmate.orchestrator.v1.ListMetricsRequest.Filter
-	nil,                                             // 71: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
-	(*SubscribeRequest_Filter)(nil),                 // 72: confirmate.orchestrator.v1.SubscribeRequest.Filter
-	(*TargetOfEvaluation_Metadata)(nil),             // 73: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
-	nil,                                             // 74: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
-	(*Catalog_Metadata)(nil),                        // 75: confirmate.orchestrator.v1.Catalog.Metadata
-	(*ListAssessmentResultsRequest_Filter)(nil),     // 76: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	(*ListAuditScopesRequest_Filter)(nil),           // 77: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
-	(*ListControlsRequest_Filter)(nil),              // 78: confirmate.orchestrator.v1.ListControlsRequest.Filter
-	(*assessment.AssessmentResult)(nil),             // 79: confirmate.assessment.v1.AssessmentResult
-	(*assessment.Metric)(nil),                       // 80: confirmate.assessment.v1.Metric
-	(*assessment.MetricConfiguration)(nil),          // 81: confirmate.assessment.v1.MetricConfiguration
-	(*assessment.MetricImplementation)(nil),         // 82: confirmate.assessment.v1.MetricImplementation
-	(*timestamppb.Timestamp)(nil),                   // 83: google.protobuf.Timestamp
-	(*common.GetRuntimeInfoRequest)(nil),            // 84: confirmate.common.v1.GetRuntimeInfoRequest
-	(*emptypb.Empty)(nil),                           // 85: google.protobuf.Empty
-	(*common.Runtime)(nil),                          // 86: confirmate.common.v1.Runtime
+	(ComplianceAttestationType)(0),                  // 2: confirmate.orchestrator.v1.ComplianceAttestationType
+	(AttestationState)(0),                           // 3: confirmate.orchestrator.v1.AttestationState
+	(TargetOfEvaluation_TargetType)(0),              // 4: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
+	(*RegisterAssessmentToolRequest)(nil),           // 5: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
+	(*ListAssessmentToolsRequest)(nil),              // 6: confirmate.orchestrator.v1.ListAssessmentToolsRequest
+	(*ListAssessmentToolsResponse)(nil),             // 7: confirmate.orchestrator.v1.ListAssessmentToolsResponse
+	(*GetAssessmentToolRequest)(nil),                // 8: confirmate.orchestrator.v1.GetAssessmentToolRequest
+	(*UpdateAssessmentToolRequest)(nil),             // 9: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
+	(*DeregisterAssessmentToolRequest)(nil),         // 10: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
+	(*StoreAssessmentResultRequest)(nil),            // 11: confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	(*StoreAssessmentResultResponse)(nil),           // 12: confirmate.orchestrator.v1.StoreAssessmentResultResponse
+	(*StoreAssessmentResultsResponse)(nil),          // 13: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
+	(*CreateMetricRequest)(nil),                     // 14: confirmate.orchestrator.v1.CreateMetricRequest
+	(*UpdateMetricRequest)(nil),                     // 15: confirmate.orchestrator.v1.UpdateMetricRequest
+	(*GetMetricRequest)(nil),                        // 16: confirmate.orchestrator.v1.GetMetricRequest
+	(*ListMetricsRequest)(nil),                      // 17: confirmate.orchestrator.v1.ListMetricsRequest
+	(*RemoveMetricRequest)(nil),                     // 18: confirmate.orchestrator.v1.RemoveMetricRequest
+	(*ListMetricsResponse)(nil),                     // 19: confirmate.orchestrator.v1.ListMetricsResponse
+	(*GetTargetOfEvaluationRequest)(nil),            // 20: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
+	(*CreateTargetOfEvaluationRequest)(nil),         // 21: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
+	(*UpdateTargetOfEvaluationRequest)(nil),         // 22: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
+	(*RemoveTargetOfEvaluationRequest)(nil),         // 23: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
+	(*ListTargetsOfEvaluationRequest)(nil),          // 24: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
+	(*ListTargetsOfEvaluationResponse)(nil),         // 25: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
+	(*GetTargetOfEvaluationStatisticsRequest)(nil),  // 26: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
+	(*GetTargetOfEvaluationStatisticsResponse)(nil), // 27: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
+	(*UpdateMetricConfigurationRequest)(nil),        // 28: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
+	(*GetMetricConfigurationRequest)(nil),           // 29: confirmate.orchestrator.v1.GetMetricConfigurationRequest
+	(*ListMetricConfigurationRequest)(nil),          // 30: confirmate.orchestrator.v1.ListMetricConfigurationRequest
+	(*ListMetricConfigurationResponse)(nil),         // 31: confirmate.orchestrator.v1.ListMetricConfigurationResponse
+	(*UpdateMetricImplementationRequest)(nil),       // 32: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
+	(*GetMetricImplementationRequest)(nil),          // 33: confirmate.orchestrator.v1.GetMetricImplementationRequest
+	(*SubscribeRequest)(nil),                        // 34: confirmate.orchestrator.v1.SubscribeRequest
+	(*ChangeEvent)(nil),                             // 35: confirmate.orchestrator.v1.ChangeEvent
+	(*AssessmentTool)(nil),                          // 36: confirmate.orchestrator.v1.AssessmentTool
+	(*TargetOfEvaluation)(nil),                      // 37: confirmate.orchestrator.v1.TargetOfEvaluation
+	(*Catalog)(nil),                                 // 38: confirmate.orchestrator.v1.Catalog
+	(*Category)(nil),                                // 39: confirmate.orchestrator.v1.Category
+	(*Control)(nil),                                 // 40: confirmate.orchestrator.v1.Control
+	(*AuditScope)(nil),                              // 41: confirmate.orchestrator.v1.AuditScope
+	(*GetAssessmentResultRequest)(nil),              // 42: confirmate.orchestrator.v1.GetAssessmentResultRequest
+	(*ListAssessmentResultsRequest)(nil),            // 43: confirmate.orchestrator.v1.ListAssessmentResultsRequest
+	(*ListAssessmentResultsResponse)(nil),           // 44: confirmate.orchestrator.v1.ListAssessmentResultsResponse
+	(*CreateAuditScopeRequest)(nil),                 // 45: confirmate.orchestrator.v1.CreateAuditScopeRequest
+	(*RemoveAuditScopeRequest)(nil),                 // 46: confirmate.orchestrator.v1.RemoveAuditScopeRequest
+	(*GetAuditScopeRequest)(nil),                    // 47: confirmate.orchestrator.v1.GetAuditScopeRequest
+	(*ListAuditScopesRequest)(nil),                  // 48: confirmate.orchestrator.v1.ListAuditScopesRequest
+	(*ListAuditScopesResponse)(nil),                 // 49: confirmate.orchestrator.v1.ListAuditScopesResponse
+	(*UpdateAuditScopeRequest)(nil),                 // 50: confirmate.orchestrator.v1.UpdateAuditScopeRequest
+	(*GetCertificateRequest)(nil),                   // 51: confirmate.orchestrator.v1.GetCertificateRequest
+	(*ListCertificatesRequest)(nil),                 // 52: confirmate.orchestrator.v1.ListCertificatesRequest
+	(*ListCertificatesResponse)(nil),                // 53: confirmate.orchestrator.v1.ListCertificatesResponse
+	(*ListPublicCertificatesRequest)(nil),           // 54: confirmate.orchestrator.v1.ListPublicCertificatesRequest
+	(*ListPublicCertificatesResponse)(nil),          // 55: confirmate.orchestrator.v1.ListPublicCertificatesResponse
+	(*UpdateCertificateRequest)(nil),                // 56: confirmate.orchestrator.v1.UpdateCertificateRequest
+	(*CreateCatalogRequest)(nil),                    // 57: confirmate.orchestrator.v1.CreateCatalogRequest
+	(*RemoveCatalogRequest)(nil),                    // 58: confirmate.orchestrator.v1.RemoveCatalogRequest
+	(*GetCatalogRequest)(nil),                       // 59: confirmate.orchestrator.v1.GetCatalogRequest
+	(*ListCatalogsRequest)(nil),                     // 60: confirmate.orchestrator.v1.ListCatalogsRequest
+	(*ListCatalogsResponse)(nil),                    // 61: confirmate.orchestrator.v1.ListCatalogsResponse
+	(*UpdateCatalogRequest)(nil),                    // 62: confirmate.orchestrator.v1.UpdateCatalogRequest
+	(*GetCategoryRequest)(nil),                      // 63: confirmate.orchestrator.v1.GetCategoryRequest
+	(*GetControlRequest)(nil),                       // 64: confirmate.orchestrator.v1.GetControlRequest
+	(*ListControlsRequest)(nil),                     // 65: confirmate.orchestrator.v1.ListControlsRequest
+	(*ListControlsResponse)(nil),                    // 66: confirmate.orchestrator.v1.ListControlsResponse
+	(*CreateCertificateRequest)(nil),                // 67: confirmate.orchestrator.v1.CreateCertificateRequest
+	(*RemoveCertificateRequest)(nil),                // 68: confirmate.orchestrator.v1.RemoveCertificateRequest
+	(*Certificate)(nil),                             // 69: confirmate.orchestrator.v1.Certificate
+	(*State)(nil),                                   // 70: confirmate.orchestrator.v1.State
+	(*ListAssessmentToolsRequest_Filter)(nil),       // 71: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
+	(*ListMetricsRequest_Filter)(nil),               // 72: confirmate.orchestrator.v1.ListMetricsRequest.Filter
+	nil,                                             // 73: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
+	(*SubscribeRequest_Filter)(nil),                 // 74: confirmate.orchestrator.v1.SubscribeRequest.Filter
+	(*TargetOfEvaluation_Metadata)(nil),             // 75: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
+	nil,                                             // 76: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
+	(*Catalog_Metadata)(nil),                        // 77: confirmate.orchestrator.v1.Catalog.Metadata
+	(*ListAssessmentResultsRequest_Filter)(nil),     // 78: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
+	(*ListAuditScopesRequest_Filter)(nil),           // 79: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
+	(*ListControlsRequest_Filter)(nil),              // 80: confirmate.orchestrator.v1.ListControlsRequest.Filter
+	(*assessment.AssessmentResult)(nil),             // 81: confirmate.assessment.v1.AssessmentResult
+	(*assessment.Metric)(nil),                       // 82: confirmate.assessment.v1.Metric
+	(*assessment.MetricConfiguration)(nil),          // 83: confirmate.assessment.v1.MetricConfiguration
+	(*assessment.MetricImplementation)(nil),         // 84: confirmate.assessment.v1.MetricImplementation
+	(*timestamppb.Timestamp)(nil),                   // 85: google.protobuf.Timestamp
+	(*common.GetRuntimeInfoRequest)(nil),            // 86: confirmate.common.v1.GetRuntimeInfoRequest
+	(*emptypb.Empty)(nil),                           // 87: google.protobuf.Empty
+	(*common.Runtime)(nil),                          // 88: confirmate.common.v1.Runtime
 }
 var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
-	34,  // 0: confirmate.orchestrator.v1.RegisterAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	69,  // 1: confirmate.orchestrator.v1.ListAssessmentToolsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
-	34,  // 2: confirmate.orchestrator.v1.ListAssessmentToolsResponse.tools:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	34,  // 3: confirmate.orchestrator.v1.UpdateAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	79,  // 4: confirmate.orchestrator.v1.StoreAssessmentResultRequest.result:type_name -> confirmate.assessment.v1.AssessmentResult
-	80,  // 5: confirmate.orchestrator.v1.CreateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
-	80,  // 6: confirmate.orchestrator.v1.UpdateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
-	70,  // 7: confirmate.orchestrator.v1.ListMetricsRequest.filter:type_name -> confirmate.orchestrator.v1.ListMetricsRequest.Filter
-	80,  // 8: confirmate.orchestrator.v1.ListMetricsResponse.metrics:type_name -> confirmate.assessment.v1.Metric
-	35,  // 9: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
-	35,  // 10: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
-	35,  // 11: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse.targets_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
-	81,  // 12: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest.configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
-	71,  // 13: confirmate.orchestrator.v1.ListMetricConfigurationResponse.configurations:type_name -> confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
-	82,  // 14: confirmate.orchestrator.v1.UpdateMetricImplementationRequest.implementation:type_name -> confirmate.assessment.v1.MetricImplementation
-	72,  // 15: confirmate.orchestrator.v1.SubscribeRequest.filter:type_name -> confirmate.orchestrator.v1.SubscribeRequest.Filter
-	83,  // 16: confirmate.orchestrator.v1.ChangeEvent.timestamp:type_name -> google.protobuf.Timestamp
+	36,  // 0: confirmate.orchestrator.v1.RegisterAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
+	71,  // 1: confirmate.orchestrator.v1.ListAssessmentToolsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
+	36,  // 2: confirmate.orchestrator.v1.ListAssessmentToolsResponse.tools:type_name -> confirmate.orchestrator.v1.AssessmentTool
+	36,  // 3: confirmate.orchestrator.v1.UpdateAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
+	81,  // 4: confirmate.orchestrator.v1.StoreAssessmentResultRequest.result:type_name -> confirmate.assessment.v1.AssessmentResult
+	82,  // 5: confirmate.orchestrator.v1.CreateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
+	82,  // 6: confirmate.orchestrator.v1.UpdateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
+	72,  // 7: confirmate.orchestrator.v1.ListMetricsRequest.filter:type_name -> confirmate.orchestrator.v1.ListMetricsRequest.Filter
+	82,  // 8: confirmate.orchestrator.v1.ListMetricsResponse.metrics:type_name -> confirmate.assessment.v1.Metric
+	37,  // 9: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 10: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 11: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse.targets_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
+	83,  // 12: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest.configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
+	73,  // 13: confirmate.orchestrator.v1.ListMetricConfigurationResponse.configurations:type_name -> confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
+	84,  // 14: confirmate.orchestrator.v1.UpdateMetricImplementationRequest.implementation:type_name -> confirmate.assessment.v1.MetricImplementation
+	74,  // 15: confirmate.orchestrator.v1.SubscribeRequest.filter:type_name -> confirmate.orchestrator.v1.SubscribeRequest.Filter
+	85,  // 16: confirmate.orchestrator.v1.ChangeEvent.timestamp:type_name -> google.protobuf.Timestamp
 	0,   // 17: confirmate.orchestrator.v1.ChangeEvent.category:type_name -> confirmate.orchestrator.v1.EventCategory
 	1,   // 18: confirmate.orchestrator.v1.ChangeEvent.request_type:type_name -> confirmate.orchestrator.v1.RequestType
-	80,  // 19: confirmate.orchestrator.v1.ChangeEvent.metric:type_name -> confirmate.assessment.v1.Metric
-	35,  // 20: confirmate.orchestrator.v1.ChangeEvent.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
-	39,  // 21: confirmate.orchestrator.v1.ChangeEvent.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	79,  // 22: confirmate.orchestrator.v1.ChangeEvent.assessment_result:type_name -> confirmate.assessment.v1.AssessmentResult
-	81,  // 23: confirmate.orchestrator.v1.ChangeEvent.metric_configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
-	82,  // 24: confirmate.orchestrator.v1.ChangeEvent.metric_implementation:type_name -> confirmate.assessment.v1.MetricImplementation
-	34,  // 25: confirmate.orchestrator.v1.ChangeEvent.assessment_tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	80,  // 26: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
-	83,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
-	83,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
-	73,  // 29: confirmate.orchestrator.v1.TargetOfEvaluation.metadata:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
-	2,   // 30: confirmate.orchestrator.v1.TargetOfEvaluation.target_type:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
-	37,  // 31: confirmate.orchestrator.v1.Catalog.categories:type_name -> confirmate.orchestrator.v1.Category
-	75,  // 32: confirmate.orchestrator.v1.Catalog.metadata:type_name -> confirmate.orchestrator.v1.Catalog.Metadata
-	38,  // 33: confirmate.orchestrator.v1.Category.controls:type_name -> confirmate.orchestrator.v1.Control
-	38,  // 34: confirmate.orchestrator.v1.Control.controls:type_name -> confirmate.orchestrator.v1.Control
-	80,  // 35: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
-	76,  // 36: confirmate.orchestrator.v1.ListAssessmentResultsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	79,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
-	39,  // 38: confirmate.orchestrator.v1.CreateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	77,  // 39: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
-	39,  // 40: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
-	39,  // 41: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	67,  // 42: confirmate.orchestrator.v1.ListCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
-	67,  // 43: confirmate.orchestrator.v1.ListPublicCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
-	67,  // 44: confirmate.orchestrator.v1.UpdateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
-	36,  // 45: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	36,  // 46: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
-	36,  // 47: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	78,  // 48: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
-	38,  // 49: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
-	67,  // 50: confirmate.orchestrator.v1.CreateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
-	68,  // 51: confirmate.orchestrator.v1.Certificate.states:type_name -> confirmate.orchestrator.v1.State
-	81,  // 52: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry.value:type_name -> confirmate.assessment.v1.MetricConfiguration
-	0,   // 53: confirmate.orchestrator.v1.SubscribeRequest.Filter.categories:type_name -> confirmate.orchestrator.v1.EventCategory
-	74,  // 54: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.labels:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
-	3,   // 55: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:input_type -> confirmate.orchestrator.v1.RegisterAssessmentToolRequest
-	4,   // 56: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:input_type -> confirmate.orchestrator.v1.ListAssessmentToolsRequest
-	6,   // 57: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:input_type -> confirmate.orchestrator.v1.GetAssessmentToolRequest
-	7,   // 58: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:input_type -> confirmate.orchestrator.v1.UpdateAssessmentToolRequest
-	8,   // 59: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:input_type -> confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
-	9,   // 60: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	9,   // 61: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	40,  // 62: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:input_type -> confirmate.orchestrator.v1.GetAssessmentResultRequest
-	41,  // 63: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:input_type -> confirmate.orchestrator.v1.ListAssessmentResultsRequest
-	12,  // 64: confirmate.orchestrator.v1.Orchestrator.CreateMetric:input_type -> confirmate.orchestrator.v1.CreateMetricRequest
-	13,  // 65: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:input_type -> confirmate.orchestrator.v1.UpdateMetricRequest
-	14,  // 66: confirmate.orchestrator.v1.Orchestrator.GetMetric:input_type -> confirmate.orchestrator.v1.GetMetricRequest
-	15,  // 67: confirmate.orchestrator.v1.Orchestrator.ListMetrics:input_type -> confirmate.orchestrator.v1.ListMetricsRequest
-	16,  // 68: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:input_type -> confirmate.orchestrator.v1.RemoveMetricRequest
-	19,  // 69: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
-	20,  // 70: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
-	18,  // 71: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
-	22,  // 72: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:input_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
-	21,  // 73: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
-	24,  // 74: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
-	26,  // 75: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:input_type -> confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
-	27,  // 76: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:input_type -> confirmate.orchestrator.v1.GetMetricConfigurationRequest
-	28,  // 77: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:input_type -> confirmate.orchestrator.v1.ListMetricConfigurationRequest
-	30,  // 78: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
-	31,  // 79: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
-	32,  // 80: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
-	65,  // 81: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:input_type -> confirmate.orchestrator.v1.CreateCertificateRequest
-	49,  // 82: confirmate.orchestrator.v1.Orchestrator.GetCertificate:input_type -> confirmate.orchestrator.v1.GetCertificateRequest
-	50,  // 83: confirmate.orchestrator.v1.Orchestrator.ListCertificates:input_type -> confirmate.orchestrator.v1.ListCertificatesRequest
-	52,  // 84: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:input_type -> confirmate.orchestrator.v1.ListPublicCertificatesRequest
-	54,  // 85: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:input_type -> confirmate.orchestrator.v1.UpdateCertificateRequest
-	66,  // 86: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:input_type -> confirmate.orchestrator.v1.RemoveCertificateRequest
-	55,  // 87: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
-	58,  // 88: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
-	57,  // 89: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
-	56,  // 90: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
-	60,  // 91: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
-	61,  // 92: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
-	63,  // 93: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
-	62,  // 94: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
-	43,  // 95: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:input_type -> confirmate.orchestrator.v1.CreateAuditScopeRequest
-	45,  // 96: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:input_type -> confirmate.orchestrator.v1.GetAuditScopeRequest
-	46,  // 97: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:input_type -> confirmate.orchestrator.v1.ListAuditScopesRequest
-	48,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:input_type -> confirmate.orchestrator.v1.UpdateAuditScopeRequest
-	44,  // 99: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:input_type -> confirmate.orchestrator.v1.RemoveAuditScopeRequest
-	84,  // 100: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:input_type -> confirmate.common.v1.GetRuntimeInfoRequest
-	34,  // 101: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	5,   // 102: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:output_type -> confirmate.orchestrator.v1.ListAssessmentToolsResponse
-	34,  // 103: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	34,  // 104: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	85,  // 105: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:output_type -> google.protobuf.Empty
-	10,  // 106: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultResponse
-	11,  // 107: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultsResponse
-	79,  // 108: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:output_type -> confirmate.assessment.v1.AssessmentResult
-	42,  // 109: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:output_type -> confirmate.orchestrator.v1.ListAssessmentResultsResponse
-	80,  // 110: confirmate.orchestrator.v1.Orchestrator.CreateMetric:output_type -> confirmate.assessment.v1.Metric
-	80,  // 111: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:output_type -> confirmate.assessment.v1.Metric
-	80,  // 112: confirmate.orchestrator.v1.Orchestrator.GetMetric:output_type -> confirmate.assessment.v1.Metric
-	17,  // 113: confirmate.orchestrator.v1.Orchestrator.ListMetrics:output_type -> confirmate.orchestrator.v1.ListMetricsResponse
-	85,  // 114: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:output_type -> google.protobuf.Empty
-	35,  // 115: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	35,  // 116: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	35,  // 117: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	23,  // 118: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:output_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
-	85,  // 119: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:output_type -> google.protobuf.Empty
-	25,  // 120: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:output_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
-	81,  // 121: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
-	81,  // 122: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
-	29,  // 123: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:output_type -> confirmate.orchestrator.v1.ListMetricConfigurationResponse
-	82,  // 124: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
-	82,  // 125: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
-	33,  // 126: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
-	67,  // 127: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	67,  // 128: confirmate.orchestrator.v1.Orchestrator.GetCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	51,  // 129: confirmate.orchestrator.v1.Orchestrator.ListCertificates:output_type -> confirmate.orchestrator.v1.ListCertificatesResponse
-	53,  // 130: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:output_type -> confirmate.orchestrator.v1.ListPublicCertificatesResponse
-	67,  // 131: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	85,  // 132: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:output_type -> google.protobuf.Empty
-	36,  // 133: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	59,  // 134: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
-	36,  // 135: confirmate.orchestrator.v1.Orchestrator.GetCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	85,  // 136: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:output_type -> google.protobuf.Empty
-	36,  // 137: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	37,  // 138: confirmate.orchestrator.v1.Orchestrator.GetCategory:output_type -> confirmate.orchestrator.v1.Category
-	64,  // 139: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
-	38,  // 140: confirmate.orchestrator.v1.Orchestrator.GetControl:output_type -> confirmate.orchestrator.v1.Control
-	39,  // 141: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	39,  // 142: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	47,  // 143: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:output_type -> confirmate.orchestrator.v1.ListAuditScopesResponse
-	39,  // 144: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	85,  // 145: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:output_type -> google.protobuf.Empty
-	86,  // 146: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:output_type -> confirmate.common.v1.Runtime
-	101, // [101:147] is the sub-list for method output_type
-	55,  // [55:101] is the sub-list for method input_type
-	55,  // [55:55] is the sub-list for extension type_name
-	55,  // [55:55] is the sub-list for extension extendee
-	0,   // [0:55] is the sub-list for field type_name
+	82,  // 19: confirmate.orchestrator.v1.ChangeEvent.metric:type_name -> confirmate.assessment.v1.Metric
+	37,  // 20: confirmate.orchestrator.v1.ChangeEvent.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
+	41,  // 21: confirmate.orchestrator.v1.ChangeEvent.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
+	81,  // 22: confirmate.orchestrator.v1.ChangeEvent.assessment_result:type_name -> confirmate.assessment.v1.AssessmentResult
+	83,  // 23: confirmate.orchestrator.v1.ChangeEvent.metric_configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
+	84,  // 24: confirmate.orchestrator.v1.ChangeEvent.metric_implementation:type_name -> confirmate.assessment.v1.MetricImplementation
+	36,  // 25: confirmate.orchestrator.v1.ChangeEvent.assessment_tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
+	82,  // 26: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
+	85,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
+	85,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
+	75,  // 29: confirmate.orchestrator.v1.TargetOfEvaluation.metadata:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
+	4,   // 30: confirmate.orchestrator.v1.TargetOfEvaluation.target_type:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
+	39,  // 31: confirmate.orchestrator.v1.Catalog.categories:type_name -> confirmate.orchestrator.v1.Category
+	77,  // 32: confirmate.orchestrator.v1.Catalog.metadata:type_name -> confirmate.orchestrator.v1.Catalog.Metadata
+	40,  // 33: confirmate.orchestrator.v1.Category.controls:type_name -> confirmate.orchestrator.v1.Control
+	40,  // 34: confirmate.orchestrator.v1.Control.controls:type_name -> confirmate.orchestrator.v1.Control
+	82,  // 35: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
+	78,  // 36: confirmate.orchestrator.v1.ListAssessmentResultsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
+	81,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
+	41,  // 38: confirmate.orchestrator.v1.CreateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
+	79,  // 39: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
+	41,  // 40: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
+	41,  // 41: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
+	69,  // 42: confirmate.orchestrator.v1.ListCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
+	69,  // 43: confirmate.orchestrator.v1.ListPublicCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
+	69,  // 44: confirmate.orchestrator.v1.UpdateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
+	38,  // 45: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 46: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 47: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	80,  // 48: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
+	40,  // 49: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
+	69,  // 50: confirmate.orchestrator.v1.CreateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
+	70,  // 51: confirmate.orchestrator.v1.Certificate.states:type_name -> confirmate.orchestrator.v1.State
+	2,   // 52: confirmate.orchestrator.v1.Certificate.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
+	85,  // 53: confirmate.orchestrator.v1.Certificate.issued_at:type_name -> google.protobuf.Timestamp
+	85,  // 54: confirmate.orchestrator.v1.Certificate.valid_from:type_name -> google.protobuf.Timestamp
+	85,  // 55: confirmate.orchestrator.v1.Certificate.valid_until:type_name -> google.protobuf.Timestamp
+	3,   // 56: confirmate.orchestrator.v1.Certificate.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
+	3,   // 57: confirmate.orchestrator.v1.State.state:type_name -> confirmate.orchestrator.v1.AttestationState
+	85,  // 58: confirmate.orchestrator.v1.State.timestamp:type_name -> google.protobuf.Timestamp
+	83,  // 59: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry.value:type_name -> confirmate.assessment.v1.MetricConfiguration
+	0,   // 60: confirmate.orchestrator.v1.SubscribeRequest.Filter.categories:type_name -> confirmate.orchestrator.v1.EventCategory
+	76,  // 61: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.labels:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
+	5,   // 62: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:input_type -> confirmate.orchestrator.v1.RegisterAssessmentToolRequest
+	6,   // 63: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:input_type -> confirmate.orchestrator.v1.ListAssessmentToolsRequest
+	8,   // 64: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:input_type -> confirmate.orchestrator.v1.GetAssessmentToolRequest
+	9,   // 65: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:input_type -> confirmate.orchestrator.v1.UpdateAssessmentToolRequest
+	10,  // 66: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:input_type -> confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
+	11,  // 67: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	11,  // 68: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	42,  // 69: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:input_type -> confirmate.orchestrator.v1.GetAssessmentResultRequest
+	43,  // 70: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:input_type -> confirmate.orchestrator.v1.ListAssessmentResultsRequest
+	14,  // 71: confirmate.orchestrator.v1.Orchestrator.CreateMetric:input_type -> confirmate.orchestrator.v1.CreateMetricRequest
+	15,  // 72: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:input_type -> confirmate.orchestrator.v1.UpdateMetricRequest
+	16,  // 73: confirmate.orchestrator.v1.Orchestrator.GetMetric:input_type -> confirmate.orchestrator.v1.GetMetricRequest
+	17,  // 74: confirmate.orchestrator.v1.Orchestrator.ListMetrics:input_type -> confirmate.orchestrator.v1.ListMetricsRequest
+	18,  // 75: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:input_type -> confirmate.orchestrator.v1.RemoveMetricRequest
+	21,  // 76: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
+	22,  // 77: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
+	20,  // 78: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
+	24,  // 79: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:input_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
+	23,  // 80: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
+	26,  // 81: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
+	28,  // 82: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:input_type -> confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
+	29,  // 83: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:input_type -> confirmate.orchestrator.v1.GetMetricConfigurationRequest
+	30,  // 84: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:input_type -> confirmate.orchestrator.v1.ListMetricConfigurationRequest
+	32,  // 85: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
+	33,  // 86: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
+	34,  // 87: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
+	67,  // 88: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:input_type -> confirmate.orchestrator.v1.CreateCertificateRequest
+	51,  // 89: confirmate.orchestrator.v1.Orchestrator.GetCertificate:input_type -> confirmate.orchestrator.v1.GetCertificateRequest
+	52,  // 90: confirmate.orchestrator.v1.Orchestrator.ListCertificates:input_type -> confirmate.orchestrator.v1.ListCertificatesRequest
+	54,  // 91: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:input_type -> confirmate.orchestrator.v1.ListPublicCertificatesRequest
+	56,  // 92: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:input_type -> confirmate.orchestrator.v1.UpdateCertificateRequest
+	68,  // 93: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:input_type -> confirmate.orchestrator.v1.RemoveCertificateRequest
+	57,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
+	60,  // 95: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
+	59,  // 96: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
+	58,  // 97: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
+	62,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
+	63,  // 99: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
+	65,  // 100: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
+	64,  // 101: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
+	45,  // 102: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:input_type -> confirmate.orchestrator.v1.CreateAuditScopeRequest
+	47,  // 103: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:input_type -> confirmate.orchestrator.v1.GetAuditScopeRequest
+	48,  // 104: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:input_type -> confirmate.orchestrator.v1.ListAuditScopesRequest
+	50,  // 105: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:input_type -> confirmate.orchestrator.v1.UpdateAuditScopeRequest
+	46,  // 106: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:input_type -> confirmate.orchestrator.v1.RemoveAuditScopeRequest
+	86,  // 107: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:input_type -> confirmate.common.v1.GetRuntimeInfoRequest
+	36,  // 108: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	7,   // 109: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:output_type -> confirmate.orchestrator.v1.ListAssessmentToolsResponse
+	36,  // 110: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	36,  // 111: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	87,  // 112: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:output_type -> google.protobuf.Empty
+	12,  // 113: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultResponse
+	13,  // 114: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultsResponse
+	81,  // 115: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:output_type -> confirmate.assessment.v1.AssessmentResult
+	44,  // 116: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:output_type -> confirmate.orchestrator.v1.ListAssessmentResultsResponse
+	82,  // 117: confirmate.orchestrator.v1.Orchestrator.CreateMetric:output_type -> confirmate.assessment.v1.Metric
+	82,  // 118: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:output_type -> confirmate.assessment.v1.Metric
+	82,  // 119: confirmate.orchestrator.v1.Orchestrator.GetMetric:output_type -> confirmate.assessment.v1.Metric
+	19,  // 120: confirmate.orchestrator.v1.Orchestrator.ListMetrics:output_type -> confirmate.orchestrator.v1.ListMetricsResponse
+	87,  // 121: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:output_type -> google.protobuf.Empty
+	37,  // 122: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 123: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 124: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	25,  // 125: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:output_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
+	87,  // 126: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:output_type -> google.protobuf.Empty
+	27,  // 127: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:output_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
+	83,  // 128: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
+	83,  // 129: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
+	31,  // 130: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:output_type -> confirmate.orchestrator.v1.ListMetricConfigurationResponse
+	84,  // 131: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
+	84,  // 132: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
+	35,  // 133: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
+	69,  // 134: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
+	69,  // 135: confirmate.orchestrator.v1.Orchestrator.GetCertificate:output_type -> confirmate.orchestrator.v1.Certificate
+	53,  // 136: confirmate.orchestrator.v1.Orchestrator.ListCertificates:output_type -> confirmate.orchestrator.v1.ListCertificatesResponse
+	55,  // 137: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:output_type -> confirmate.orchestrator.v1.ListPublicCertificatesResponse
+	69,  // 138: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
+	87,  // 139: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:output_type -> google.protobuf.Empty
+	38,  // 140: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	61,  // 141: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
+	38,  // 142: confirmate.orchestrator.v1.Orchestrator.GetCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	87,  // 143: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:output_type -> google.protobuf.Empty
+	38,  // 144: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	39,  // 145: confirmate.orchestrator.v1.Orchestrator.GetCategory:output_type -> confirmate.orchestrator.v1.Category
+	66,  // 146: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
+	40,  // 147: confirmate.orchestrator.v1.Orchestrator.GetControl:output_type -> confirmate.orchestrator.v1.Control
+	41,  // 148: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	41,  // 149: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	49,  // 150: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:output_type -> confirmate.orchestrator.v1.ListAuditScopesResponse
+	41,  // 151: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	87,  // 152: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:output_type -> google.protobuf.Empty
+	88,  // 153: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:output_type -> confirmate.common.v1.Runtime
+	108, // [108:154] is the sub-list for method output_type
+	62,  // [62:108] is the sub-list for method input_type
+	62,  // [62:62] is the sub-list for extension type_name
+	62,  // [62:62] is the sub-list for extension extendee
+	0,   // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_api_orchestrator_orchestrator_proto_init() }
@@ -5364,6 +5602,7 @@ func file_api_orchestrator_orchestrator_proto_init() {
 	file_api_orchestrator_orchestrator_proto_msgTypes[38].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[43].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[60].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[64].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[67].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[70].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[72].OneofWrappers = []any{}
@@ -5374,7 +5613,7 @@ func file_api_orchestrator_orchestrator_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_orchestrator_orchestrator_proto_rawDesc), len(file_api_orchestrator_orchestrator_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      5,
 			NumMessages:   76,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -3143,27 +3143,27 @@ func (x *UpdateAuditScopeRequest) GetAuditScope() *AuditScope {
 	return nil
 }
 
-type GetCertificateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CertificateId string                 `protobuf:"bytes,1,opt,name=certificate_id,json=certificateId,proto3" json:"certificate_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+type GetComplianceAttestationRequest struct {
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	ComplianceAttestationId string                 `protobuf:"bytes,1,opt,name=compliance_attestation_id,json=complianceAttestationId,proto3" json:"compliance_attestation_id,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
-func (x *GetCertificateRequest) Reset() {
-	*x = GetCertificateRequest{}
+func (x *GetComplianceAttestationRequest) Reset() {
+	*x = GetComplianceAttestationRequest{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetCertificateRequest) String() string {
+func (x *GetComplianceAttestationRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetCertificateRequest) ProtoMessage() {}
+func (*GetComplianceAttestationRequest) ProtoMessage() {}
 
-func (x *GetCertificateRequest) ProtoReflect() protoreflect.Message {
+func (x *GetComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3175,19 +3175,19 @@ func (x *GetCertificateRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetCertificateRequest.ProtoReflect.Descriptor instead.
-func (*GetCertificateRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetComplianceAttestationRequest.ProtoReflect.Descriptor instead.
+func (*GetComplianceAttestationRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{46}
 }
 
-func (x *GetCertificateRequest) GetCertificateId() string {
+func (x *GetComplianceAttestationRequest) GetComplianceAttestationId() string {
 	if x != nil {
-		return x.CertificateId
+		return x.ComplianceAttestationId
 	}
 	return ""
 }
 
-type ListCertificatesRequest struct {
+type ListComplianceAttestationsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PageSize      int32                  `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	PageToken     string                 `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
@@ -3197,20 +3197,20 @@ type ListCertificatesRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListCertificatesRequest) Reset() {
-	*x = ListCertificatesRequest{}
+func (x *ListComplianceAttestationsRequest) Reset() {
+	*x = ListComplianceAttestationsRequest{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListCertificatesRequest) String() string {
+func (x *ListComplianceAttestationsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListCertificatesRequest) ProtoMessage() {}
+func (*ListComplianceAttestationsRequest) ProtoMessage() {}
 
-func (x *ListCertificatesRequest) ProtoReflect() protoreflect.Message {
+func (x *ListComplianceAttestationsRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3222,61 +3222,61 @@ func (x *ListCertificatesRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListCertificatesRequest.ProtoReflect.Descriptor instead.
-func (*ListCertificatesRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListComplianceAttestationsRequest.ProtoReflect.Descriptor instead.
+func (*ListComplianceAttestationsRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{47}
 }
 
-func (x *ListCertificatesRequest) GetPageSize() int32 {
+func (x *ListComplianceAttestationsRequest) GetPageSize() int32 {
 	if x != nil {
 		return x.PageSize
 	}
 	return 0
 }
 
-func (x *ListCertificatesRequest) GetPageToken() string {
+func (x *ListComplianceAttestationsRequest) GetPageToken() string {
 	if x != nil {
 		return x.PageToken
 	}
 	return ""
 }
 
-func (x *ListCertificatesRequest) GetOrderBy() string {
+func (x *ListComplianceAttestationsRequest) GetOrderBy() string {
 	if x != nil {
 		return x.OrderBy
 	}
 	return ""
 }
 
-func (x *ListCertificatesRequest) GetAsc() bool {
+func (x *ListComplianceAttestationsRequest) GetAsc() bool {
 	if x != nil {
 		return x.Asc
 	}
 	return false
 }
 
-type ListCertificatesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Certificates  []*Certificate         `protobuf:"bytes,1,rep,name=certificates,proto3" json:"certificates,omitempty"`
-	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+type ListComplianceAttestationsResponse struct {
+	state                  protoimpl.MessageState   `protogen:"open.v1"`
+	ComplianceAttestations []*ComplianceAttestation `protobuf:"bytes,1,rep,name=compliance_attestations,json=complianceAttestations,proto3" json:"compliance_attestations,omitempty"`
+	NextPageToken          string                   `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
-func (x *ListCertificatesResponse) Reset() {
-	*x = ListCertificatesResponse{}
+func (x *ListComplianceAttestationsResponse) Reset() {
+	*x = ListComplianceAttestationsResponse{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListCertificatesResponse) String() string {
+func (x *ListComplianceAttestationsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListCertificatesResponse) ProtoMessage() {}
+func (*ListComplianceAttestationsResponse) ProtoMessage() {}
 
-func (x *ListCertificatesResponse) ProtoReflect() protoreflect.Message {
+func (x *ListComplianceAttestationsResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3288,26 +3288,26 @@ func (x *ListCertificatesResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListCertificatesResponse.ProtoReflect.Descriptor instead.
-func (*ListCertificatesResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListComplianceAttestationsResponse.ProtoReflect.Descriptor instead.
+func (*ListComplianceAttestationsResponse) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{48}
 }
 
-func (x *ListCertificatesResponse) GetCertificates() []*Certificate {
+func (x *ListComplianceAttestationsResponse) GetComplianceAttestations() []*ComplianceAttestation {
 	if x != nil {
-		return x.Certificates
+		return x.ComplianceAttestations
 	}
 	return nil
 }
 
-func (x *ListCertificatesResponse) GetNextPageToken() string {
+func (x *ListComplianceAttestationsResponse) GetNextPageToken() string {
 	if x != nil {
 		return x.NextPageToken
 	}
 	return ""
 }
 
-type ListPublicCertificatesRequest struct {
+type ListPublicComplianceAttestationsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PageSize      int32                  `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	PageToken     string                 `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
@@ -3317,20 +3317,20 @@ type ListPublicCertificatesRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListPublicCertificatesRequest) Reset() {
-	*x = ListPublicCertificatesRequest{}
+func (x *ListPublicComplianceAttestationsRequest) Reset() {
+	*x = ListPublicComplianceAttestationsRequest{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListPublicCertificatesRequest) String() string {
+func (x *ListPublicComplianceAttestationsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListPublicCertificatesRequest) ProtoMessage() {}
+func (*ListPublicComplianceAttestationsRequest) ProtoMessage() {}
 
-func (x *ListPublicCertificatesRequest) ProtoReflect() protoreflect.Message {
+func (x *ListPublicComplianceAttestationsRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3342,61 +3342,61 @@ func (x *ListPublicCertificatesRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListPublicCertificatesRequest.ProtoReflect.Descriptor instead.
-func (*ListPublicCertificatesRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListPublicComplianceAttestationsRequest.ProtoReflect.Descriptor instead.
+func (*ListPublicComplianceAttestationsRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{49}
 }
 
-func (x *ListPublicCertificatesRequest) GetPageSize() int32 {
+func (x *ListPublicComplianceAttestationsRequest) GetPageSize() int32 {
 	if x != nil {
 		return x.PageSize
 	}
 	return 0
 }
 
-func (x *ListPublicCertificatesRequest) GetPageToken() string {
+func (x *ListPublicComplianceAttestationsRequest) GetPageToken() string {
 	if x != nil {
 		return x.PageToken
 	}
 	return ""
 }
 
-func (x *ListPublicCertificatesRequest) GetOrderBy() string {
+func (x *ListPublicComplianceAttestationsRequest) GetOrderBy() string {
 	if x != nil {
 		return x.OrderBy
 	}
 	return ""
 }
 
-func (x *ListPublicCertificatesRequest) GetAsc() bool {
+func (x *ListPublicComplianceAttestationsRequest) GetAsc() bool {
 	if x != nil {
 		return x.Asc
 	}
 	return false
 }
 
-type ListPublicCertificatesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Certificates  []*Certificate         `protobuf:"bytes,1,rep,name=certificates,proto3" json:"certificates,omitempty"`
-	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+type ListPublicComplianceAttestationsResponse struct {
+	state                  protoimpl.MessageState   `protogen:"open.v1"`
+	ComplianceAttestations []*ComplianceAttestation `protobuf:"bytes,1,rep,name=compliance_attestations,json=complianceAttestations,proto3" json:"compliance_attestations,omitempty"`
+	NextPageToken          string                   `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
-func (x *ListPublicCertificatesResponse) Reset() {
-	*x = ListPublicCertificatesResponse{}
+func (x *ListPublicComplianceAttestationsResponse) Reset() {
+	*x = ListPublicComplianceAttestationsResponse{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListPublicCertificatesResponse) String() string {
+func (x *ListPublicComplianceAttestationsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListPublicCertificatesResponse) ProtoMessage() {}
+func (*ListPublicComplianceAttestationsResponse) ProtoMessage() {}
 
-func (x *ListPublicCertificatesResponse) ProtoReflect() protoreflect.Message {
+func (x *ListPublicComplianceAttestationsResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3408,46 +3408,46 @@ func (x *ListPublicCertificatesResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListPublicCertificatesResponse.ProtoReflect.Descriptor instead.
-func (*ListPublicCertificatesResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListPublicComplianceAttestationsResponse.ProtoReflect.Descriptor instead.
+func (*ListPublicComplianceAttestationsResponse) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{50}
 }
 
-func (x *ListPublicCertificatesResponse) GetCertificates() []*Certificate {
+func (x *ListPublicComplianceAttestationsResponse) GetComplianceAttestations() []*ComplianceAttestation {
 	if x != nil {
-		return x.Certificates
+		return x.ComplianceAttestations
 	}
 	return nil
 }
 
-func (x *ListPublicCertificatesResponse) GetNextPageToken() string {
+func (x *ListPublicComplianceAttestationsResponse) GetNextPageToken() string {
 	if x != nil {
 		return x.NextPageToken
 	}
 	return ""
 }
 
-type UpdateCertificateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Certificate   *Certificate           `protobuf:"bytes,1,opt,name=certificate,proto3" json:"certificate,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+type UpdateComplianceAttestationRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	ComplianceAttestation *ComplianceAttestation `protobuf:"bytes,1,opt,name=compliance_attestation,json=complianceAttestation,proto3" json:"compliance_attestation,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
-func (x *UpdateCertificateRequest) Reset() {
-	*x = UpdateCertificateRequest{}
+func (x *UpdateComplianceAttestationRequest) Reset() {
+	*x = UpdateComplianceAttestationRequest{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *UpdateCertificateRequest) String() string {
+func (x *UpdateComplianceAttestationRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*UpdateCertificateRequest) ProtoMessage() {}
+func (*UpdateComplianceAttestationRequest) ProtoMessage() {}
 
-func (x *UpdateCertificateRequest) ProtoReflect() protoreflect.Message {
+func (x *UpdateComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3459,16 +3459,374 @@ func (x *UpdateCertificateRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use UpdateCertificateRequest.ProtoReflect.Descriptor instead.
-func (*UpdateCertificateRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use UpdateComplianceAttestationRequest.ProtoReflect.Descriptor instead.
+func (*UpdateComplianceAttestationRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{51}
 }
 
-func (x *UpdateCertificateRequest) GetCertificate() *Certificate {
+func (x *UpdateComplianceAttestationRequest) GetComplianceAttestation() *ComplianceAttestation {
 	if x != nil {
-		return x.Certificate
+		return x.ComplianceAttestation
 	}
 	return nil
+}
+
+type CreateComplianceAttestationRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	ComplianceAttestation *ComplianceAttestation `protobuf:"bytes,1,opt,name=compliance_attestation,json=complianceAttestation,proto3" json:"compliance_attestation,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *CreateComplianceAttestationRequest) Reset() {
+	*x = CreateComplianceAttestationRequest{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateComplianceAttestationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateComplianceAttestationRequest) ProtoMessage() {}
+
+func (x *CreateComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateComplianceAttestationRequest.ProtoReflect.Descriptor instead.
+func (*CreateComplianceAttestationRequest) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *CreateComplianceAttestationRequest) GetComplianceAttestation() *ComplianceAttestation {
+	if x != nil {
+		return x.ComplianceAttestation
+	}
+	return nil
+}
+
+type RemoveComplianceAttestationRequest struct {
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	ComplianceAttestationId string                 `protobuf:"bytes,1,opt,name=compliance_attestation_id,json=complianceAttestationId,proto3" json:"compliance_attestation_id,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *RemoveComplianceAttestationRequest) Reset() {
+	*x = RemoveComplianceAttestationRequest{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveComplianceAttestationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveComplianceAttestationRequest) ProtoMessage() {}
+
+func (x *RemoveComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveComplianceAttestationRequest.ProtoReflect.Descriptor instead.
+func (*RemoveComplianceAttestationRequest) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *RemoveComplianceAttestationRequest) GetComplianceAttestationId() string {
+	if x != nil {
+		return x.ComplianceAttestationId
+	}
+	return ""
+}
+
+// ComplianceAttestation is the unified API resource for certificates, third-party
+// attestations, and internal compliance declarations.
+type ComplianceAttestation struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name           string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	IssueDate      string                 `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
+	ExpirationDate string                 `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
+	Standard       string                 `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
+	AssuranceLevel string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
+	Cab            string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
+	Description    string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
+	// A list of states at specific times
+	States []*ComplianceAttestationState `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
+	// Audit scope this attestation belongs to. This binds the attestation to a
+	// specific target of evaluation and catalog combination.
+	AuditScopeId string `protobuf:"bytes,11,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
+	// Type of compliance attestation, e.g. certificate or attestation.
+	AttestationType ComplianceAttestationType `protobuf:"varint,12,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType" json:"attestation_type,omitempty"`
+	// Structured validity timestamps for lifecycle-aware consumers.
+	IssuedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	ValidFrom  *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=valid_from,json=validFrom,proto3,oneof" json:"valid_from,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	ValidUntil *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=valid_until,json=validUntil,proto3,oneof" json:"valid_until,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Optional auditor / certification body information.
+	CertificationBody string `protobuf:"bytes,16,opt,name=certification_body,json=certificationBody,proto3" json:"certification_body,omitempty"`
+	Auditor           string `protobuf:"bytes,17,opt,name=auditor,proto3" json:"auditor,omitempty"`
+	// Current summarized compliance state. Detailed transitions live in states.
+	ComplianceStatus AttestationState `protobuf:"varint,18,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"compliance_status,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ComplianceAttestation) Reset() {
+	*x = ComplianceAttestation{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComplianceAttestation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComplianceAttestation) ProtoMessage() {}
+
+func (x *ComplianceAttestation) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComplianceAttestation.ProtoReflect.Descriptor instead.
+func (*ComplianceAttestation) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *ComplianceAttestation) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetIssueDate() string {
+	if x != nil {
+		return x.IssueDate
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetExpirationDate() string {
+	if x != nil {
+		return x.ExpirationDate
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetStandard() string {
+	if x != nil {
+		return x.Standard
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetAssuranceLevel() string {
+	if x != nil {
+		return x.AssuranceLevel
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetCab() string {
+	if x != nil {
+		return x.Cab
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetStates() []*ComplianceAttestationState {
+	if x != nil {
+		return x.States
+	}
+	return nil
+}
+
+func (x *ComplianceAttestation) GetAuditScopeId() string {
+	if x != nil {
+		return x.AuditScopeId
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetAttestationType() ComplianceAttestationType {
+	if x != nil {
+		return x.AttestationType
+	}
+	return ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+}
+
+func (x *ComplianceAttestation) GetIssuedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.IssuedAt
+	}
+	return nil
+}
+
+func (x *ComplianceAttestation) GetValidFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidFrom
+	}
+	return nil
+}
+
+func (x *ComplianceAttestation) GetValidUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidUntil
+	}
+	return nil
+}
+
+func (x *ComplianceAttestation) GetCertificationBody() string {
+	if x != nil {
+		return x.CertificationBody
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetAuditor() string {
+	if x != nil {
+		return x.Auditor
+	}
+	return ""
+}
+
+func (x *ComplianceAttestation) GetComplianceStatus() AttestationState {
+	if x != nil {
+		return x.ComplianceStatus
+	}
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
+}
+
+// ComplianceAttestationState records a lifecycle transition of a compliance attestation.
+type ComplianceAttestationState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// An EUCS-defined or platform-defined attestation lifecycle state.
+	State AttestationState `protobuf:"varint,2,opt,name=state,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"state,omitempty"`
+	// Optional transparency log or external evidence tree reference.
+	TreeId    string                 `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
+	// Reference to the compliance attestation.
+	ComplianceAttestationId string `protobuf:"bytes,5,opt,name=compliance_attestation_id,json=complianceAttestationId,proto3" json:"compliance_attestation_id,omitempty"`
+	// Optional human-readable reason for the state transition.
+	Reason        string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComplianceAttestationState) Reset() {
+	*x = ComplianceAttestationState{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComplianceAttestationState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComplianceAttestationState) ProtoMessage() {}
+
+func (x *ComplianceAttestationState) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComplianceAttestationState.ProtoReflect.Descriptor instead.
+func (*ComplianceAttestationState) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *ComplianceAttestationState) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ComplianceAttestationState) GetState() AttestationState {
+	if x != nil {
+		return x.State
+	}
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
+}
+
+func (x *ComplianceAttestationState) GetTreeId() string {
+	if x != nil {
+		return x.TreeId
+	}
+	return ""
+}
+
+func (x *ComplianceAttestationState) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *ComplianceAttestationState) GetComplianceAttestationId() string {
+	if x != nil {
+		return x.ComplianceAttestationId
+	}
+	return ""
+}
+
+func (x *ComplianceAttestationState) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 type CreateCatalogRequest struct {
@@ -3480,7 +3838,7 @@ type CreateCatalogRequest struct {
 
 func (x *CreateCatalogRequest) Reset() {
 	*x = CreateCatalogRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3492,7 +3850,7 @@ func (x *CreateCatalogRequest) String() string {
 func (*CreateCatalogRequest) ProtoMessage() {}
 
 func (x *CreateCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3505,7 +3863,7 @@ func (x *CreateCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCatalogRequest.ProtoReflect.Descriptor instead.
 func (*CreateCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{52}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateCatalogRequest) GetCatalog() *Catalog {
@@ -3524,7 +3882,7 @@ type RemoveCatalogRequest struct {
 
 func (x *RemoveCatalogRequest) Reset() {
 	*x = RemoveCatalogRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[53]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3536,7 +3894,7 @@ func (x *RemoveCatalogRequest) String() string {
 func (*RemoveCatalogRequest) ProtoMessage() {}
 
 func (x *RemoveCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[53]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3549,7 +3907,7 @@ func (x *RemoveCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCatalogRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{53}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *RemoveCatalogRequest) GetCatalogId() string {
@@ -3568,7 +3926,7 @@ type GetCatalogRequest struct {
 
 func (x *GetCatalogRequest) Reset() {
 	*x = GetCatalogRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[54]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3580,7 +3938,7 @@ func (x *GetCatalogRequest) String() string {
 func (*GetCatalogRequest) ProtoMessage() {}
 
 func (x *GetCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[54]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3593,7 +3951,7 @@ func (x *GetCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCatalogRequest.ProtoReflect.Descriptor instead.
 func (*GetCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{54}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetCatalogRequest) GetCatalogId() string {
@@ -3615,7 +3973,7 @@ type ListCatalogsRequest struct {
 
 func (x *ListCatalogsRequest) Reset() {
 	*x = ListCatalogsRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[55]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3627,7 +3985,7 @@ func (x *ListCatalogsRequest) String() string {
 func (*ListCatalogsRequest) ProtoMessage() {}
 
 func (x *ListCatalogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[55]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3640,7 +3998,7 @@ func (x *ListCatalogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCatalogsRequest.ProtoReflect.Descriptor instead.
 func (*ListCatalogsRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{55}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ListCatalogsRequest) GetPageSize() int32 {
@@ -3681,7 +4039,7 @@ type ListCatalogsResponse struct {
 
 func (x *ListCatalogsResponse) Reset() {
 	*x = ListCatalogsResponse{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[56]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3693,7 +4051,7 @@ func (x *ListCatalogsResponse) String() string {
 func (*ListCatalogsResponse) ProtoMessage() {}
 
 func (x *ListCatalogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[56]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3706,7 +4064,7 @@ func (x *ListCatalogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCatalogsResponse.ProtoReflect.Descriptor instead.
 func (*ListCatalogsResponse) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{56}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListCatalogsResponse) GetCatalogs() []*Catalog {
@@ -3732,7 +4090,7 @@ type UpdateCatalogRequest struct {
 
 func (x *UpdateCatalogRequest) Reset() {
 	*x = UpdateCatalogRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[57]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3744,7 +4102,7 @@ func (x *UpdateCatalogRequest) String() string {
 func (*UpdateCatalogRequest) ProtoMessage() {}
 
 func (x *UpdateCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[57]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3757,7 +4115,7 @@ func (x *UpdateCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateCatalogRequest.ProtoReflect.Descriptor instead.
 func (*UpdateCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{57}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UpdateCatalogRequest) GetCatalog() *Catalog {
@@ -3777,7 +4135,7 @@ type GetCategoryRequest struct {
 
 func (x *GetCategoryRequest) Reset() {
 	*x = GetCategoryRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[58]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3789,7 +4147,7 @@ func (x *GetCategoryRequest) String() string {
 func (*GetCategoryRequest) ProtoMessage() {}
 
 func (x *GetCategoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[58]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3802,7 +4160,7 @@ func (x *GetCategoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCategoryRequest.ProtoReflect.Descriptor instead.
 func (*GetCategoryRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{58}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetCategoryRequest) GetCatalogId() string {
@@ -3830,7 +4188,7 @@ type GetControlRequest struct {
 
 func (x *GetControlRequest) Reset() {
 	*x = GetControlRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[59]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3842,7 +4200,7 @@ func (x *GetControlRequest) String() string {
 func (*GetControlRequest) ProtoMessage() {}
 
 func (x *GetControlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[59]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3855,7 +4213,7 @@ func (x *GetControlRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetControlRequest.ProtoReflect.Descriptor instead.
 func (*GetControlRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{59}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetControlRequest) GetCatalogId() string {
@@ -3895,7 +4253,7 @@ type ListControlsRequest struct {
 
 func (x *ListControlsRequest) Reset() {
 	*x = ListControlsRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[60]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3907,7 +4265,7 @@ func (x *ListControlsRequest) String() string {
 func (*ListControlsRequest) ProtoMessage() {}
 
 func (x *ListControlsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[60]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3920,7 +4278,7 @@ func (x *ListControlsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListControlsRequest.ProtoReflect.Descriptor instead.
 func (*ListControlsRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{60}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListControlsRequest) GetCatalogId() string {
@@ -3982,7 +4340,7 @@ type ListControlsResponse struct {
 
 func (x *ListControlsResponse) Reset() {
 	*x = ListControlsResponse{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[61]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3994,7 +4352,7 @@ func (x *ListControlsResponse) String() string {
 func (*ListControlsResponse) ProtoMessage() {}
 
 func (x *ListControlsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[61]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4007,7 +4365,7 @@ func (x *ListControlsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListControlsResponse.ProtoReflect.Descriptor instead.
 func (*ListControlsResponse) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{61}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListControlsResponse) GetControls() []*Control {
@@ -4020,365 +4378,6 @@ func (x *ListControlsResponse) GetControls() []*Control {
 func (x *ListControlsResponse) GetNextPageToken() string {
 	if x != nil {
 		return x.NextPageToken
-	}
-	return ""
-}
-
-type CreateCertificateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Certificate   *Certificate           `protobuf:"bytes,1,opt,name=certificate,proto3" json:"certificate,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CreateCertificateRequest) Reset() {
-	*x = CreateCertificateRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[62]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CreateCertificateRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CreateCertificateRequest) ProtoMessage() {}
-
-func (x *CreateCertificateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[62]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CreateCertificateRequest.ProtoReflect.Descriptor instead.
-func (*CreateCertificateRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{62}
-}
-
-func (x *CreateCertificateRequest) GetCertificate() *Certificate {
-	if x != nil {
-		return x.Certificate
-	}
-	return nil
-}
-
-type RemoveCertificateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CertificateId string                 `protobuf:"bytes,1,opt,name=certificate_id,json=certificateId,proto3" json:"certificate_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *RemoveCertificateRequest) Reset() {
-	*x = RemoveCertificateRequest{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[63]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RemoveCertificateRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RemoveCertificateRequest) ProtoMessage() {}
-
-func (x *RemoveCertificateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[63]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RemoveCertificateRequest.ProtoReflect.Descriptor instead.
-func (*RemoveCertificateRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{63}
-}
-
-func (x *RemoveCertificateRequest) GetCertificateId() string {
-	if x != nil {
-		return x.CertificateId
-	}
-	return ""
-}
-
-// Certificate is the legacy API name for a compliance attestation.
-// It represents an assertion that a target of evaluation complies with a catalog
-// in the scope of a specific audit scope.
-type Certificate struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name           string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	IssueDate      string                 `protobuf:"bytes,4,opt,name=issue_date,json=issueDate,proto3" json:"issue_date,omitempty"`
-	ExpirationDate string                 `protobuf:"bytes,5,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
-	Standard       string                 `protobuf:"bytes,6,opt,name=standard,proto3" json:"standard,omitempty"`
-	AssuranceLevel string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
-	Cab            string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
-	Description    string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
-	// A list of states at specific times
-	States []*State `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
-	// Audit scope this attestation belongs to. This binds the attestation to a
-	// specific target of evaluation and catalog combination.
-	AuditScopeId string `protobuf:"bytes,11,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
-	// Type of compliance attestation, e.g. certificate or attestation.
-	AttestationType ComplianceAttestationType `protobuf:"varint,12,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType" json:"attestation_type,omitempty"`
-	// Structured validity timestamps for lifecycle-aware consumers.
-	IssuedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
-	ValidFrom  *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=valid_from,json=validFrom,proto3,oneof" json:"valid_from,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
-	ValidUntil *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=valid_until,json=validUntil,proto3,oneof" json:"valid_until,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
-	// Optional auditor / certification body information.
-	CertificationBody string `protobuf:"bytes,16,opt,name=certification_body,json=certificationBody,proto3" json:"certification_body,omitempty"`
-	Auditor           string `protobuf:"bytes,17,opt,name=auditor,proto3" json:"auditor,omitempty"`
-	// Current summarized compliance state. Detailed transitions live in states.
-	ComplianceStatus AttestationState `protobuf:"varint,18,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"compliance_status,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
-}
-
-func (x *Certificate) Reset() {
-	*x = Certificate{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[64]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Certificate) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Certificate) ProtoMessage() {}
-
-func (x *Certificate) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[64]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Certificate.ProtoReflect.Descriptor instead.
-func (*Certificate) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{64}
-}
-
-func (x *Certificate) GetId() string {
-	if x != nil {
-		return x.Id
-	}
-	return ""
-}
-
-func (x *Certificate) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *Certificate) GetIssueDate() string {
-	if x != nil {
-		return x.IssueDate
-	}
-	return ""
-}
-
-func (x *Certificate) GetExpirationDate() string {
-	if x != nil {
-		return x.ExpirationDate
-	}
-	return ""
-}
-
-func (x *Certificate) GetStandard() string {
-	if x != nil {
-		return x.Standard
-	}
-	return ""
-}
-
-func (x *Certificate) GetAssuranceLevel() string {
-	if x != nil {
-		return x.AssuranceLevel
-	}
-	return ""
-}
-
-func (x *Certificate) GetCab() string {
-	if x != nil {
-		return x.Cab
-	}
-	return ""
-}
-
-func (x *Certificate) GetDescription() string {
-	if x != nil {
-		return x.Description
-	}
-	return ""
-}
-
-func (x *Certificate) GetStates() []*State {
-	if x != nil {
-		return x.States
-	}
-	return nil
-}
-
-func (x *Certificate) GetAuditScopeId() string {
-	if x != nil {
-		return x.AuditScopeId
-	}
-	return ""
-}
-
-func (x *Certificate) GetAttestationType() ComplianceAttestationType {
-	if x != nil {
-		return x.AttestationType
-	}
-	return ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
-}
-
-func (x *Certificate) GetIssuedAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.IssuedAt
-	}
-	return nil
-}
-
-func (x *Certificate) GetValidFrom() *timestamppb.Timestamp {
-	if x != nil {
-		return x.ValidFrom
-	}
-	return nil
-}
-
-func (x *Certificate) GetValidUntil() *timestamppb.Timestamp {
-	if x != nil {
-		return x.ValidUntil
-	}
-	return nil
-}
-
-func (x *Certificate) GetCertificationBody() string {
-	if x != nil {
-		return x.CertificationBody
-	}
-	return ""
-}
-
-func (x *Certificate) GetAuditor() string {
-	if x != nil {
-		return x.Auditor
-	}
-	return ""
-}
-
-func (x *Certificate) GetComplianceStatus() AttestationState {
-	if x != nil {
-		return x.ComplianceStatus
-	}
-	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
-}
-
-// State is the legacy API name for a compliance attestation state transition.
-type State struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// An EUCS-defined or platform-defined attestation lifecycle state.
-	State AttestationState `protobuf:"varint,2,opt,name=state,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"state,omitempty"`
-	// Optional transparency log or external evidence tree reference.
-	TreeId    string                 `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
-	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
-	// Reference to the certificate / compliance attestation.
-	CertificateId string `protobuf:"bytes,5,opt,name=certificate_id,json=certificateId,proto3" json:"certificate_id,omitempty"`
-	// Optional human-readable reason for the state transition.
-	Reason        string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *State) Reset() {
-	*x = State{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[65]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *State) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*State) ProtoMessage() {}
-
-func (x *State) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[65]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use State.ProtoReflect.Descriptor instead.
-func (*State) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{65}
-}
-
-func (x *State) GetId() string {
-	if x != nil {
-		return x.Id
-	}
-	return ""
-}
-
-func (x *State) GetState() AttestationState {
-	if x != nil {
-		return x.State
-	}
-	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
-}
-
-func (x *State) GetTreeId() string {
-	if x != nil {
-		return x.TreeId
-	}
-	return ""
-}
-
-func (x *State) GetTimestamp() *timestamppb.Timestamp {
-	if x != nil {
-		return x.Timestamp
-	}
-	return nil
-}
-
-func (x *State) GetCertificateId() string {
-	if x != nil {
-		return x.CertificateId
-	}
-	return ""
-}
-
-func (x *State) GetReason() string {
-	if x != nil {
-		return x.Reason
 	}
 	return ""
 }
@@ -4812,7 +4811,7 @@ func (x *ListControlsRequest_Filter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListControlsRequest_Filter.ProtoReflect.Descriptor instead.
 func (*ListControlsRequest_Filter) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{60, 0}
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{64, 0}
 }
 
 func (x *ListControlsRequest_Filter) GetAssuranceLevels() []string {
@@ -5110,32 +5109,72 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"m\n" +
 	"\x17UpdateAuditScopeRequest\x12R\n" +
 	"\vaudit_scope\x18\x03 \x01(\v2&.confirmate.orchestrator.v1.AuditScopeB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\n" +
-	"auditScope\"J\n" +
-	"\x15GetCertificateRequest\x121\n" +
-	"\x0ecertificate_id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\rcertificateId\"\x82\x01\n" +
-	"\x17ListCertificatesRequest\x12\x1b\n" +
+	"auditScope\"i\n" +
+	"\x1fGetComplianceAttestationRequest\x12F\n" +
+	"\x19compliance_attestation_id\x18\x01 \x01(\tB\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\x8c\x01\n" +
+	"!ListComplianceAttestationsRequest\x12\x1b\n" +
 	"\tpage_size\x18\n" +
 	" \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\"\x8f\x01\n" +
-	"\x18ListCertificatesResponse\x12K\n" +
-	"\fcertificates\x18\x01 \x03(\v2'.confirmate.orchestrator.v1.CertificateR\fcertificates\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x88\x01\n" +
-	"\x1dListPublicCertificatesRequest\x12\x1b\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\"\xb8\x01\n" +
+	"\"ListComplianceAttestationsResponse\x12j\n" +
+	"\x17compliance_attestations\x18\x01 \x03(\v21.confirmate.orchestrator.v1.ComplianceAttestationR\x16complianceAttestations\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x92\x01\n" +
+	"'ListPublicComplianceAttestationsRequest\x12\x1b\n" +
 	"\tpage_size\x18\n" +
 	" \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\"\x95\x01\n" +
-	"\x1eListPublicCertificatesResponse\x12K\n" +
-	"\fcertificates\x18\x01 \x03(\v2'.confirmate.orchestrator.v1.CertificateR\fcertificates\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"p\n" +
-	"\x18UpdateCertificateRequest\x12T\n" +
-	"\vcertificate\x18\x01 \x01(\v2'.confirmate.orchestrator.v1.CertificateB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\vcertificate\"`\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\"\xbe\x01\n" +
+	"(ListPublicComplianceAttestationsResponse\x12j\n" +
+	"\x17compliance_attestations\x18\x01 \x03(\v21.confirmate.orchestrator.v1.ComplianceAttestationR\x16complianceAttestations\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x99\x01\n" +
+	"\"UpdateComplianceAttestationRequest\x12s\n" +
+	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"\x99\x01\n" +
+	"\"CreateComplianceAttestationRequest\x12s\n" +
+	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"l\n" +
+	"\"RemoveComplianceAttestationRequest\x12F\n" +
+	"\x19compliance_attestation_id\x18\x01 \x01(\tB\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\xe0\b\n" +
+	"\x15ComplianceAttestation\x12\x1a\n" +
+	"\x02id\x18\x01 \x01(\tB\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x02id\x12\x1e\n" +
+	"\x04name\x18\x02 \x01(\tB\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12\x1d\n" +
+	"\n" +
+	"issue_date\x18\x04 \x01(\tR\tissueDate\x12'\n" +
+	"\x0fexpiration_date\x18\x05 \x01(\tR\x0eexpirationDate\x12\x1a\n" +
+	"\bstandard\x18\x06 \x01(\tR\bstandard\x12'\n" +
+	"\x0fassurance_level\x18\a \x01(\tR\x0eassuranceLevel\x12\x10\n" +
+	"\x03cab\x18\b \x01(\tR\x03cab\x12 \n" +
+	"\vdescription\x18\t \x01(\tR\vdescription\x12w\n" +
+	"\x06states\x18\n" +
+	" \x03(\v26.confirmate.orchestrator.v1.ComplianceAttestationStateB'\x9a\x84\x9e\x03\"gorm:\"constraint:OnDelete:CASCADE\"R\x06states\x121\n" +
+	"\x0eaudit_scope_id\x18\v \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\fauditScopeId\x12j\n" +
+	"\x10attestation_type\x18\f \x01(\x0e25.confirmate.orchestrator.v1.ComplianceAttestationTypeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x0fattestationType\x12o\n" +
+	"\tissued_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x00R\bissuedAt\x88\x01\x01\x12q\n" +
+	"\n" +
+	"valid_from\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x01R\tvalidFrom\x88\x01\x01\x12s\n" +
+	"\vvalid_until\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x02R\n" +
+	"validUntil\x88\x01\x01\x12-\n" +
+	"\x12certification_body\x18\x10 \x01(\tR\x11certificationBody\x12\x18\n" +
+	"\aauditor\x18\x11 \x01(\tR\aauditor\x12c\n" +
+	"\x11compliance_status\x18\x12 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x10complianceStatusB\f\n" +
+	"\n" +
+	"_issued_atB\r\n" +
+	"\v_valid_fromB\x0e\n" +
+	"\f_valid_until\"\xd4\x02\n" +
+	"\x1aComplianceAttestationState\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12L\n" +
+	"\x05state\x18\x02 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05state\x12\x17\n" +
+	"\atree_id\x18\x03 \x01(\tR\x06treeId\x12k\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"R\ttimestamp\x12:\n" +
+	"\x19compliance_attestation_id\x18\x05 \x01(\tR\x17complianceAttestationId\x12\x16\n" +
+	"\x06reason\x18\x06 \x01(\tR\x06reason\"`\n" +
 	"\x14CreateCatalogRequest\x12H\n" +
 	"\acatalog\x18\x01 \x01(\v2#.confirmate.orchestrator.v1.CatalogB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\acatalog\"A\n" +
 	"\x14RemoveCatalogRequest\x12)\n" +
@@ -5189,47 +5228,7 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\a_filter\"\x7f\n" +
 	"\x14ListControlsResponse\x12?\n" +
 	"\bcontrols\x18\x01 \x03(\v2#.confirmate.orchestrator.v1.ControlR\bcontrols\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"p\n" +
-	"\x18CreateCertificateRequest\x12T\n" +
-	"\vcertificate\x18\x01 \x01(\v2'.confirmate.orchestrator.v1.CertificateB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\vcertificate\"M\n" +
-	"\x18RemoveCertificateRequest\x121\n" +
-	"\x0ecertificate_id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\rcertificateId\"\xc1\b\n" +
-	"\vCertificate\x12\x1a\n" +
-	"\x02id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x02id\x12\x1e\n" +
-	"\x04name\x18\x02 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x04name\x12\x1d\n" +
-	"\n" +
-	"issue_date\x18\x04 \x01(\tR\tissueDate\x12'\n" +
-	"\x0fexpiration_date\x18\x05 \x01(\tR\x0eexpirationDate\x12\x1a\n" +
-	"\bstandard\x18\x06 \x01(\tR\bstandard\x12'\n" +
-	"\x0fassurance_level\x18\a \x01(\tR\x0eassuranceLevel\x12\x10\n" +
-	"\x03cab\x18\b \x01(\tR\x03cab\x12 \n" +
-	"\vdescription\x18\t \x01(\tR\vdescription\x12b\n" +
-	"\x06states\x18\n" +
-	" \x03(\v2!.confirmate.orchestrator.v1.StateB'\x9a\x84\x9e\x03\"gorm:\"constraint:OnDelete:CASCADE\"R\x06states\x121\n" +
-	"\x0eaudit_scope_id\x18\v \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\fauditScopeId\x12j\n" +
-	"\x10attestation_type\x18\f \x01(\x0e25.confirmate.orchestrator.v1.ComplianceAttestationTypeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x0fattestationType\x12o\n" +
-	"\tissued_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x00R\bissuedAt\x88\x01\x01\x12q\n" +
-	"\n" +
-	"valid_from\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x01R\tvalidFrom\x88\x01\x01\x12s\n" +
-	"\vvalid_until\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"H\x02R\n" +
-	"validUntil\x88\x01\x01\x12-\n" +
-	"\x12certification_body\x18\x10 \x01(\tR\x11certificationBody\x12\x18\n" +
-	"\aauditor\x18\x11 \x01(\tR\aauditor\x12c\n" +
-	"\x11compliance_status\x18\x12 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x10complianceStatusB\f\n" +
-	"\n" +
-	"_issued_atB\r\n" +
-	"\v_valid_fromB\x0e\n" +
-	"\f_valid_until\"\xaa\x02\n" +
-	"\x05State\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12L\n" +
-	"\x05state\x18\x02 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05state\x12\x17\n" +
-	"\atree_id\x18\x03 \x01(\tR\x06treeId\x12k\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"R\ttimestamp\x12%\n" +
-	"\x0ecertificate_id\x18\x05 \x01(\tR\rcertificateId\x12\x16\n" +
-	"\x06reason\x18\x06 \x01(\tR\x06reason*\xb0\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*\xb0\x02\n" +
 	"\rEventCategory\x12\x1e\n" +
 	"\x1aEVENT_CATEGORY_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15EVENT_CATEGORY_METRIC\x10\x01\x12'\n" +
@@ -5261,7 +5260,7 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x19ATTESTATION_STATE_EXPIRED\x10\x06\x12\x1d\n" +
 	"\x19ATTESTATION_STATE_APPLIED\x10\a\x12\"\n" +
 	"\x1eATTESTATION_STATE_UNDER_REVIEW\x10\b\x12\x1e\n" +
-	"\x1aATTESTATION_STATE_REJECTED\x10\t2\xb9A\n" +
+	"\x1aATTESTATION_STATE_REJECTED\x10\t2\xdcC\n" +
 	"\fOrchestrator\x12\xb0\x01\n" +
 	"\x16RegisterAssessmentTool\x129.confirmate.orchestrator.v1.RegisterAssessmentToolRequest\x1a*.confirmate.orchestrator.v1.AssessmentTool\"/\x82\xd3\xe4\x93\x02):\x04tool\"!/v1/orchestrator/assessment_tools\x12\xb1\x01\n" +
 	"\x13ListAssessmentTools\x126.confirmate.orchestrator.v1.ListAssessmentToolsRequest\x1a7.confirmate.orchestrator.v1.ListAssessmentToolsResponse\")\x82\xd3\xe4\x93\x02#\x12!/v1/orchestrator/assessment_tools\x12\xaa\x01\n" +
@@ -5288,13 +5287,13 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x18ListMetricConfigurations\x12:.confirmate.orchestrator.v1.ListMetricConfigurationRequest\x1a;.confirmate.orchestrator.v1.ListMetricConfigurationResponse\"^\x82\xd3\xe4\x93\x02X\x12V/v1/orchestrator/targets_of_evaluation/{target_of_evaluation_id}/metric_configurations\x12\xe7\x01\n" +
 	"\x1aUpdateMetricImplementation\x12=.confirmate.orchestrator.v1.UpdateMetricImplementationRequest\x1a..confirmate.assessment.v1.MetricImplementation\"Z\x82\xd3\xe4\x93\x02T:\x0eimplementation\x1aB/v1/orchestrator/metrics/{implementation.metric_id}/implementation\x12\xc2\x01\n" +
 	"\x17GetMetricImplementation\x12:.confirmate.orchestrator.v1.GetMetricImplementationRequest\x1a..confirmate.assessment.v1.MetricImplementation\";\x82\xd3\xe4\x93\x025\x123/v1/orchestrator/metrics/{metric_id}/implementation\x12f\n" +
-	"\tSubscribe\x12,.confirmate.orchestrator.v1.SubscribeRequest\x1a'.confirmate.orchestrator.v1.ChangeEvent\"\x000\x01\x12\xa6\x01\n" +
-	"\x11CreateCertificate\x124.confirmate.orchestrator.v1.CreateCertificateRequest\x1a'.confirmate.orchestrator.v1.Certificate\"2\x82\xd3\xe4\x93\x02,:\vcertificate\"\x1d/v1/orchestrator/certificates\x12\xa4\x01\n" +
-	"\x0eGetCertificate\x121.confirmate.orchestrator.v1.GetCertificateRequest\x1a'.confirmate.orchestrator.v1.Certificate\"6\x82\xd3\xe4\x93\x020\x12./v1/orchestrator/certificates/{certificate_id}\x12\xa4\x01\n" +
-	"\x10ListCertificates\x123.confirmate.orchestrator.v1.ListCertificatesRequest\x1a4.confirmate.orchestrator.v1.ListCertificatesResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/v1/orchestrator/certificates\x12\xbd\x01\n" +
-	"\x16ListPublicCertificates\x129.confirmate.orchestrator.v1.ListPublicCertificatesRequest\x1a:.confirmate.orchestrator.v1.ListPublicCertificatesResponse\",\x82\xd3\xe4\x93\x02&\x12$/v1/orchestrator/public/certificates\x12\xb7\x01\n" +
-	"\x11UpdateCertificate\x124.confirmate.orchestrator.v1.UpdateCertificateRequest\x1a'.confirmate.orchestrator.v1.Certificate\"C\x82\xd3\xe4\x93\x02=:\vcertificate\x1a./v1/orchestrator/certificates/{certificate.id}\x12\x99\x01\n" +
-	"\x11RemoveCertificate\x124.confirmate.orchestrator.v1.RemoveCertificateRequest\x1a\x16.google.protobuf.Empty\"6\x82\xd3\xe4\x93\x020*./v1/orchestrator/certificates/{certificate_id}\x12\x92\x01\n" +
+	"\tSubscribe\x12,.confirmate.orchestrator.v1.SubscribeRequest\x1a'.confirmate.orchestrator.v1.ChangeEvent\"\x000\x01\x12\xda\x01\n" +
+	"\x1bCreateComplianceAttestation\x12>.confirmate.orchestrator.v1.CreateComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\"H\x82\xd3\xe4\x93\x02B:\x16compliance_attestation\"(/v1/orchestrator/compliance_attestations\x12\xd8\x01\n" +
+	"\x18GetComplianceAttestation\x12;.confirmate.orchestrator.v1.GetComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\"L\x82\xd3\xe4\x93\x02F\x12D/v1/orchestrator/compliance_attestations/{compliance_attestation_id}\x12\xcd\x01\n" +
+	"\x1aListComplianceAttestations\x12=.confirmate.orchestrator.v1.ListComplianceAttestationsRequest\x1a>.confirmate.orchestrator.v1.ListComplianceAttestationsResponse\"0\x82\xd3\xe4\x93\x02*\x12(/v1/orchestrator/compliance_attestations\x12\xe6\x01\n" +
+	" ListPublicComplianceAttestations\x12C.confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest\x1aD.confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse\"7\x82\xd3\xe4\x93\x021\x12//v1/orchestrator/public/compliance_attestations\x12\xf6\x01\n" +
+	"\x1bUpdateComplianceAttestation\x12>.confirmate.orchestrator.v1.UpdateComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\"d\x82\xd3\xe4\x93\x02^:\x16compliance_attestation\x1aD/v1/orchestrator/compliance_attestations/{compliance_attestation.id}\x12\xc3\x01\n" +
+	"\x1bRemoveComplianceAttestation\x12>.confirmate.orchestrator.v1.RemoveComplianceAttestationRequest\x1a\x16.google.protobuf.Empty\"L\x82\xd3\xe4\x93\x02F*D/v1/orchestrator/compliance_attestations/{compliance_attestation_id}\x12\x92\x01\n" +
 	"\rCreateCatalog\x120.confirmate.orchestrator.v1.CreateCatalogRequest\x1a#.confirmate.orchestrator.v1.Catalog\"*\x82\xd3\xe4\x93\x02$:\acatalog\"\x19/v1/orchestrator/catalogs\x12\x94\x01\n" +
 	"\fListCatalogs\x12/.confirmate.orchestrator.v1.ListCatalogsRequest\x1a0.confirmate.orchestrator.v1.ListCatalogsResponse\"!\x82\xd3\xe4\x93\x02\x1b\x12\x19/v1/orchestrator/catalogs\x12\x90\x01\n" +
 	"\n" +
@@ -5327,95 +5326,95 @@ func file_api_orchestrator_orchestrator_proto_rawDescGZIP() []byte {
 var file_api_orchestrator_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_api_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
 var file_api_orchestrator_orchestrator_proto_goTypes = []any{
-	(EventCategory)(0),                              // 0: confirmate.orchestrator.v1.EventCategory
-	(RequestType)(0),                                // 1: confirmate.orchestrator.v1.RequestType
-	(ComplianceAttestationType)(0),                  // 2: confirmate.orchestrator.v1.ComplianceAttestationType
-	(AttestationState)(0),                           // 3: confirmate.orchestrator.v1.AttestationState
-	(TargetOfEvaluation_TargetType)(0),              // 4: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
-	(*RegisterAssessmentToolRequest)(nil),           // 5: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
-	(*ListAssessmentToolsRequest)(nil),              // 6: confirmate.orchestrator.v1.ListAssessmentToolsRequest
-	(*ListAssessmentToolsResponse)(nil),             // 7: confirmate.orchestrator.v1.ListAssessmentToolsResponse
-	(*GetAssessmentToolRequest)(nil),                // 8: confirmate.orchestrator.v1.GetAssessmentToolRequest
-	(*UpdateAssessmentToolRequest)(nil),             // 9: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
-	(*DeregisterAssessmentToolRequest)(nil),         // 10: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
-	(*StoreAssessmentResultRequest)(nil),            // 11: confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	(*StoreAssessmentResultResponse)(nil),           // 12: confirmate.orchestrator.v1.StoreAssessmentResultResponse
-	(*StoreAssessmentResultsResponse)(nil),          // 13: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
-	(*CreateMetricRequest)(nil),                     // 14: confirmate.orchestrator.v1.CreateMetricRequest
-	(*UpdateMetricRequest)(nil),                     // 15: confirmate.orchestrator.v1.UpdateMetricRequest
-	(*GetMetricRequest)(nil),                        // 16: confirmate.orchestrator.v1.GetMetricRequest
-	(*ListMetricsRequest)(nil),                      // 17: confirmate.orchestrator.v1.ListMetricsRequest
-	(*RemoveMetricRequest)(nil),                     // 18: confirmate.orchestrator.v1.RemoveMetricRequest
-	(*ListMetricsResponse)(nil),                     // 19: confirmate.orchestrator.v1.ListMetricsResponse
-	(*GetTargetOfEvaluationRequest)(nil),            // 20: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
-	(*CreateTargetOfEvaluationRequest)(nil),         // 21: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
-	(*UpdateTargetOfEvaluationRequest)(nil),         // 22: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
-	(*RemoveTargetOfEvaluationRequest)(nil),         // 23: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
-	(*ListTargetsOfEvaluationRequest)(nil),          // 24: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
-	(*ListTargetsOfEvaluationResponse)(nil),         // 25: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
-	(*GetTargetOfEvaluationStatisticsRequest)(nil),  // 26: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
-	(*GetTargetOfEvaluationStatisticsResponse)(nil), // 27: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
-	(*UpdateMetricConfigurationRequest)(nil),        // 28: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
-	(*GetMetricConfigurationRequest)(nil),           // 29: confirmate.orchestrator.v1.GetMetricConfigurationRequest
-	(*ListMetricConfigurationRequest)(nil),          // 30: confirmate.orchestrator.v1.ListMetricConfigurationRequest
-	(*ListMetricConfigurationResponse)(nil),         // 31: confirmate.orchestrator.v1.ListMetricConfigurationResponse
-	(*UpdateMetricImplementationRequest)(nil),       // 32: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
-	(*GetMetricImplementationRequest)(nil),          // 33: confirmate.orchestrator.v1.GetMetricImplementationRequest
-	(*SubscribeRequest)(nil),                        // 34: confirmate.orchestrator.v1.SubscribeRequest
-	(*ChangeEvent)(nil),                             // 35: confirmate.orchestrator.v1.ChangeEvent
-	(*AssessmentTool)(nil),                          // 36: confirmate.orchestrator.v1.AssessmentTool
-	(*TargetOfEvaluation)(nil),                      // 37: confirmate.orchestrator.v1.TargetOfEvaluation
-	(*Catalog)(nil),                                 // 38: confirmate.orchestrator.v1.Catalog
-	(*Category)(nil),                                // 39: confirmate.orchestrator.v1.Category
-	(*Control)(nil),                                 // 40: confirmate.orchestrator.v1.Control
-	(*AuditScope)(nil),                              // 41: confirmate.orchestrator.v1.AuditScope
-	(*GetAssessmentResultRequest)(nil),              // 42: confirmate.orchestrator.v1.GetAssessmentResultRequest
-	(*ListAssessmentResultsRequest)(nil),            // 43: confirmate.orchestrator.v1.ListAssessmentResultsRequest
-	(*ListAssessmentResultsResponse)(nil),           // 44: confirmate.orchestrator.v1.ListAssessmentResultsResponse
-	(*CreateAuditScopeRequest)(nil),                 // 45: confirmate.orchestrator.v1.CreateAuditScopeRequest
-	(*RemoveAuditScopeRequest)(nil),                 // 46: confirmate.orchestrator.v1.RemoveAuditScopeRequest
-	(*GetAuditScopeRequest)(nil),                    // 47: confirmate.orchestrator.v1.GetAuditScopeRequest
-	(*ListAuditScopesRequest)(nil),                  // 48: confirmate.orchestrator.v1.ListAuditScopesRequest
-	(*ListAuditScopesResponse)(nil),                 // 49: confirmate.orchestrator.v1.ListAuditScopesResponse
-	(*UpdateAuditScopeRequest)(nil),                 // 50: confirmate.orchestrator.v1.UpdateAuditScopeRequest
-	(*GetCertificateRequest)(nil),                   // 51: confirmate.orchestrator.v1.GetCertificateRequest
-	(*ListCertificatesRequest)(nil),                 // 52: confirmate.orchestrator.v1.ListCertificatesRequest
-	(*ListCertificatesResponse)(nil),                // 53: confirmate.orchestrator.v1.ListCertificatesResponse
-	(*ListPublicCertificatesRequest)(nil),           // 54: confirmate.orchestrator.v1.ListPublicCertificatesRequest
-	(*ListPublicCertificatesResponse)(nil),          // 55: confirmate.orchestrator.v1.ListPublicCertificatesResponse
-	(*UpdateCertificateRequest)(nil),                // 56: confirmate.orchestrator.v1.UpdateCertificateRequest
-	(*CreateCatalogRequest)(nil),                    // 57: confirmate.orchestrator.v1.CreateCatalogRequest
-	(*RemoveCatalogRequest)(nil),                    // 58: confirmate.orchestrator.v1.RemoveCatalogRequest
-	(*GetCatalogRequest)(nil),                       // 59: confirmate.orchestrator.v1.GetCatalogRequest
-	(*ListCatalogsRequest)(nil),                     // 60: confirmate.orchestrator.v1.ListCatalogsRequest
-	(*ListCatalogsResponse)(nil),                    // 61: confirmate.orchestrator.v1.ListCatalogsResponse
-	(*UpdateCatalogRequest)(nil),                    // 62: confirmate.orchestrator.v1.UpdateCatalogRequest
-	(*GetCategoryRequest)(nil),                      // 63: confirmate.orchestrator.v1.GetCategoryRequest
-	(*GetControlRequest)(nil),                       // 64: confirmate.orchestrator.v1.GetControlRequest
-	(*ListControlsRequest)(nil),                     // 65: confirmate.orchestrator.v1.ListControlsRequest
-	(*ListControlsResponse)(nil),                    // 66: confirmate.orchestrator.v1.ListControlsResponse
-	(*CreateCertificateRequest)(nil),                // 67: confirmate.orchestrator.v1.CreateCertificateRequest
-	(*RemoveCertificateRequest)(nil),                // 68: confirmate.orchestrator.v1.RemoveCertificateRequest
-	(*Certificate)(nil),                             // 69: confirmate.orchestrator.v1.Certificate
-	(*State)(nil),                                   // 70: confirmate.orchestrator.v1.State
-	(*ListAssessmentToolsRequest_Filter)(nil),       // 71: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
-	(*ListMetricsRequest_Filter)(nil),               // 72: confirmate.orchestrator.v1.ListMetricsRequest.Filter
-	nil,                                             // 73: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
-	(*SubscribeRequest_Filter)(nil),                 // 74: confirmate.orchestrator.v1.SubscribeRequest.Filter
-	(*TargetOfEvaluation_Metadata)(nil),             // 75: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
-	nil,                                             // 76: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
-	(*Catalog_Metadata)(nil),                        // 77: confirmate.orchestrator.v1.Catalog.Metadata
-	(*ListAssessmentResultsRequest_Filter)(nil),     // 78: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	(*ListAuditScopesRequest_Filter)(nil),           // 79: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
-	(*ListControlsRequest_Filter)(nil),              // 80: confirmate.orchestrator.v1.ListControlsRequest.Filter
-	(*assessment.AssessmentResult)(nil),             // 81: confirmate.assessment.v1.AssessmentResult
-	(*assessment.Metric)(nil),                       // 82: confirmate.assessment.v1.Metric
-	(*assessment.MetricConfiguration)(nil),          // 83: confirmate.assessment.v1.MetricConfiguration
-	(*assessment.MetricImplementation)(nil),         // 84: confirmate.assessment.v1.MetricImplementation
-	(*timestamppb.Timestamp)(nil),                   // 85: google.protobuf.Timestamp
-	(*common.GetRuntimeInfoRequest)(nil),            // 86: confirmate.common.v1.GetRuntimeInfoRequest
-	(*emptypb.Empty)(nil),                           // 87: google.protobuf.Empty
-	(*common.Runtime)(nil),                          // 88: confirmate.common.v1.Runtime
+	(EventCategory)(0),                               // 0: confirmate.orchestrator.v1.EventCategory
+	(RequestType)(0),                                 // 1: confirmate.orchestrator.v1.RequestType
+	(ComplianceAttestationType)(0),                   // 2: confirmate.orchestrator.v1.ComplianceAttestationType
+	(AttestationState)(0),                            // 3: confirmate.orchestrator.v1.AttestationState
+	(TargetOfEvaluation_TargetType)(0),               // 4: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
+	(*RegisterAssessmentToolRequest)(nil),            // 5: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
+	(*ListAssessmentToolsRequest)(nil),               // 6: confirmate.orchestrator.v1.ListAssessmentToolsRequest
+	(*ListAssessmentToolsResponse)(nil),              // 7: confirmate.orchestrator.v1.ListAssessmentToolsResponse
+	(*GetAssessmentToolRequest)(nil),                 // 8: confirmate.orchestrator.v1.GetAssessmentToolRequest
+	(*UpdateAssessmentToolRequest)(nil),              // 9: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
+	(*DeregisterAssessmentToolRequest)(nil),          // 10: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
+	(*StoreAssessmentResultRequest)(nil),             // 11: confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	(*StoreAssessmentResultResponse)(nil),            // 12: confirmate.orchestrator.v1.StoreAssessmentResultResponse
+	(*StoreAssessmentResultsResponse)(nil),           // 13: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
+	(*CreateMetricRequest)(nil),                      // 14: confirmate.orchestrator.v1.CreateMetricRequest
+	(*UpdateMetricRequest)(nil),                      // 15: confirmate.orchestrator.v1.UpdateMetricRequest
+	(*GetMetricRequest)(nil),                         // 16: confirmate.orchestrator.v1.GetMetricRequest
+	(*ListMetricsRequest)(nil),                       // 17: confirmate.orchestrator.v1.ListMetricsRequest
+	(*RemoveMetricRequest)(nil),                      // 18: confirmate.orchestrator.v1.RemoveMetricRequest
+	(*ListMetricsResponse)(nil),                      // 19: confirmate.orchestrator.v1.ListMetricsResponse
+	(*GetTargetOfEvaluationRequest)(nil),             // 20: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
+	(*CreateTargetOfEvaluationRequest)(nil),          // 21: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
+	(*UpdateTargetOfEvaluationRequest)(nil),          // 22: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
+	(*RemoveTargetOfEvaluationRequest)(nil),          // 23: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
+	(*ListTargetsOfEvaluationRequest)(nil),           // 24: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
+	(*ListTargetsOfEvaluationResponse)(nil),          // 25: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
+	(*GetTargetOfEvaluationStatisticsRequest)(nil),   // 26: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
+	(*GetTargetOfEvaluationStatisticsResponse)(nil),  // 27: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
+	(*UpdateMetricConfigurationRequest)(nil),         // 28: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
+	(*GetMetricConfigurationRequest)(nil),            // 29: confirmate.orchestrator.v1.GetMetricConfigurationRequest
+	(*ListMetricConfigurationRequest)(nil),           // 30: confirmate.orchestrator.v1.ListMetricConfigurationRequest
+	(*ListMetricConfigurationResponse)(nil),          // 31: confirmate.orchestrator.v1.ListMetricConfigurationResponse
+	(*UpdateMetricImplementationRequest)(nil),        // 32: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
+	(*GetMetricImplementationRequest)(nil),           // 33: confirmate.orchestrator.v1.GetMetricImplementationRequest
+	(*SubscribeRequest)(nil),                         // 34: confirmate.orchestrator.v1.SubscribeRequest
+	(*ChangeEvent)(nil),                              // 35: confirmate.orchestrator.v1.ChangeEvent
+	(*AssessmentTool)(nil),                           // 36: confirmate.orchestrator.v1.AssessmentTool
+	(*TargetOfEvaluation)(nil),                       // 37: confirmate.orchestrator.v1.TargetOfEvaluation
+	(*Catalog)(nil),                                  // 38: confirmate.orchestrator.v1.Catalog
+	(*Category)(nil),                                 // 39: confirmate.orchestrator.v1.Category
+	(*Control)(nil),                                  // 40: confirmate.orchestrator.v1.Control
+	(*AuditScope)(nil),                               // 41: confirmate.orchestrator.v1.AuditScope
+	(*GetAssessmentResultRequest)(nil),               // 42: confirmate.orchestrator.v1.GetAssessmentResultRequest
+	(*ListAssessmentResultsRequest)(nil),             // 43: confirmate.orchestrator.v1.ListAssessmentResultsRequest
+	(*ListAssessmentResultsResponse)(nil),            // 44: confirmate.orchestrator.v1.ListAssessmentResultsResponse
+	(*CreateAuditScopeRequest)(nil),                  // 45: confirmate.orchestrator.v1.CreateAuditScopeRequest
+	(*RemoveAuditScopeRequest)(nil),                  // 46: confirmate.orchestrator.v1.RemoveAuditScopeRequest
+	(*GetAuditScopeRequest)(nil),                     // 47: confirmate.orchestrator.v1.GetAuditScopeRequest
+	(*ListAuditScopesRequest)(nil),                   // 48: confirmate.orchestrator.v1.ListAuditScopesRequest
+	(*ListAuditScopesResponse)(nil),                  // 49: confirmate.orchestrator.v1.ListAuditScopesResponse
+	(*UpdateAuditScopeRequest)(nil),                  // 50: confirmate.orchestrator.v1.UpdateAuditScopeRequest
+	(*GetComplianceAttestationRequest)(nil),          // 51: confirmate.orchestrator.v1.GetComplianceAttestationRequest
+	(*ListComplianceAttestationsRequest)(nil),        // 52: confirmate.orchestrator.v1.ListComplianceAttestationsRequest
+	(*ListComplianceAttestationsResponse)(nil),       // 53: confirmate.orchestrator.v1.ListComplianceAttestationsResponse
+	(*ListPublicComplianceAttestationsRequest)(nil),  // 54: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
+	(*ListPublicComplianceAttestationsResponse)(nil), // 55: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
+	(*UpdateComplianceAttestationRequest)(nil),       // 56: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
+	(*CreateComplianceAttestationRequest)(nil),       // 57: confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	(*RemoveComplianceAttestationRequest)(nil),       // 58: confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
+	(*ComplianceAttestation)(nil),                    // 59: confirmate.orchestrator.v1.ComplianceAttestation
+	(*ComplianceAttestationState)(nil),               // 60: confirmate.orchestrator.v1.ComplianceAttestationState
+	(*CreateCatalogRequest)(nil),                     // 61: confirmate.orchestrator.v1.CreateCatalogRequest
+	(*RemoveCatalogRequest)(nil),                     // 62: confirmate.orchestrator.v1.RemoveCatalogRequest
+	(*GetCatalogRequest)(nil),                        // 63: confirmate.orchestrator.v1.GetCatalogRequest
+	(*ListCatalogsRequest)(nil),                      // 64: confirmate.orchestrator.v1.ListCatalogsRequest
+	(*ListCatalogsResponse)(nil),                     // 65: confirmate.orchestrator.v1.ListCatalogsResponse
+	(*UpdateCatalogRequest)(nil),                     // 66: confirmate.orchestrator.v1.UpdateCatalogRequest
+	(*GetCategoryRequest)(nil),                       // 67: confirmate.orchestrator.v1.GetCategoryRequest
+	(*GetControlRequest)(nil),                        // 68: confirmate.orchestrator.v1.GetControlRequest
+	(*ListControlsRequest)(nil),                      // 69: confirmate.orchestrator.v1.ListControlsRequest
+	(*ListControlsResponse)(nil),                     // 70: confirmate.orchestrator.v1.ListControlsResponse
+	(*ListAssessmentToolsRequest_Filter)(nil),        // 71: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
+	(*ListMetricsRequest_Filter)(nil),                // 72: confirmate.orchestrator.v1.ListMetricsRequest.Filter
+	nil,                                              // 73: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
+	(*SubscribeRequest_Filter)(nil),                  // 74: confirmate.orchestrator.v1.SubscribeRequest.Filter
+	(*TargetOfEvaluation_Metadata)(nil),              // 75: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
+	nil,                                              // 76: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
+	(*Catalog_Metadata)(nil),                         // 77: confirmate.orchestrator.v1.Catalog.Metadata
+	(*ListAssessmentResultsRequest_Filter)(nil),      // 78: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
+	(*ListAuditScopesRequest_Filter)(nil),            // 79: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
+	(*ListControlsRequest_Filter)(nil),               // 80: confirmate.orchestrator.v1.ListControlsRequest.Filter
+	(*assessment.AssessmentResult)(nil),              // 81: confirmate.assessment.v1.AssessmentResult
+	(*assessment.Metric)(nil),                        // 82: confirmate.assessment.v1.Metric
+	(*assessment.MetricConfiguration)(nil),           // 83: confirmate.assessment.v1.MetricConfiguration
+	(*assessment.MetricImplementation)(nil),          // 84: confirmate.assessment.v1.MetricImplementation
+	(*timestamppb.Timestamp)(nil),                    // 85: google.protobuf.Timestamp
+	(*common.GetRuntimeInfoRequest)(nil),             // 86: confirmate.common.v1.GetRuntimeInfoRequest
+	(*emptypb.Empty)(nil),                            // 87: google.protobuf.Empty
+	(*common.Runtime)(nil),                           // 88: confirmate.common.v1.Runtime
 }
 var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	36,  // 0: confirmate.orchestrator.v1.RegisterAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
@@ -5460,23 +5459,23 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	79,  // 39: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
 	41,  // 40: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
 	41,  // 41: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	69,  // 42: confirmate.orchestrator.v1.ListCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
-	69,  // 43: confirmate.orchestrator.v1.ListPublicCertificatesResponse.certificates:type_name -> confirmate.orchestrator.v1.Certificate
-	69,  // 44: confirmate.orchestrator.v1.UpdateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
-	38,  // 45: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	38,  // 46: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
-	38,  // 47: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	80,  // 48: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
-	40,  // 49: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
-	69,  // 50: confirmate.orchestrator.v1.CreateCertificateRequest.certificate:type_name -> confirmate.orchestrator.v1.Certificate
-	70,  // 51: confirmate.orchestrator.v1.Certificate.states:type_name -> confirmate.orchestrator.v1.State
-	2,   // 52: confirmate.orchestrator.v1.Certificate.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
-	85,  // 53: confirmate.orchestrator.v1.Certificate.issued_at:type_name -> google.protobuf.Timestamp
-	85,  // 54: confirmate.orchestrator.v1.Certificate.valid_from:type_name -> google.protobuf.Timestamp
-	85,  // 55: confirmate.orchestrator.v1.Certificate.valid_until:type_name -> google.protobuf.Timestamp
-	3,   // 56: confirmate.orchestrator.v1.Certificate.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
-	3,   // 57: confirmate.orchestrator.v1.State.state:type_name -> confirmate.orchestrator.v1.AttestationState
-	85,  // 58: confirmate.orchestrator.v1.State.timestamp:type_name -> google.protobuf.Timestamp
+	59,  // 42: confirmate.orchestrator.v1.ListComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 43: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 44: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 45: confirmate.orchestrator.v1.CreateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	60,  // 46: confirmate.orchestrator.v1.ComplianceAttestation.states:type_name -> confirmate.orchestrator.v1.ComplianceAttestationState
+	2,   // 47: confirmate.orchestrator.v1.ComplianceAttestation.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
+	85,  // 48: confirmate.orchestrator.v1.ComplianceAttestation.issued_at:type_name -> google.protobuf.Timestamp
+	85,  // 49: confirmate.orchestrator.v1.ComplianceAttestation.valid_from:type_name -> google.protobuf.Timestamp
+	85,  // 50: confirmate.orchestrator.v1.ComplianceAttestation.valid_until:type_name -> google.protobuf.Timestamp
+	3,   // 51: confirmate.orchestrator.v1.ComplianceAttestation.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
+	3,   // 52: confirmate.orchestrator.v1.ComplianceAttestationState.state:type_name -> confirmate.orchestrator.v1.AttestationState
+	85,  // 53: confirmate.orchestrator.v1.ComplianceAttestationState.timestamp:type_name -> google.protobuf.Timestamp
+	38,  // 54: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 55: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 56: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	80,  // 57: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
+	40,  // 58: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
 	83,  // 59: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry.value:type_name -> confirmate.assessment.v1.MetricConfiguration
 	0,   // 60: confirmate.orchestrator.v1.SubscribeRequest.Filter.categories:type_name -> confirmate.orchestrator.v1.EventCategory
 	76,  // 61: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.labels:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
@@ -5506,20 +5505,20 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	32,  // 85: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
 	33,  // 86: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
 	34,  // 87: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
-	67,  // 88: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:input_type -> confirmate.orchestrator.v1.CreateCertificateRequest
-	51,  // 89: confirmate.orchestrator.v1.Orchestrator.GetCertificate:input_type -> confirmate.orchestrator.v1.GetCertificateRequest
-	52,  // 90: confirmate.orchestrator.v1.Orchestrator.ListCertificates:input_type -> confirmate.orchestrator.v1.ListCertificatesRequest
-	54,  // 91: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:input_type -> confirmate.orchestrator.v1.ListPublicCertificatesRequest
-	56,  // 92: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:input_type -> confirmate.orchestrator.v1.UpdateCertificateRequest
-	68,  // 93: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:input_type -> confirmate.orchestrator.v1.RemoveCertificateRequest
-	57,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
-	60,  // 95: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
-	59,  // 96: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
-	58,  // 97: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
-	62,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
-	63,  // 99: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
-	65,  // 100: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
-	64,  // 101: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
+	57,  // 88: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:input_type -> confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	51,  // 89: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:input_type -> confirmate.orchestrator.v1.GetComplianceAttestationRequest
+	52,  // 90: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest
+	54,  // 91: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
+	56,  // 92: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:input_type -> confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
+	58,  // 93: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:input_type -> confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
+	61,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
+	64,  // 95: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
+	63,  // 96: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
+	62,  // 97: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
+	66,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
+	67,  // 99: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
+	69,  // 100: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
+	68,  // 101: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
 	45,  // 102: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:input_type -> confirmate.orchestrator.v1.CreateAuditScopeRequest
 	47,  // 103: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:input_type -> confirmate.orchestrator.v1.GetAuditScopeRequest
 	48,  // 104: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:input_type -> confirmate.orchestrator.v1.ListAuditScopesRequest
@@ -5552,19 +5551,19 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	84,  // 131: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
 	84,  // 132: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
 	35,  // 133: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
-	69,  // 134: confirmate.orchestrator.v1.Orchestrator.CreateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	69,  // 135: confirmate.orchestrator.v1.Orchestrator.GetCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	53,  // 136: confirmate.orchestrator.v1.Orchestrator.ListCertificates:output_type -> confirmate.orchestrator.v1.ListCertificatesResponse
-	55,  // 137: confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates:output_type -> confirmate.orchestrator.v1.ListPublicCertificatesResponse
-	69,  // 138: confirmate.orchestrator.v1.Orchestrator.UpdateCertificate:output_type -> confirmate.orchestrator.v1.Certificate
-	87,  // 139: confirmate.orchestrator.v1.Orchestrator.RemoveCertificate:output_type -> google.protobuf.Empty
+	59,  // 134: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 135: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	53,  // 136: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListComplianceAttestationsResponse
+	55,  // 137: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
+	59,  // 138: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	87,  // 139: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:output_type -> google.protobuf.Empty
 	38,  // 140: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	61,  // 141: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
+	65,  // 141: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
 	38,  // 142: confirmate.orchestrator.v1.Orchestrator.GetCatalog:output_type -> confirmate.orchestrator.v1.Catalog
 	87,  // 143: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:output_type -> google.protobuf.Empty
 	38,  // 144: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
 	39,  // 145: confirmate.orchestrator.v1.Orchestrator.GetCategory:output_type -> confirmate.orchestrator.v1.Category
-	66,  // 146: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
+	70,  // 146: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
 	40,  // 147: confirmate.orchestrator.v1.Orchestrator.GetControl:output_type -> confirmate.orchestrator.v1.Control
 	41,  // 148: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
 	41,  // 149: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
@@ -5601,7 +5600,7 @@ func file_api_orchestrator_orchestrator_proto_init() {
 	file_api_orchestrator_orchestrator_proto_msgTypes[36].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[38].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[43].OneofWrappers = []any{}
-	file_api_orchestrator_orchestrator_proto_msgTypes[60].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[54].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[64].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[67].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[70].OneofWrappers = []any{}

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -3200,11 +3200,12 @@ func (x *GetComplianceAttestationRequest) GetComplianceAttestationId() string {
 }
 
 type ListComplianceAttestationsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PageSize      int32                  `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string                 `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
-	OrderBy       string                 `protobuf:"bytes,12,opt,name=order_by,json=orderBy,proto3" json:"order_by,omitempty"`
-	Asc           bool                   `protobuf:"varint,13,opt,name=asc,proto3" json:"asc,omitempty"`
+	state         protoimpl.MessageState                    `protogen:"open.v1"`
+	Filter        *ListComplianceAttestationsRequest_Filter `protobuf:"bytes,1,opt,name=filter,proto3,oneof" json:"filter,omitempty"`
+	PageSize      int32                                     `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	PageToken     string                                    `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	OrderBy       string                                    `protobuf:"bytes,12,opt,name=order_by,json=orderBy,proto3" json:"order_by,omitempty"`
+	Asc           bool                                      `protobuf:"varint,13,opt,name=asc,proto3" json:"asc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3237,6 +3238,13 @@ func (x *ListComplianceAttestationsRequest) ProtoReflect() protoreflect.Message 
 // Deprecated: Use ListComplianceAttestationsRequest.ProtoReflect.Descriptor instead.
 func (*ListComplianceAttestationsRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ListComplianceAttestationsRequest) GetFilter() *ListComplianceAttestationsRequest_Filter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
 }
 
 func (x *ListComplianceAttestationsRequest) GetPageSize() int32 {
@@ -3320,11 +3328,12 @@ func (x *ListComplianceAttestationsResponse) GetNextPageToken() string {
 }
 
 type ListPublicComplianceAttestationsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PageSize      int32                  `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string                 `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
-	OrderBy       string                 `protobuf:"bytes,12,opt,name=order_by,json=orderBy,proto3" json:"order_by,omitempty"`
-	Asc           bool                   `protobuf:"varint,13,opt,name=asc,proto3" json:"asc,omitempty"`
+	state         protoimpl.MessageState                          `protogen:"open.v1"`
+	Filter        *ListPublicComplianceAttestationsRequest_Filter `protobuf:"bytes,1,opt,name=filter,proto3,oneof" json:"filter,omitempty"`
+	PageSize      int32                                           `protobuf:"varint,10,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	PageToken     string                                          `protobuf:"bytes,11,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	OrderBy       string                                          `protobuf:"bytes,12,opt,name=order_by,json=orderBy,proto3" json:"order_by,omitempty"`
+	Asc           bool                                            `protobuf:"varint,13,opt,name=asc,proto3" json:"asc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3357,6 +3366,13 @@ func (x *ListPublicComplianceAttestationsRequest) ProtoReflect() protoreflect.Me
 // Deprecated: Use ListPublicComplianceAttestationsRequest.ProtoReflect.Descriptor instead.
 func (*ListPublicComplianceAttestationsRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *ListPublicComplianceAttestationsRequest) GetFilter() *ListPublicComplianceAttestationsRequest_Filter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
 }
 
 func (x *ListPublicComplianceAttestationsRequest) GetPageSize() int32 {
@@ -4794,6 +4810,132 @@ func (x *ListAuditScopesRequest_Filter) GetCatalogId() string {
 	return ""
 }
 
+type ListComplianceAttestationsRequest_Filter struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional. List only compliance attestations for a specific audit scope.
+	AuditScopeId *string `protobuf:"bytes,1,opt,name=audit_scope_id,json=auditScopeId,proto3,oneof" json:"audit_scope_id,omitempty"`
+	// Optional. List only compliance attestations of the specified type.
+	AttestationType *ComplianceAttestationType `protobuf:"varint,2,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType,oneof" json:"attestation_type,omitempty"`
+	// Optional. List only compliance attestations in the specified lifecycle state.
+	ComplianceStatus *AttestationState `protobuf:"varint,3,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState,oneof" json:"compliance_status,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ListComplianceAttestationsRequest_Filter) Reset() {
+	*x = ListComplianceAttestationsRequest_Filter{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListComplianceAttestationsRequest_Filter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListComplianceAttestationsRequest_Filter) ProtoMessage() {}
+
+func (x *ListComplianceAttestationsRequest_Filter) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListComplianceAttestationsRequest_Filter.ProtoReflect.Descriptor instead.
+func (*ListComplianceAttestationsRequest_Filter) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{47, 0}
+}
+
+func (x *ListComplianceAttestationsRequest_Filter) GetAuditScopeId() string {
+	if x != nil && x.AuditScopeId != nil {
+		return *x.AuditScopeId
+	}
+	return ""
+}
+
+func (x *ListComplianceAttestationsRequest_Filter) GetAttestationType() ComplianceAttestationType {
+	if x != nil && x.AttestationType != nil {
+		return *x.AttestationType
+	}
+	return ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+}
+
+func (x *ListComplianceAttestationsRequest_Filter) GetComplianceStatus() AttestationState {
+	if x != nil && x.ComplianceStatus != nil {
+		return *x.ComplianceStatus
+	}
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
+}
+
+type ListPublicComplianceAttestationsRequest_Filter struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional. List only compliance attestations for a specific audit scope.
+	AuditScopeId *string `protobuf:"bytes,1,opt,name=audit_scope_id,json=auditScopeId,proto3,oneof" json:"audit_scope_id,omitempty"`
+	// Optional. List only compliance attestations of the specified type.
+	AttestationType *ComplianceAttestationType `protobuf:"varint,2,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType,oneof" json:"attestation_type,omitempty"`
+	// Optional. List only compliance attestations in the specified lifecycle state.
+	ComplianceStatus *AttestationState `protobuf:"varint,3,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState,oneof" json:"compliance_status,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) Reset() {
+	*x = ListPublicComplianceAttestationsRequest_Filter{}
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPublicComplianceAttestationsRequest_Filter) ProtoMessage() {}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPublicComplianceAttestationsRequest_Filter.ProtoReflect.Descriptor instead.
+func (*ListPublicComplianceAttestationsRequest_Filter) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{49, 0}
+}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) GetAuditScopeId() string {
+	if x != nil && x.AuditScopeId != nil {
+		return *x.AuditScopeId
+	}
+	return ""
+}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) GetAttestationType() ComplianceAttestationType {
+	if x != nil && x.AttestationType != nil {
+		return *x.AttestationType
+	}
+	return ComplianceAttestationType_COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED
+}
+
+func (x *ListPublicComplianceAttestationsRequest_Filter) GetComplianceStatus() AttestationState {
+	if x != nil && x.ComplianceStatus != nil {
+		return *x.ComplianceStatus
+	}
+	return AttestationState_ATTESTATION_STATE_UNSPECIFIED
+}
+
 type ListControlsRequest_Filter struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional. Lists only controls with the specified assurance levels.
@@ -4804,7 +4946,7 @@ type ListControlsRequest_Filter struct {
 
 func (x *ListControlsRequest_Filter) Reset() {
 	*x = ListControlsRequest_Filter{}
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[75]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4816,7 +4958,7 @@ func (x *ListControlsRequest_Filter) String() string {
 func (*ListControlsRequest_Filter) ProtoMessage() {}
 
 func (x *ListControlsRequest_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[75]
+	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5130,24 +5272,42 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"auditScope\"i\n" +
 	"\x1fGetComplianceAttestationRequest\x12F\n" +
 	"\x19compliance_attestation_id\x18\x01 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\x8c\x01\n" +
-	"!ListComplianceAttestationsRequest\x12\x1b\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\xd3\x04\n" +
+	"!ListComplianceAttestationsRequest\x12a\n" +
+	"\x06filter\x18\x01 \x01(\v2D.confirmate.orchestrator.v1.ListComplianceAttestationsRequest.FilterH\x00R\x06filter\x88\x01\x01\x12\x1b\n" +
 	"\tpage_size\x18\n" +
 	" \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\"\xb8\x01\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\x1a\xd6\x02\n" +
+	"\x06Filter\x123\n" +
+	"\x0eaudit_scope_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\fauditScopeId\x88\x01\x01\x12o\n" +
+	"\x10attestation_type\x18\x02 \x01(\x0e25.confirmate.orchestrator.v1.ComplianceAttestationTypeB\b\xbaH\x05\x82\x01\x02\x10\x01H\x01R\x0fattestationType\x88\x01\x01\x12h\n" +
+	"\x11compliance_status\x18\x03 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01H\x02R\x10complianceStatus\x88\x01\x01B\x11\n" +
+	"\x0f_audit_scope_idB\x13\n" +
+	"\x11_attestation_typeB\x14\n" +
+	"\x12_compliance_statusB\t\n" +
+	"\a_filter\"\xb8\x01\n" +
 	"\"ListComplianceAttestationsResponse\x12j\n" +
 	"\x17compliance_attestations\x18\x01 \x03(\v21.confirmate.orchestrator.v1.ComplianceAttestationR\x16complianceAttestations\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x92\x01\n" +
-	"'ListPublicComplianceAttestationsRequest\x12\x1b\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xdf\x04\n" +
+	"'ListPublicComplianceAttestationsRequest\x12g\n" +
+	"\x06filter\x18\x01 \x01(\v2J.confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.FilterH\x00R\x06filter\x88\x01\x01\x12\x1b\n" +
 	"\tpage_size\x18\n" +
 	" \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\"\xbe\x01\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\x1a\xd6\x02\n" +
+	"\x06Filter\x123\n" +
+	"\x0eaudit_scope_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\fauditScopeId\x88\x01\x01\x12o\n" +
+	"\x10attestation_type\x18\x02 \x01(\x0e25.confirmate.orchestrator.v1.ComplianceAttestationTypeB\b\xbaH\x05\x82\x01\x02\x10\x01H\x01R\x0fattestationType\x88\x01\x01\x12h\n" +
+	"\x11compliance_status\x18\x03 \x01(\x0e2,.confirmate.orchestrator.v1.AttestationStateB\b\xbaH\x05\x82\x01\x02\x10\x01H\x02R\x10complianceStatus\x88\x01\x01B\x11\n" +
+	"\x0f_audit_scope_idB\x13\n" +
+	"\x11_attestation_typeB\x14\n" +
+	"\x12_compliance_statusB\t\n" +
+	"\a_filter\"\xbe\x01\n" +
 	"(ListPublicComplianceAttestationsResponse\x12j\n" +
 	"\x17compliance_attestations\x18\x01 \x03(\v21.confirmate.orchestrator.v1.ComplianceAttestationR\x16complianceAttestations\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x99\x01\n" +
@@ -5342,258 +5502,266 @@ func file_api_orchestrator_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_api_orchestrator_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_api_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
+var file_api_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 78)
 var file_api_orchestrator_orchestrator_proto_goTypes = []any{
-	(EventCategory)(0),                               // 0: confirmate.orchestrator.v1.EventCategory
-	(RequestType)(0),                                 // 1: confirmate.orchestrator.v1.RequestType
-	(ComplianceAttestationType)(0),                   // 2: confirmate.orchestrator.v1.ComplianceAttestationType
-	(AttestationState)(0),                            // 3: confirmate.orchestrator.v1.AttestationState
-	(TargetOfEvaluation_TargetType)(0),               // 4: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
-	(*RegisterAssessmentToolRequest)(nil),            // 5: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
-	(*ListAssessmentToolsRequest)(nil),               // 6: confirmate.orchestrator.v1.ListAssessmentToolsRequest
-	(*ListAssessmentToolsResponse)(nil),              // 7: confirmate.orchestrator.v1.ListAssessmentToolsResponse
-	(*GetAssessmentToolRequest)(nil),                 // 8: confirmate.orchestrator.v1.GetAssessmentToolRequest
-	(*UpdateAssessmentToolRequest)(nil),              // 9: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
-	(*DeregisterAssessmentToolRequest)(nil),          // 10: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
-	(*StoreAssessmentResultRequest)(nil),             // 11: confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	(*StoreAssessmentResultResponse)(nil),            // 12: confirmate.orchestrator.v1.StoreAssessmentResultResponse
-	(*StoreAssessmentResultsResponse)(nil),           // 13: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
-	(*CreateMetricRequest)(nil),                      // 14: confirmate.orchestrator.v1.CreateMetricRequest
-	(*UpdateMetricRequest)(nil),                      // 15: confirmate.orchestrator.v1.UpdateMetricRequest
-	(*GetMetricRequest)(nil),                         // 16: confirmate.orchestrator.v1.GetMetricRequest
-	(*ListMetricsRequest)(nil),                       // 17: confirmate.orchestrator.v1.ListMetricsRequest
-	(*RemoveMetricRequest)(nil),                      // 18: confirmate.orchestrator.v1.RemoveMetricRequest
-	(*ListMetricsResponse)(nil),                      // 19: confirmate.orchestrator.v1.ListMetricsResponse
-	(*GetTargetOfEvaluationRequest)(nil),             // 20: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
-	(*CreateTargetOfEvaluationRequest)(nil),          // 21: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
-	(*UpdateTargetOfEvaluationRequest)(nil),          // 22: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
-	(*RemoveTargetOfEvaluationRequest)(nil),          // 23: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
-	(*ListTargetsOfEvaluationRequest)(nil),           // 24: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
-	(*ListTargetsOfEvaluationResponse)(nil),          // 25: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
-	(*GetTargetOfEvaluationStatisticsRequest)(nil),   // 26: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
-	(*GetTargetOfEvaluationStatisticsResponse)(nil),  // 27: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
-	(*UpdateMetricConfigurationRequest)(nil),         // 28: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
-	(*GetMetricConfigurationRequest)(nil),            // 29: confirmate.orchestrator.v1.GetMetricConfigurationRequest
-	(*ListMetricConfigurationRequest)(nil),           // 30: confirmate.orchestrator.v1.ListMetricConfigurationRequest
-	(*ListMetricConfigurationResponse)(nil),          // 31: confirmate.orchestrator.v1.ListMetricConfigurationResponse
-	(*UpdateMetricImplementationRequest)(nil),        // 32: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
-	(*GetMetricImplementationRequest)(nil),           // 33: confirmate.orchestrator.v1.GetMetricImplementationRequest
-	(*SubscribeRequest)(nil),                         // 34: confirmate.orchestrator.v1.SubscribeRequest
-	(*ChangeEvent)(nil),                              // 35: confirmate.orchestrator.v1.ChangeEvent
-	(*AssessmentTool)(nil),                           // 36: confirmate.orchestrator.v1.AssessmentTool
-	(*TargetOfEvaluation)(nil),                       // 37: confirmate.orchestrator.v1.TargetOfEvaluation
-	(*Catalog)(nil),                                  // 38: confirmate.orchestrator.v1.Catalog
-	(*Category)(nil),                                 // 39: confirmate.orchestrator.v1.Category
-	(*Control)(nil),                                  // 40: confirmate.orchestrator.v1.Control
-	(*AuditScope)(nil),                               // 41: confirmate.orchestrator.v1.AuditScope
-	(*GetAssessmentResultRequest)(nil),               // 42: confirmate.orchestrator.v1.GetAssessmentResultRequest
-	(*ListAssessmentResultsRequest)(nil),             // 43: confirmate.orchestrator.v1.ListAssessmentResultsRequest
-	(*ListAssessmentResultsResponse)(nil),            // 44: confirmate.orchestrator.v1.ListAssessmentResultsResponse
-	(*CreateAuditScopeRequest)(nil),                  // 45: confirmate.orchestrator.v1.CreateAuditScopeRequest
-	(*RemoveAuditScopeRequest)(nil),                  // 46: confirmate.orchestrator.v1.RemoveAuditScopeRequest
-	(*GetAuditScopeRequest)(nil),                     // 47: confirmate.orchestrator.v1.GetAuditScopeRequest
-	(*ListAuditScopesRequest)(nil),                   // 48: confirmate.orchestrator.v1.ListAuditScopesRequest
-	(*ListAuditScopesResponse)(nil),                  // 49: confirmate.orchestrator.v1.ListAuditScopesResponse
-	(*UpdateAuditScopeRequest)(nil),                  // 50: confirmate.orchestrator.v1.UpdateAuditScopeRequest
-	(*GetComplianceAttestationRequest)(nil),          // 51: confirmate.orchestrator.v1.GetComplianceAttestationRequest
-	(*ListComplianceAttestationsRequest)(nil),        // 52: confirmate.orchestrator.v1.ListComplianceAttestationsRequest
-	(*ListComplianceAttestationsResponse)(nil),       // 53: confirmate.orchestrator.v1.ListComplianceAttestationsResponse
-	(*ListPublicComplianceAttestationsRequest)(nil),  // 54: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
-	(*ListPublicComplianceAttestationsResponse)(nil), // 55: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
-	(*UpdateComplianceAttestationRequest)(nil),       // 56: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
-	(*CreateComplianceAttestationRequest)(nil),       // 57: confirmate.orchestrator.v1.CreateComplianceAttestationRequest
-	(*RemoveComplianceAttestationRequest)(nil),       // 58: confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
-	(*ComplianceAttestation)(nil),                    // 59: confirmate.orchestrator.v1.ComplianceAttestation
-	(*ComplianceAttestationState)(nil),               // 60: confirmate.orchestrator.v1.ComplianceAttestationState
-	(*CreateCatalogRequest)(nil),                     // 61: confirmate.orchestrator.v1.CreateCatalogRequest
-	(*RemoveCatalogRequest)(nil),                     // 62: confirmate.orchestrator.v1.RemoveCatalogRequest
-	(*GetCatalogRequest)(nil),                        // 63: confirmate.orchestrator.v1.GetCatalogRequest
-	(*ListCatalogsRequest)(nil),                      // 64: confirmate.orchestrator.v1.ListCatalogsRequest
-	(*ListCatalogsResponse)(nil),                     // 65: confirmate.orchestrator.v1.ListCatalogsResponse
-	(*UpdateCatalogRequest)(nil),                     // 66: confirmate.orchestrator.v1.UpdateCatalogRequest
-	(*GetCategoryRequest)(nil),                       // 67: confirmate.orchestrator.v1.GetCategoryRequest
-	(*GetControlRequest)(nil),                        // 68: confirmate.orchestrator.v1.GetControlRequest
-	(*ListControlsRequest)(nil),                      // 69: confirmate.orchestrator.v1.ListControlsRequest
-	(*ListControlsResponse)(nil),                     // 70: confirmate.orchestrator.v1.ListControlsResponse
-	(*ListAssessmentToolsRequest_Filter)(nil),        // 71: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
-	(*ListMetricsRequest_Filter)(nil),                // 72: confirmate.orchestrator.v1.ListMetricsRequest.Filter
-	nil,                                              // 73: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
-	(*SubscribeRequest_Filter)(nil),                  // 74: confirmate.orchestrator.v1.SubscribeRequest.Filter
-	(*TargetOfEvaluation_Metadata)(nil),              // 75: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
-	nil,                                              // 76: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
-	(*Catalog_Metadata)(nil),                         // 77: confirmate.orchestrator.v1.Catalog.Metadata
-	(*ListAssessmentResultsRequest_Filter)(nil),      // 78: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	(*ListAuditScopesRequest_Filter)(nil),            // 79: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
-	(*ListControlsRequest_Filter)(nil),               // 80: confirmate.orchestrator.v1.ListControlsRequest.Filter
-	(*assessment.AssessmentResult)(nil),              // 81: confirmate.assessment.v1.AssessmentResult
-	(*assessment.Metric)(nil),                        // 82: confirmate.assessment.v1.Metric
-	(*assessment.MetricConfiguration)(nil),           // 83: confirmate.assessment.v1.MetricConfiguration
-	(*assessment.MetricImplementation)(nil),          // 84: confirmate.assessment.v1.MetricImplementation
-	(*timestamppb.Timestamp)(nil),                    // 85: google.protobuf.Timestamp
-	(*common.GetRuntimeInfoRequest)(nil),             // 86: confirmate.common.v1.GetRuntimeInfoRequest
-	(*emptypb.Empty)(nil),                            // 87: google.protobuf.Empty
-	(*common.Runtime)(nil),                           // 88: confirmate.common.v1.Runtime
+	(EventCategory)(0),                                     // 0: confirmate.orchestrator.v1.EventCategory
+	(RequestType)(0),                                       // 1: confirmate.orchestrator.v1.RequestType
+	(ComplianceAttestationType)(0),                         // 2: confirmate.orchestrator.v1.ComplianceAttestationType
+	(AttestationState)(0),                                  // 3: confirmate.orchestrator.v1.AttestationState
+	(TargetOfEvaluation_TargetType)(0),                     // 4: confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
+	(*RegisterAssessmentToolRequest)(nil),                  // 5: confirmate.orchestrator.v1.RegisterAssessmentToolRequest
+	(*ListAssessmentToolsRequest)(nil),                     // 6: confirmate.orchestrator.v1.ListAssessmentToolsRequest
+	(*ListAssessmentToolsResponse)(nil),                    // 7: confirmate.orchestrator.v1.ListAssessmentToolsResponse
+	(*GetAssessmentToolRequest)(nil),                       // 8: confirmate.orchestrator.v1.GetAssessmentToolRequest
+	(*UpdateAssessmentToolRequest)(nil),                    // 9: confirmate.orchestrator.v1.UpdateAssessmentToolRequest
+	(*DeregisterAssessmentToolRequest)(nil),                // 10: confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
+	(*StoreAssessmentResultRequest)(nil),                   // 11: confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	(*StoreAssessmentResultResponse)(nil),                  // 12: confirmate.orchestrator.v1.StoreAssessmentResultResponse
+	(*StoreAssessmentResultsResponse)(nil),                 // 13: confirmate.orchestrator.v1.StoreAssessmentResultsResponse
+	(*CreateMetricRequest)(nil),                            // 14: confirmate.orchestrator.v1.CreateMetricRequest
+	(*UpdateMetricRequest)(nil),                            // 15: confirmate.orchestrator.v1.UpdateMetricRequest
+	(*GetMetricRequest)(nil),                               // 16: confirmate.orchestrator.v1.GetMetricRequest
+	(*ListMetricsRequest)(nil),                             // 17: confirmate.orchestrator.v1.ListMetricsRequest
+	(*RemoveMetricRequest)(nil),                            // 18: confirmate.orchestrator.v1.RemoveMetricRequest
+	(*ListMetricsResponse)(nil),                            // 19: confirmate.orchestrator.v1.ListMetricsResponse
+	(*GetTargetOfEvaluationRequest)(nil),                   // 20: confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
+	(*CreateTargetOfEvaluationRequest)(nil),                // 21: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
+	(*UpdateTargetOfEvaluationRequest)(nil),                // 22: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
+	(*RemoveTargetOfEvaluationRequest)(nil),                // 23: confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
+	(*ListTargetsOfEvaluationRequest)(nil),                 // 24: confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
+	(*ListTargetsOfEvaluationResponse)(nil),                // 25: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
+	(*GetTargetOfEvaluationStatisticsRequest)(nil),         // 26: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
+	(*GetTargetOfEvaluationStatisticsResponse)(nil),        // 27: confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
+	(*UpdateMetricConfigurationRequest)(nil),               // 28: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
+	(*GetMetricConfigurationRequest)(nil),                  // 29: confirmate.orchestrator.v1.GetMetricConfigurationRequest
+	(*ListMetricConfigurationRequest)(nil),                 // 30: confirmate.orchestrator.v1.ListMetricConfigurationRequest
+	(*ListMetricConfigurationResponse)(nil),                // 31: confirmate.orchestrator.v1.ListMetricConfigurationResponse
+	(*UpdateMetricImplementationRequest)(nil),              // 32: confirmate.orchestrator.v1.UpdateMetricImplementationRequest
+	(*GetMetricImplementationRequest)(nil),                 // 33: confirmate.orchestrator.v1.GetMetricImplementationRequest
+	(*SubscribeRequest)(nil),                               // 34: confirmate.orchestrator.v1.SubscribeRequest
+	(*ChangeEvent)(nil),                                    // 35: confirmate.orchestrator.v1.ChangeEvent
+	(*AssessmentTool)(nil),                                 // 36: confirmate.orchestrator.v1.AssessmentTool
+	(*TargetOfEvaluation)(nil),                             // 37: confirmate.orchestrator.v1.TargetOfEvaluation
+	(*Catalog)(nil),                                        // 38: confirmate.orchestrator.v1.Catalog
+	(*Category)(nil),                                       // 39: confirmate.orchestrator.v1.Category
+	(*Control)(nil),                                        // 40: confirmate.orchestrator.v1.Control
+	(*AuditScope)(nil),                                     // 41: confirmate.orchestrator.v1.AuditScope
+	(*GetAssessmentResultRequest)(nil),                     // 42: confirmate.orchestrator.v1.GetAssessmentResultRequest
+	(*ListAssessmentResultsRequest)(nil),                   // 43: confirmate.orchestrator.v1.ListAssessmentResultsRequest
+	(*ListAssessmentResultsResponse)(nil),                  // 44: confirmate.orchestrator.v1.ListAssessmentResultsResponse
+	(*CreateAuditScopeRequest)(nil),                        // 45: confirmate.orchestrator.v1.CreateAuditScopeRequest
+	(*RemoveAuditScopeRequest)(nil),                        // 46: confirmate.orchestrator.v1.RemoveAuditScopeRequest
+	(*GetAuditScopeRequest)(nil),                           // 47: confirmate.orchestrator.v1.GetAuditScopeRequest
+	(*ListAuditScopesRequest)(nil),                         // 48: confirmate.orchestrator.v1.ListAuditScopesRequest
+	(*ListAuditScopesResponse)(nil),                        // 49: confirmate.orchestrator.v1.ListAuditScopesResponse
+	(*UpdateAuditScopeRequest)(nil),                        // 50: confirmate.orchestrator.v1.UpdateAuditScopeRequest
+	(*GetComplianceAttestationRequest)(nil),                // 51: confirmate.orchestrator.v1.GetComplianceAttestationRequest
+	(*ListComplianceAttestationsRequest)(nil),              // 52: confirmate.orchestrator.v1.ListComplianceAttestationsRequest
+	(*ListComplianceAttestationsResponse)(nil),             // 53: confirmate.orchestrator.v1.ListComplianceAttestationsResponse
+	(*ListPublicComplianceAttestationsRequest)(nil),        // 54: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
+	(*ListPublicComplianceAttestationsResponse)(nil),       // 55: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
+	(*UpdateComplianceAttestationRequest)(nil),             // 56: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
+	(*CreateComplianceAttestationRequest)(nil),             // 57: confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	(*RemoveComplianceAttestationRequest)(nil),             // 58: confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
+	(*ComplianceAttestation)(nil),                          // 59: confirmate.orchestrator.v1.ComplianceAttestation
+	(*ComplianceAttestationState)(nil),                     // 60: confirmate.orchestrator.v1.ComplianceAttestationState
+	(*CreateCatalogRequest)(nil),                           // 61: confirmate.orchestrator.v1.CreateCatalogRequest
+	(*RemoveCatalogRequest)(nil),                           // 62: confirmate.orchestrator.v1.RemoveCatalogRequest
+	(*GetCatalogRequest)(nil),                              // 63: confirmate.orchestrator.v1.GetCatalogRequest
+	(*ListCatalogsRequest)(nil),                            // 64: confirmate.orchestrator.v1.ListCatalogsRequest
+	(*ListCatalogsResponse)(nil),                           // 65: confirmate.orchestrator.v1.ListCatalogsResponse
+	(*UpdateCatalogRequest)(nil),                           // 66: confirmate.orchestrator.v1.UpdateCatalogRequest
+	(*GetCategoryRequest)(nil),                             // 67: confirmate.orchestrator.v1.GetCategoryRequest
+	(*GetControlRequest)(nil),                              // 68: confirmate.orchestrator.v1.GetControlRequest
+	(*ListControlsRequest)(nil),                            // 69: confirmate.orchestrator.v1.ListControlsRequest
+	(*ListControlsResponse)(nil),                           // 70: confirmate.orchestrator.v1.ListControlsResponse
+	(*ListAssessmentToolsRequest_Filter)(nil),              // 71: confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
+	(*ListMetricsRequest_Filter)(nil),                      // 72: confirmate.orchestrator.v1.ListMetricsRequest.Filter
+	nil,                                                    // 73: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
+	(*SubscribeRequest_Filter)(nil),                        // 74: confirmate.orchestrator.v1.SubscribeRequest.Filter
+	(*TargetOfEvaluation_Metadata)(nil),                    // 75: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
+	nil,                                                    // 76: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
+	(*Catalog_Metadata)(nil),                               // 77: confirmate.orchestrator.v1.Catalog.Metadata
+	(*ListAssessmentResultsRequest_Filter)(nil),            // 78: confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
+	(*ListAuditScopesRequest_Filter)(nil),                  // 79: confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
+	(*ListComplianceAttestationsRequest_Filter)(nil),       // 80: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter
+	(*ListPublicComplianceAttestationsRequest_Filter)(nil), // 81: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter
+	(*ListControlsRequest_Filter)(nil),                     // 82: confirmate.orchestrator.v1.ListControlsRequest.Filter
+	(*assessment.AssessmentResult)(nil),                    // 83: confirmate.assessment.v1.AssessmentResult
+	(*assessment.Metric)(nil),                              // 84: confirmate.assessment.v1.Metric
+	(*assessment.MetricConfiguration)(nil),                 // 85: confirmate.assessment.v1.MetricConfiguration
+	(*assessment.MetricImplementation)(nil),                // 86: confirmate.assessment.v1.MetricImplementation
+	(*timestamppb.Timestamp)(nil),                          // 87: google.protobuf.Timestamp
+	(*common.GetRuntimeInfoRequest)(nil),                   // 88: confirmate.common.v1.GetRuntimeInfoRequest
+	(*emptypb.Empty)(nil),                                  // 89: google.protobuf.Empty
+	(*common.Runtime)(nil),                                 // 90: confirmate.common.v1.Runtime
 }
 var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	36,  // 0: confirmate.orchestrator.v1.RegisterAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
 	71,  // 1: confirmate.orchestrator.v1.ListAssessmentToolsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentToolsRequest.Filter
 	36,  // 2: confirmate.orchestrator.v1.ListAssessmentToolsResponse.tools:type_name -> confirmate.orchestrator.v1.AssessmentTool
 	36,  // 3: confirmate.orchestrator.v1.UpdateAssessmentToolRequest.tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	81,  // 4: confirmate.orchestrator.v1.StoreAssessmentResultRequest.result:type_name -> confirmate.assessment.v1.AssessmentResult
-	82,  // 5: confirmate.orchestrator.v1.CreateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
-	82,  // 6: confirmate.orchestrator.v1.UpdateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
+	83,  // 4: confirmate.orchestrator.v1.StoreAssessmentResultRequest.result:type_name -> confirmate.assessment.v1.AssessmentResult
+	84,  // 5: confirmate.orchestrator.v1.CreateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
+	84,  // 6: confirmate.orchestrator.v1.UpdateMetricRequest.metric:type_name -> confirmate.assessment.v1.Metric
 	72,  // 7: confirmate.orchestrator.v1.ListMetricsRequest.filter:type_name -> confirmate.orchestrator.v1.ListMetricsRequest.Filter
-	82,  // 8: confirmate.orchestrator.v1.ListMetricsResponse.metrics:type_name -> confirmate.assessment.v1.Metric
+	84,  // 8: confirmate.orchestrator.v1.ListMetricsResponse.metrics:type_name -> confirmate.assessment.v1.Metric
 	37,  // 9: confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
 	37,  // 10: confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
 	37,  // 11: confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse.targets_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
-	83,  // 12: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest.configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
+	85,  // 12: confirmate.orchestrator.v1.UpdateMetricConfigurationRequest.configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
 	73,  // 13: confirmate.orchestrator.v1.ListMetricConfigurationResponse.configurations:type_name -> confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry
-	84,  // 14: confirmate.orchestrator.v1.UpdateMetricImplementationRequest.implementation:type_name -> confirmate.assessment.v1.MetricImplementation
+	86,  // 14: confirmate.orchestrator.v1.UpdateMetricImplementationRequest.implementation:type_name -> confirmate.assessment.v1.MetricImplementation
 	74,  // 15: confirmate.orchestrator.v1.SubscribeRequest.filter:type_name -> confirmate.orchestrator.v1.SubscribeRequest.Filter
-	85,  // 16: confirmate.orchestrator.v1.ChangeEvent.timestamp:type_name -> google.protobuf.Timestamp
+	87,  // 16: confirmate.orchestrator.v1.ChangeEvent.timestamp:type_name -> google.protobuf.Timestamp
 	0,   // 17: confirmate.orchestrator.v1.ChangeEvent.category:type_name -> confirmate.orchestrator.v1.EventCategory
 	1,   // 18: confirmate.orchestrator.v1.ChangeEvent.request_type:type_name -> confirmate.orchestrator.v1.RequestType
-	82,  // 19: confirmate.orchestrator.v1.ChangeEvent.metric:type_name -> confirmate.assessment.v1.Metric
+	84,  // 19: confirmate.orchestrator.v1.ChangeEvent.metric:type_name -> confirmate.assessment.v1.Metric
 	37,  // 20: confirmate.orchestrator.v1.ChangeEvent.target_of_evaluation:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation
 	41,  // 21: confirmate.orchestrator.v1.ChangeEvent.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	81,  // 22: confirmate.orchestrator.v1.ChangeEvent.assessment_result:type_name -> confirmate.assessment.v1.AssessmentResult
-	83,  // 23: confirmate.orchestrator.v1.ChangeEvent.metric_configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
-	84,  // 24: confirmate.orchestrator.v1.ChangeEvent.metric_implementation:type_name -> confirmate.assessment.v1.MetricImplementation
+	83,  // 22: confirmate.orchestrator.v1.ChangeEvent.assessment_result:type_name -> confirmate.assessment.v1.AssessmentResult
+	85,  // 23: confirmate.orchestrator.v1.ChangeEvent.metric_configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
+	86,  // 24: confirmate.orchestrator.v1.ChangeEvent.metric_implementation:type_name -> confirmate.assessment.v1.MetricImplementation
 	36,  // 25: confirmate.orchestrator.v1.ChangeEvent.assessment_tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	82,  // 26: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
-	85,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
-	85,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
+	84,  // 26: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
+	87,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
+	87,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
 	75,  // 29: confirmate.orchestrator.v1.TargetOfEvaluation.metadata:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
 	4,   // 30: confirmate.orchestrator.v1.TargetOfEvaluation.target_type:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
 	39,  // 31: confirmate.orchestrator.v1.Catalog.categories:type_name -> confirmate.orchestrator.v1.Category
 	77,  // 32: confirmate.orchestrator.v1.Catalog.metadata:type_name -> confirmate.orchestrator.v1.Catalog.Metadata
 	40,  // 33: confirmate.orchestrator.v1.Category.controls:type_name -> confirmate.orchestrator.v1.Control
 	40,  // 34: confirmate.orchestrator.v1.Control.controls:type_name -> confirmate.orchestrator.v1.Control
-	82,  // 35: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
+	84,  // 35: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
 	78,  // 36: confirmate.orchestrator.v1.ListAssessmentResultsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	81,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
+	83,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
 	41,  // 38: confirmate.orchestrator.v1.CreateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
 	79,  // 39: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
 	41,  // 40: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
 	41,  // 41: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	59,  // 42: confirmate.orchestrator.v1.ListComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 43: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 44: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 45: confirmate.orchestrator.v1.CreateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	60,  // 46: confirmate.orchestrator.v1.ComplianceAttestation.states:type_name -> confirmate.orchestrator.v1.ComplianceAttestationState
-	2,   // 47: confirmate.orchestrator.v1.ComplianceAttestation.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
-	85,  // 48: confirmate.orchestrator.v1.ComplianceAttestation.issued_at:type_name -> google.protobuf.Timestamp
-	85,  // 49: confirmate.orchestrator.v1.ComplianceAttestation.valid_from:type_name -> google.protobuf.Timestamp
-	85,  // 50: confirmate.orchestrator.v1.ComplianceAttestation.valid_until:type_name -> google.protobuf.Timestamp
-	3,   // 51: confirmate.orchestrator.v1.ComplianceAttestation.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
-	3,   // 52: confirmate.orchestrator.v1.ComplianceAttestationState.state:type_name -> confirmate.orchestrator.v1.AttestationState
-	85,  // 53: confirmate.orchestrator.v1.ComplianceAttestationState.timestamp:type_name -> google.protobuf.Timestamp
-	38,  // 54: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	38,  // 55: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
-	38,  // 56: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
-	80,  // 57: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
-	40,  // 58: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
-	83,  // 59: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry.value:type_name -> confirmate.assessment.v1.MetricConfiguration
-	0,   // 60: confirmate.orchestrator.v1.SubscribeRequest.Filter.categories:type_name -> confirmate.orchestrator.v1.EventCategory
-	76,  // 61: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.labels:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
-	5,   // 62: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:input_type -> confirmate.orchestrator.v1.RegisterAssessmentToolRequest
-	6,   // 63: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:input_type -> confirmate.orchestrator.v1.ListAssessmentToolsRequest
-	8,   // 64: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:input_type -> confirmate.orchestrator.v1.GetAssessmentToolRequest
-	9,   // 65: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:input_type -> confirmate.orchestrator.v1.UpdateAssessmentToolRequest
-	10,  // 66: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:input_type -> confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
-	11,  // 67: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	11,  // 68: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
-	42,  // 69: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:input_type -> confirmate.orchestrator.v1.GetAssessmentResultRequest
-	43,  // 70: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:input_type -> confirmate.orchestrator.v1.ListAssessmentResultsRequest
-	14,  // 71: confirmate.orchestrator.v1.Orchestrator.CreateMetric:input_type -> confirmate.orchestrator.v1.CreateMetricRequest
-	15,  // 72: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:input_type -> confirmate.orchestrator.v1.UpdateMetricRequest
-	16,  // 73: confirmate.orchestrator.v1.Orchestrator.GetMetric:input_type -> confirmate.orchestrator.v1.GetMetricRequest
-	17,  // 74: confirmate.orchestrator.v1.Orchestrator.ListMetrics:input_type -> confirmate.orchestrator.v1.ListMetricsRequest
-	18,  // 75: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:input_type -> confirmate.orchestrator.v1.RemoveMetricRequest
-	21,  // 76: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
-	22,  // 77: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
-	20,  // 78: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
-	24,  // 79: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:input_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
-	23,  // 80: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
-	26,  // 81: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
-	28,  // 82: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:input_type -> confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
-	29,  // 83: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:input_type -> confirmate.orchestrator.v1.GetMetricConfigurationRequest
-	30,  // 84: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:input_type -> confirmate.orchestrator.v1.ListMetricConfigurationRequest
-	32,  // 85: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
-	33,  // 86: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
-	34,  // 87: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
-	57,  // 88: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:input_type -> confirmate.orchestrator.v1.CreateComplianceAttestationRequest
-	51,  // 89: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:input_type -> confirmate.orchestrator.v1.GetComplianceAttestationRequest
-	52,  // 90: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest
-	54,  // 91: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
-	56,  // 92: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:input_type -> confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
-	58,  // 93: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:input_type -> confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
-	61,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
-	64,  // 95: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
-	63,  // 96: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
-	62,  // 97: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
-	66,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
-	67,  // 99: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
-	69,  // 100: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
-	68,  // 101: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
-	45,  // 102: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:input_type -> confirmate.orchestrator.v1.CreateAuditScopeRequest
-	47,  // 103: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:input_type -> confirmate.orchestrator.v1.GetAuditScopeRequest
-	48,  // 104: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:input_type -> confirmate.orchestrator.v1.ListAuditScopesRequest
-	50,  // 105: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:input_type -> confirmate.orchestrator.v1.UpdateAuditScopeRequest
-	46,  // 106: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:input_type -> confirmate.orchestrator.v1.RemoveAuditScopeRequest
-	86,  // 107: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:input_type -> confirmate.common.v1.GetRuntimeInfoRequest
-	36,  // 108: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	7,   // 109: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:output_type -> confirmate.orchestrator.v1.ListAssessmentToolsResponse
-	36,  // 110: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	36,  // 111: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
-	87,  // 112: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:output_type -> google.protobuf.Empty
-	12,  // 113: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultResponse
-	13,  // 114: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultsResponse
-	81,  // 115: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:output_type -> confirmate.assessment.v1.AssessmentResult
-	44,  // 116: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:output_type -> confirmate.orchestrator.v1.ListAssessmentResultsResponse
-	82,  // 117: confirmate.orchestrator.v1.Orchestrator.CreateMetric:output_type -> confirmate.assessment.v1.Metric
-	82,  // 118: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:output_type -> confirmate.assessment.v1.Metric
-	82,  // 119: confirmate.orchestrator.v1.Orchestrator.GetMetric:output_type -> confirmate.assessment.v1.Metric
-	19,  // 120: confirmate.orchestrator.v1.Orchestrator.ListMetrics:output_type -> confirmate.orchestrator.v1.ListMetricsResponse
-	87,  // 121: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:output_type -> google.protobuf.Empty
-	37,  // 122: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	37,  // 123: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	37,  // 124: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
-	25,  // 125: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:output_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
-	87,  // 126: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:output_type -> google.protobuf.Empty
-	27,  // 127: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:output_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
-	83,  // 128: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
-	83,  // 129: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
-	31,  // 130: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:output_type -> confirmate.orchestrator.v1.ListMetricConfigurationResponse
-	84,  // 131: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
-	84,  // 132: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
-	35,  // 133: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
-	59,  // 134: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 135: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
-	53,  // 136: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListComplianceAttestationsResponse
-	55,  // 137: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
-	59,  // 138: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
-	87,  // 139: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:output_type -> google.protobuf.Empty
-	38,  // 140: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	65,  // 141: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
-	38,  // 142: confirmate.orchestrator.v1.Orchestrator.GetCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	87,  // 143: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:output_type -> google.protobuf.Empty
-	38,  // 144: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
-	39,  // 145: confirmate.orchestrator.v1.Orchestrator.GetCategory:output_type -> confirmate.orchestrator.v1.Category
-	70,  // 146: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
-	40,  // 147: confirmate.orchestrator.v1.Orchestrator.GetControl:output_type -> confirmate.orchestrator.v1.Control
-	41,  // 148: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	41,  // 149: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	49,  // 150: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:output_type -> confirmate.orchestrator.v1.ListAuditScopesResponse
-	41,  // 151: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
-	87,  // 152: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:output_type -> google.protobuf.Empty
-	88,  // 153: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:output_type -> confirmate.common.v1.Runtime
-	108, // [108:154] is the sub-list for method output_type
-	62,  // [62:108] is the sub-list for method input_type
-	62,  // [62:62] is the sub-list for extension type_name
-	62,  // [62:62] is the sub-list for extension extendee
-	0,   // [0:62] is the sub-list for field type_name
+	80,  // 42: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter
+	59,  // 43: confirmate.orchestrator.v1.ListComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	81,  // 44: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter
+	59,  // 45: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 46: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 47: confirmate.orchestrator.v1.CreateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	60,  // 48: confirmate.orchestrator.v1.ComplianceAttestation.states:type_name -> confirmate.orchestrator.v1.ComplianceAttestationState
+	2,   // 49: confirmate.orchestrator.v1.ComplianceAttestation.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
+	87,  // 50: confirmate.orchestrator.v1.ComplianceAttestation.issued_at:type_name -> google.protobuf.Timestamp
+	87,  // 51: confirmate.orchestrator.v1.ComplianceAttestation.valid_from:type_name -> google.protobuf.Timestamp
+	87,  // 52: confirmate.orchestrator.v1.ComplianceAttestation.valid_until:type_name -> google.protobuf.Timestamp
+	3,   // 53: confirmate.orchestrator.v1.ComplianceAttestation.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
+	3,   // 54: confirmate.orchestrator.v1.ComplianceAttestationState.state:type_name -> confirmate.orchestrator.v1.AttestationState
+	87,  // 55: confirmate.orchestrator.v1.ComplianceAttestationState.timestamp:type_name -> google.protobuf.Timestamp
+	38,  // 56: confirmate.orchestrator.v1.CreateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 57: confirmate.orchestrator.v1.ListCatalogsResponse.catalogs:type_name -> confirmate.orchestrator.v1.Catalog
+	38,  // 58: confirmate.orchestrator.v1.UpdateCatalogRequest.catalog:type_name -> confirmate.orchestrator.v1.Catalog
+	82,  // 59: confirmate.orchestrator.v1.ListControlsRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsRequest.Filter
+	40,  // 60: confirmate.orchestrator.v1.ListControlsResponse.controls:type_name -> confirmate.orchestrator.v1.Control
+	85,  // 61: confirmate.orchestrator.v1.ListMetricConfigurationResponse.ConfigurationsEntry.value:type_name -> confirmate.assessment.v1.MetricConfiguration
+	0,   // 62: confirmate.orchestrator.v1.SubscribeRequest.Filter.categories:type_name -> confirmate.orchestrator.v1.EventCategory
+	76,  // 63: confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.labels:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata.LabelsEntry
+	2,   // 64: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
+	3,   // 65: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
+	2,   // 66: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
+	3,   // 67: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter.compliance_status:type_name -> confirmate.orchestrator.v1.AttestationState
+	5,   // 68: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:input_type -> confirmate.orchestrator.v1.RegisterAssessmentToolRequest
+	6,   // 69: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:input_type -> confirmate.orchestrator.v1.ListAssessmentToolsRequest
+	8,   // 70: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:input_type -> confirmate.orchestrator.v1.GetAssessmentToolRequest
+	9,   // 71: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:input_type -> confirmate.orchestrator.v1.UpdateAssessmentToolRequest
+	10,  // 72: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:input_type -> confirmate.orchestrator.v1.DeregisterAssessmentToolRequest
+	11,  // 73: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	11,  // 74: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:input_type -> confirmate.orchestrator.v1.StoreAssessmentResultRequest
+	42,  // 75: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:input_type -> confirmate.orchestrator.v1.GetAssessmentResultRequest
+	43,  // 76: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:input_type -> confirmate.orchestrator.v1.ListAssessmentResultsRequest
+	14,  // 77: confirmate.orchestrator.v1.Orchestrator.CreateMetric:input_type -> confirmate.orchestrator.v1.CreateMetricRequest
+	15,  // 78: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:input_type -> confirmate.orchestrator.v1.UpdateMetricRequest
+	16,  // 79: confirmate.orchestrator.v1.Orchestrator.GetMetric:input_type -> confirmate.orchestrator.v1.GetMetricRequest
+	17,  // 80: confirmate.orchestrator.v1.Orchestrator.ListMetrics:input_type -> confirmate.orchestrator.v1.ListMetricsRequest
+	18,  // 81: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:input_type -> confirmate.orchestrator.v1.RemoveMetricRequest
+	21,  // 82: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.CreateTargetOfEvaluationRequest
+	22,  // 83: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.UpdateTargetOfEvaluationRequest
+	20,  // 84: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationRequest
+	24,  // 85: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:input_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationRequest
+	23,  // 86: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:input_type -> confirmate.orchestrator.v1.RemoveTargetOfEvaluationRequest
+	26,  // 87: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:input_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsRequest
+	28,  // 88: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:input_type -> confirmate.orchestrator.v1.UpdateMetricConfigurationRequest
+	29,  // 89: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:input_type -> confirmate.orchestrator.v1.GetMetricConfigurationRequest
+	30,  // 90: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:input_type -> confirmate.orchestrator.v1.ListMetricConfigurationRequest
+	32,  // 91: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
+	33,  // 92: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
+	34,  // 93: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
+	57,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:input_type -> confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	51,  // 95: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:input_type -> confirmate.orchestrator.v1.GetComplianceAttestationRequest
+	52,  // 96: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest
+	54,  // 97: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
+	56,  // 98: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:input_type -> confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
+	58,  // 99: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:input_type -> confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
+	61,  // 100: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:input_type -> confirmate.orchestrator.v1.CreateCatalogRequest
+	64,  // 101: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:input_type -> confirmate.orchestrator.v1.ListCatalogsRequest
+	63,  // 102: confirmate.orchestrator.v1.Orchestrator.GetCatalog:input_type -> confirmate.orchestrator.v1.GetCatalogRequest
+	62,  // 103: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:input_type -> confirmate.orchestrator.v1.RemoveCatalogRequest
+	66,  // 104: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:input_type -> confirmate.orchestrator.v1.UpdateCatalogRequest
+	67,  // 105: confirmate.orchestrator.v1.Orchestrator.GetCategory:input_type -> confirmate.orchestrator.v1.GetCategoryRequest
+	69,  // 106: confirmate.orchestrator.v1.Orchestrator.ListControls:input_type -> confirmate.orchestrator.v1.ListControlsRequest
+	68,  // 107: confirmate.orchestrator.v1.Orchestrator.GetControl:input_type -> confirmate.orchestrator.v1.GetControlRequest
+	45,  // 108: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:input_type -> confirmate.orchestrator.v1.CreateAuditScopeRequest
+	47,  // 109: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:input_type -> confirmate.orchestrator.v1.GetAuditScopeRequest
+	48,  // 110: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:input_type -> confirmate.orchestrator.v1.ListAuditScopesRequest
+	50,  // 111: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:input_type -> confirmate.orchestrator.v1.UpdateAuditScopeRequest
+	46,  // 112: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:input_type -> confirmate.orchestrator.v1.RemoveAuditScopeRequest
+	88,  // 113: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:input_type -> confirmate.common.v1.GetRuntimeInfoRequest
+	36,  // 114: confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	7,   // 115: confirmate.orchestrator.v1.Orchestrator.ListAssessmentTools:output_type -> confirmate.orchestrator.v1.ListAssessmentToolsResponse
+	36,  // 116: confirmate.orchestrator.v1.Orchestrator.GetAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	36,  // 117: confirmate.orchestrator.v1.Orchestrator.UpdateAssessmentTool:output_type -> confirmate.orchestrator.v1.AssessmentTool
+	89,  // 118: confirmate.orchestrator.v1.Orchestrator.DeregisterAssessmentTool:output_type -> google.protobuf.Empty
+	12,  // 119: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResult:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultResponse
+	13,  // 120: confirmate.orchestrator.v1.Orchestrator.StoreAssessmentResults:output_type -> confirmate.orchestrator.v1.StoreAssessmentResultsResponse
+	83,  // 121: confirmate.orchestrator.v1.Orchestrator.GetAssessmentResult:output_type -> confirmate.assessment.v1.AssessmentResult
+	44,  // 122: confirmate.orchestrator.v1.Orchestrator.ListAssessmentResults:output_type -> confirmate.orchestrator.v1.ListAssessmentResultsResponse
+	84,  // 123: confirmate.orchestrator.v1.Orchestrator.CreateMetric:output_type -> confirmate.assessment.v1.Metric
+	84,  // 124: confirmate.orchestrator.v1.Orchestrator.UpdateMetric:output_type -> confirmate.assessment.v1.Metric
+	84,  // 125: confirmate.orchestrator.v1.Orchestrator.GetMetric:output_type -> confirmate.assessment.v1.Metric
+	19,  // 126: confirmate.orchestrator.v1.Orchestrator.ListMetrics:output_type -> confirmate.orchestrator.v1.ListMetricsResponse
+	89,  // 127: confirmate.orchestrator.v1.Orchestrator.RemoveMetric:output_type -> google.protobuf.Empty
+	37,  // 128: confirmate.orchestrator.v1.Orchestrator.CreateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 129: confirmate.orchestrator.v1.Orchestrator.UpdateTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	37,  // 130: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluation:output_type -> confirmate.orchestrator.v1.TargetOfEvaluation
+	25,  // 131: confirmate.orchestrator.v1.Orchestrator.ListTargetsOfEvaluation:output_type -> confirmate.orchestrator.v1.ListTargetsOfEvaluationResponse
+	89,  // 132: confirmate.orchestrator.v1.Orchestrator.RemoveTargetOfEvaluation:output_type -> google.protobuf.Empty
+	27,  // 133: confirmate.orchestrator.v1.Orchestrator.GetTargetOfEvaluationStatistics:output_type -> confirmate.orchestrator.v1.GetTargetOfEvaluationStatisticsResponse
+	85,  // 134: confirmate.orchestrator.v1.Orchestrator.UpdateMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
+	85,  // 135: confirmate.orchestrator.v1.Orchestrator.GetMetricConfiguration:output_type -> confirmate.assessment.v1.MetricConfiguration
+	31,  // 136: confirmate.orchestrator.v1.Orchestrator.ListMetricConfigurations:output_type -> confirmate.orchestrator.v1.ListMetricConfigurationResponse
+	86,  // 137: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
+	86,  // 138: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
+	35,  // 139: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
+	59,  // 140: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 141: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	53,  // 142: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListComplianceAttestationsResponse
+	55,  // 143: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
+	59,  // 144: confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	89,  // 145: confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation:output_type -> google.protobuf.Empty
+	38,  // 146: confirmate.orchestrator.v1.Orchestrator.CreateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	65,  // 147: confirmate.orchestrator.v1.Orchestrator.ListCatalogs:output_type -> confirmate.orchestrator.v1.ListCatalogsResponse
+	38,  // 148: confirmate.orchestrator.v1.Orchestrator.GetCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	89,  // 149: confirmate.orchestrator.v1.Orchestrator.RemoveCatalog:output_type -> google.protobuf.Empty
+	38,  // 150: confirmate.orchestrator.v1.Orchestrator.UpdateCatalog:output_type -> confirmate.orchestrator.v1.Catalog
+	39,  // 151: confirmate.orchestrator.v1.Orchestrator.GetCategory:output_type -> confirmate.orchestrator.v1.Category
+	70,  // 152: confirmate.orchestrator.v1.Orchestrator.ListControls:output_type -> confirmate.orchestrator.v1.ListControlsResponse
+	40,  // 153: confirmate.orchestrator.v1.Orchestrator.GetControl:output_type -> confirmate.orchestrator.v1.Control
+	41,  // 154: confirmate.orchestrator.v1.Orchestrator.CreateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	41,  // 155: confirmate.orchestrator.v1.Orchestrator.GetAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	49,  // 156: confirmate.orchestrator.v1.Orchestrator.ListAuditScopes:output_type -> confirmate.orchestrator.v1.ListAuditScopesResponse
+	41,  // 157: confirmate.orchestrator.v1.Orchestrator.UpdateAuditScope:output_type -> confirmate.orchestrator.v1.AuditScope
+	89,  // 158: confirmate.orchestrator.v1.Orchestrator.RemoveAuditScope:output_type -> google.protobuf.Empty
+	90,  // 159: confirmate.orchestrator.v1.Orchestrator.GetRuntimeInfo:output_type -> confirmate.common.v1.Runtime
+	114, // [114:160] is the sub-list for method output_type
+	68,  // [68:114] is the sub-list for method input_type
+	68,  // [68:68] is the sub-list for extension type_name
+	68,  // [68:68] is the sub-list for extension extendee
+	0,   // [0:68] is the sub-list for field type_name
 }
 
 func init() { file_api_orchestrator_orchestrator_proto_init() }
@@ -5618,6 +5786,8 @@ func file_api_orchestrator_orchestrator_proto_init() {
 	file_api_orchestrator_orchestrator_proto_msgTypes[36].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[38].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[43].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[47].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[49].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[54].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[64].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[67].OneofWrappers = []any{}
@@ -5625,13 +5795,15 @@ func file_api_orchestrator_orchestrator_proto_init() {
 	file_api_orchestrator_orchestrator_proto_msgTypes[72].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[73].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[74].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[75].OneofWrappers = []any{}
+	file_api_orchestrator_orchestrator_proto_msgTypes[76].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_orchestrator_orchestrator_proto_rawDesc), len(file_api_orchestrator_orchestrator_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   76,
+			NumMessages:   78,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -46,14 +46,15 @@ const (
 type EventCategory int32
 
 const (
-	EventCategory_EVENT_CATEGORY_UNSPECIFIED           EventCategory = 0
-	EventCategory_EVENT_CATEGORY_METRIC                EventCategory = 1
-	EventCategory_EVENT_CATEGORY_METRIC_CONFIGURATION  EventCategory = 2
-	EventCategory_EVENT_CATEGORY_METRIC_IMPLEMENTATION EventCategory = 3
-	EventCategory_EVENT_CATEGORY_TARGET_OF_EVALUATION  EventCategory = 4
-	EventCategory_EVENT_CATEGORY_AUDIT_SCOPE           EventCategory = 5
-	EventCategory_EVENT_CATEGORY_ASSESSMENT_RESULT     EventCategory = 6
-	EventCategory_EVENT_CATEGORY_ASSESSMENT_TOOL       EventCategory = 7
+	EventCategory_EVENT_CATEGORY_UNSPECIFIED            EventCategory = 0
+	EventCategory_EVENT_CATEGORY_METRIC                 EventCategory = 1
+	EventCategory_EVENT_CATEGORY_METRIC_CONFIGURATION   EventCategory = 2
+	EventCategory_EVENT_CATEGORY_METRIC_IMPLEMENTATION  EventCategory = 3
+	EventCategory_EVENT_CATEGORY_TARGET_OF_EVALUATION   EventCategory = 4
+	EventCategory_EVENT_CATEGORY_AUDIT_SCOPE            EventCategory = 5
+	EventCategory_EVENT_CATEGORY_ASSESSMENT_RESULT      EventCategory = 6
+	EventCategory_EVENT_CATEGORY_ASSESSMENT_TOOL        EventCategory = 7
+	EventCategory_EVENT_CATEGORY_COMPLIANCE_ATTESTATION EventCategory = 8
 )
 
 // Enum value maps for EventCategory.
@@ -67,16 +68,18 @@ var (
 		5: "EVENT_CATEGORY_AUDIT_SCOPE",
 		6: "EVENT_CATEGORY_ASSESSMENT_RESULT",
 		7: "EVENT_CATEGORY_ASSESSMENT_TOOL",
+		8: "EVENT_CATEGORY_COMPLIANCE_ATTESTATION",
 	}
 	EventCategory_value = map[string]int32{
-		"EVENT_CATEGORY_UNSPECIFIED":           0,
-		"EVENT_CATEGORY_METRIC":                1,
-		"EVENT_CATEGORY_METRIC_CONFIGURATION":  2,
-		"EVENT_CATEGORY_METRIC_IMPLEMENTATION": 3,
-		"EVENT_CATEGORY_TARGET_OF_EVALUATION":  4,
-		"EVENT_CATEGORY_AUDIT_SCOPE":           5,
-		"EVENT_CATEGORY_ASSESSMENT_RESULT":     6,
-		"EVENT_CATEGORY_ASSESSMENT_TOOL":       7,
+		"EVENT_CATEGORY_UNSPECIFIED":            0,
+		"EVENT_CATEGORY_METRIC":                 1,
+		"EVENT_CATEGORY_METRIC_CONFIGURATION":   2,
+		"EVENT_CATEGORY_METRIC_IMPLEMENTATION":  3,
+		"EVENT_CATEGORY_TARGET_OF_EVALUATION":   4,
+		"EVENT_CATEGORY_AUDIT_SCOPE":            5,
+		"EVENT_CATEGORY_ASSESSMENT_RESULT":      6,
+		"EVENT_CATEGORY_ASSESSMENT_TOOL":        7,
+		"EVENT_CATEGORY_COMPLIANCE_ATTESTATION": 8,
 	}
 )
 
@@ -1903,6 +1906,7 @@ type ChangeEvent struct {
 	//	*ChangeEvent_MetricConfiguration
 	//	*ChangeEvent_MetricImplementation
 	//	*ChangeEvent_AssessmentTool
+	//	*ChangeEvent_ComplianceAttestation
 	Entity        isChangeEvent_Entity `protobuf_oneof:"entity"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2043,6 +2047,15 @@ func (x *ChangeEvent) GetAssessmentTool() *AssessmentTool {
 	return nil
 }
 
+func (x *ChangeEvent) GetComplianceAttestation() *ComplianceAttestation {
+	if x != nil {
+		if x, ok := x.Entity.(*ChangeEvent_ComplianceAttestation); ok {
+			return x.ComplianceAttestation
+		}
+	}
+	return nil
+}
+
 type isChangeEvent_Entity interface {
 	isChangeEvent_Entity()
 }
@@ -2075,6 +2088,10 @@ type ChangeEvent_AssessmentTool struct {
 	AssessmentTool *AssessmentTool `protobuf:"bytes,16,opt,name=assessment_tool,json=assessmentTool,proto3,oneof"`
 }
 
+type ChangeEvent_ComplianceAttestation struct {
+	ComplianceAttestation *ComplianceAttestation `protobuf:"bytes,17,opt,name=compliance_attestation,json=complianceAttestation,proto3,oneof"`
+}
+
 func (*ChangeEvent_Metric) isChangeEvent_Entity() {}
 
 func (*ChangeEvent_TargetOfEvaluation) isChangeEvent_Entity() {}
@@ -2088,6 +2105,8 @@ func (*ChangeEvent_MetricConfiguration) isChangeEvent_Entity() {}
 func (*ChangeEvent_MetricImplementation) isChangeEvent_Entity() {}
 
 func (*ChangeEvent_AssessmentTool) isChangeEvent_Entity() {}
+
+func (*ChangeEvent_ComplianceAttestation) isChangeEvent_Entity() {}
 
 // Represents an external tool or service that offers assessments according to
 // certain metrics.
@@ -3502,27 +3521,27 @@ func (x *UpdateComplianceAttestationRequest) GetComplianceAttestation() *Complia
 	return nil
 }
 
-type CreateComplianceAttestationRequest struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
-	ComplianceAttestation *ComplianceAttestation `protobuf:"bytes,1,opt,name=compliance_attestation,json=complianceAttestation,proto3" json:"compliance_attestation,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+type InitiateComplianceAttestationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AuditScopeId  string                 `protobuf:"bytes,1,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *CreateComplianceAttestationRequest) Reset() {
-	*x = CreateComplianceAttestationRequest{}
+func (x *InitiateComplianceAttestationRequest) Reset() {
+	*x = InitiateComplianceAttestationRequest{}
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *CreateComplianceAttestationRequest) String() string {
+func (x *InitiateComplianceAttestationRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CreateComplianceAttestationRequest) ProtoMessage() {}
+func (*InitiateComplianceAttestationRequest) ProtoMessage() {}
 
-func (x *CreateComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
+func (x *InitiateComplianceAttestationRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_orchestrator_orchestrator_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3534,16 +3553,16 @@ func (x *CreateComplianceAttestationRequest) ProtoReflect() protoreflect.Message
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CreateComplianceAttestationRequest.ProtoReflect.Descriptor instead.
-func (*CreateComplianceAttestationRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use InitiateComplianceAttestationRequest.ProtoReflect.Descriptor instead.
+func (*InitiateComplianceAttestationRequest) Descriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{52}
 }
 
-func (x *CreateComplianceAttestationRequest) GetComplianceAttestation() *ComplianceAttestation {
+func (x *InitiateComplianceAttestationRequest) GetAuditScopeId() string {
 	if x != nil {
-		return x.ComplianceAttestation
+		return x.AuditScopeId
 	}
-	return nil
+	return ""
 }
 
 type RemoveComplianceAttestationRequest struct {
@@ -5114,7 +5133,7 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"operations\x12\x1d\n" +
 	"\n" +
 	"metric_ids\x18\x03 \x03(\tR\tmetricIds\x127\n" +
-	"\x18target_of_evaluation_ids\x18\x04 \x03(\tR\x15targetOfEvaluationIds\"\x9a\b\n" +
+	"\x18target_of_evaluation_ids\x18\x04 \x03(\tR\x15targetOfEvaluationIds\"\x86\t\n" +
 	"\vChangeEvent\x12k\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampB1\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"R\ttimestamp\x12R\n" +
 	"\bcategory\x18\x02 \x01(\x0e2).confirmate.orchestrator.v1.EventCategoryB\v\xe0A\x02\xbaH\x05\x82\x01\x02\x10\x01R\bcategory\x12W\n" +
@@ -5130,7 +5149,8 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x11assessment_result\x18\r \x01(\v2*.confirmate.assessment.v1.AssessmentResultH\x00R\x10assessmentResult\x12b\n" +
 	"\x14metric_configuration\x18\x0e \x01(\v2-.confirmate.assessment.v1.MetricConfigurationH\x00R\x13metricConfiguration\x12e\n" +
 	"\x15metric_implementation\x18\x0f \x01(\v2..confirmate.assessment.v1.MetricImplementationH\x00R\x14metricImplementation\x12U\n" +
-	"\x0fassessment_tool\x18\x10 \x01(\v2*.confirmate.orchestrator.v1.AssessmentToolH\x00R\x0eassessmentToolB\b\n" +
+	"\x0fassessment_tool\x18\x10 \x01(\v2*.confirmate.orchestrator.v1.AssessmentToolH\x00R\x0eassessmentTool\x12j\n" +
+	"\x16compliance_attestation\x18\x11 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationH\x00R\x15complianceAttestationB\b\n" +
 	"\x06entityB\x1a\n" +
 	"\x18_target_of_evaluation_id\"\xc5\x01\n" +
 	"\x0eAssessmentTool\x12\x18\n" +
@@ -5325,9 +5345,9 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x17compliance_attestations\x18\x01 \x03(\v21.confirmate.orchestrator.v1.ComplianceAttestationR\x16complianceAttestations\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x99\x01\n" +
 	"\"UpdateComplianceAttestationRequest\x12s\n" +
-	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"\x99\x01\n" +
-	"\"CreateComplianceAttestationRequest\x12s\n" +
-	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"l\n" +
+	"\x16compliance_attestation\x18\x01 \x01(\v21.confirmate.orchestrator.v1.ComplianceAttestationB\t\xe0A\x02\xbaH\x03\xc8\x01\x01R\x15complianceAttestation\"Y\n" +
+	"$InitiateComplianceAttestationRequest\x121\n" +
+	"\x0eaudit_scope_id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\fauditScopeId\"l\n" +
 	"\"RemoveComplianceAttestationRequest\x12F\n" +
 	"\x19compliance_attestation_id\x18\x01 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x17complianceAttestationId\"\xe8\b\n" +
@@ -5419,7 +5439,7 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\a_filter\"\x7f\n" +
 	"\x14ListControlsResponse\x12?\n" +
 	"\bcontrols\x18\x01 \x03(\v2#.confirmate.orchestrator.v1.ControlR\bcontrols\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*\xb0\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*\xdb\x02\n" +
 	"\rEventCategory\x12\x1e\n" +
 	"\x1aEVENT_CATEGORY_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15EVENT_CATEGORY_METRIC\x10\x01\x12'\n" +
@@ -5428,7 +5448,8 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"#EVENT_CATEGORY_TARGET_OF_EVALUATION\x10\x04\x12\x1e\n" +
 	"\x1aEVENT_CATEGORY_AUDIT_SCOPE\x10\x05\x12$\n" +
 	" EVENT_CATEGORY_ASSESSMENT_RESULT\x10\x06\x12\"\n" +
-	"\x1eEVENT_CATEGORY_ASSESSMENT_TOOL\x10\a*\xaf\x01\n" +
+	"\x1eEVENT_CATEGORY_ASSESSMENT_TOOL\x10\a\x12)\n" +
+	"%EVENT_CATEGORY_COMPLIANCE_ATTESTATION\x10\b*\xaf\x01\n" +
 	"\vRequestType\x12\x1c\n" +
 	"\x18REQUEST_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14REQUEST_TYPE_CREATED\x10\x01\x12\x18\n" +
@@ -5451,7 +5472,7 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x19ATTESTATION_STATE_EXPIRED\x10\x06\x12\x1d\n" +
 	"\x19ATTESTATION_STATE_APPLIED\x10\a\x12\"\n" +
 	"\x1eATTESTATION_STATE_UNDER_REVIEW\x10\b\x12\x1e\n" +
-	"\x1aATTESTATION_STATE_REJECTED\x10\t2\xdcC\n" +
+	"\x1aATTESTATION_STATE_REJECTED\x10\t2\x96C\n" +
 	"\fOrchestrator\x12\xb0\x01\n" +
 	"\x16RegisterAssessmentTool\x129.confirmate.orchestrator.v1.RegisterAssessmentToolRequest\x1a*.confirmate.orchestrator.v1.AssessmentTool\"/\x82\xd3\xe4\x93\x02):\x04tool\"!/v1/orchestrator/assessment_tools\x12\xb1\x01\n" +
 	"\x13ListAssessmentTools\x126.confirmate.orchestrator.v1.ListAssessmentToolsRequest\x1a7.confirmate.orchestrator.v1.ListAssessmentToolsResponse\")\x82\xd3\xe4\x93\x02#\x12!/v1/orchestrator/assessment_tools\x12\xaa\x01\n" +
@@ -5478,8 +5499,8 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x18ListMetricConfigurations\x12:.confirmate.orchestrator.v1.ListMetricConfigurationRequest\x1a;.confirmate.orchestrator.v1.ListMetricConfigurationResponse\"^\x82\xd3\xe4\x93\x02X\x12V/v1/orchestrator/targets_of_evaluation/{target_of_evaluation_id}/metric_configurations\x12\xe7\x01\n" +
 	"\x1aUpdateMetricImplementation\x12=.confirmate.orchestrator.v1.UpdateMetricImplementationRequest\x1a..confirmate.assessment.v1.MetricImplementation\"Z\x82\xd3\xe4\x93\x02T:\x0eimplementation\x1aB/v1/orchestrator/metrics/{implementation.metric_id}/implementation\x12\xc2\x01\n" +
 	"\x17GetMetricImplementation\x12:.confirmate.orchestrator.v1.GetMetricImplementationRequest\x1a..confirmate.assessment.v1.MetricImplementation\";\x82\xd3\xe4\x93\x025\x123/v1/orchestrator/metrics/{metric_id}/implementation\x12f\n" +
-	"\tSubscribe\x12,.confirmate.orchestrator.v1.SubscribeRequest\x1a'.confirmate.orchestrator.v1.ChangeEvent\"\x000\x01\x12\xda\x01\n" +
-	"\x1bCreateComplianceAttestation\x12>.confirmate.orchestrator.v1.CreateComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\"H\x82\xd3\xe4\x93\x02B:\x16compliance_attestation\"(/v1/orchestrator/compliance_attestations\x12\xd8\x01\n" +
+	"\tSubscribe\x12,.confirmate.orchestrator.v1.SubscribeRequest\x1a'.confirmate.orchestrator.v1.ChangeEvent\"\x000\x01\x12\x94\x01\n" +
+	"\x1dInitiateComplianceAttestation\x12@.confirmate.orchestrator.v1.InitiateComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\x12\xd8\x01\n" +
 	"\x18GetComplianceAttestation\x12;.confirmate.orchestrator.v1.GetComplianceAttestationRequest\x1a1.confirmate.orchestrator.v1.ComplianceAttestation\"L\x82\xd3\xe4\x93\x02F\x12D/v1/orchestrator/compliance_attestations/{compliance_attestation_id}\x12\xcd\x01\n" +
 	"\x1aListComplianceAttestations\x12=.confirmate.orchestrator.v1.ListComplianceAttestationsRequest\x1a>.confirmate.orchestrator.v1.ListComplianceAttestationsResponse\"0\x82\xd3\xe4\x93\x02*\x12(/v1/orchestrator/compliance_attestations\x12\xe6\x01\n" +
 	" ListPublicComplianceAttestations\x12C.confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest\x1aD.confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse\"7\x82\xd3\xe4\x93\x021\x12//v1/orchestrator/public/compliance_attestations\x12\xf6\x01\n" +
@@ -5574,7 +5595,7 @@ var file_api_orchestrator_orchestrator_proto_goTypes = []any{
 	(*ListPublicComplianceAttestationsRequest)(nil),        // 54: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
 	(*ListPublicComplianceAttestationsResponse)(nil),       // 55: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
 	(*UpdateComplianceAttestationRequest)(nil),             // 56: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest
-	(*CreateComplianceAttestationRequest)(nil),             // 57: confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	(*InitiateComplianceAttestationRequest)(nil),           // 57: confirmate.orchestrator.v1.InitiateComplianceAttestationRequest
 	(*RemoveComplianceAttestationRequest)(nil),             // 58: confirmate.orchestrator.v1.RemoveComplianceAttestationRequest
 	(*ComplianceAttestation)(nil),                          // 59: confirmate.orchestrator.v1.ComplianceAttestation
 	(*ComplianceAttestationState)(nil),                     // 60: confirmate.orchestrator.v1.ComplianceAttestationState
@@ -5636,28 +5657,28 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	85,  // 23: confirmate.orchestrator.v1.ChangeEvent.metric_configuration:type_name -> confirmate.assessment.v1.MetricConfiguration
 	86,  // 24: confirmate.orchestrator.v1.ChangeEvent.metric_implementation:type_name -> confirmate.assessment.v1.MetricImplementation
 	36,  // 25: confirmate.orchestrator.v1.ChangeEvent.assessment_tool:type_name -> confirmate.orchestrator.v1.AssessmentTool
-	84,  // 26: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
-	87,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
-	87,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
-	75,  // 29: confirmate.orchestrator.v1.TargetOfEvaluation.metadata:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
-	4,   // 30: confirmate.orchestrator.v1.TargetOfEvaluation.target_type:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
-	39,  // 31: confirmate.orchestrator.v1.Catalog.categories:type_name -> confirmate.orchestrator.v1.Category
-	77,  // 32: confirmate.orchestrator.v1.Catalog.metadata:type_name -> confirmate.orchestrator.v1.Catalog.Metadata
-	40,  // 33: confirmate.orchestrator.v1.Category.controls:type_name -> confirmate.orchestrator.v1.Control
-	40,  // 34: confirmate.orchestrator.v1.Control.controls:type_name -> confirmate.orchestrator.v1.Control
-	84,  // 35: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
-	78,  // 36: confirmate.orchestrator.v1.ListAssessmentResultsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
-	83,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
-	41,  // 38: confirmate.orchestrator.v1.CreateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	79,  // 39: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
-	41,  // 40: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
-	41,  // 41: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
-	80,  // 42: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter
-	59,  // 43: confirmate.orchestrator.v1.ListComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	81,  // 44: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter
-	59,  // 45: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 46: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
-	59,  // 47: confirmate.orchestrator.v1.CreateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 26: confirmate.orchestrator.v1.ChangeEvent.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	84,  // 27: confirmate.orchestrator.v1.TargetOfEvaluation.configured_metrics:type_name -> confirmate.assessment.v1.Metric
+	87,  // 28: confirmate.orchestrator.v1.TargetOfEvaluation.created_at:type_name -> google.protobuf.Timestamp
+	87,  // 29: confirmate.orchestrator.v1.TargetOfEvaluation.updated_at:type_name -> google.protobuf.Timestamp
+	75,  // 30: confirmate.orchestrator.v1.TargetOfEvaluation.metadata:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.Metadata
+	4,   // 31: confirmate.orchestrator.v1.TargetOfEvaluation.target_type:type_name -> confirmate.orchestrator.v1.TargetOfEvaluation.TargetType
+	39,  // 32: confirmate.orchestrator.v1.Catalog.categories:type_name -> confirmate.orchestrator.v1.Category
+	77,  // 33: confirmate.orchestrator.v1.Catalog.metadata:type_name -> confirmate.orchestrator.v1.Catalog.Metadata
+	40,  // 34: confirmate.orchestrator.v1.Category.controls:type_name -> confirmate.orchestrator.v1.Control
+	40,  // 35: confirmate.orchestrator.v1.Control.controls:type_name -> confirmate.orchestrator.v1.Control
+	84,  // 36: confirmate.orchestrator.v1.Control.metrics:type_name -> confirmate.assessment.v1.Metric
+	78,  // 37: confirmate.orchestrator.v1.ListAssessmentResultsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAssessmentResultsRequest.Filter
+	83,  // 38: confirmate.orchestrator.v1.ListAssessmentResultsResponse.results:type_name -> confirmate.assessment.v1.AssessmentResult
+	41,  // 39: confirmate.orchestrator.v1.CreateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
+	79,  // 40: confirmate.orchestrator.v1.ListAuditScopesRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditScopesRequest.Filter
+	41,  // 41: confirmate.orchestrator.v1.ListAuditScopesResponse.audit_scopes:type_name -> confirmate.orchestrator.v1.AuditScope
+	41,  // 42: confirmate.orchestrator.v1.UpdateAuditScopeRequest.audit_scope:type_name -> confirmate.orchestrator.v1.AuditScope
+	80,  // 43: confirmate.orchestrator.v1.ListComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest.Filter
+	59,  // 44: confirmate.orchestrator.v1.ListComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	81,  // 45: confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.filter:type_name -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest.Filter
+	59,  // 46: confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse.compliance_attestations:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 47: confirmate.orchestrator.v1.UpdateComplianceAttestationRequest.compliance_attestation:type_name -> confirmate.orchestrator.v1.ComplianceAttestation
 	60,  // 48: confirmate.orchestrator.v1.ComplianceAttestation.states:type_name -> confirmate.orchestrator.v1.ComplianceAttestationState
 	2,   // 49: confirmate.orchestrator.v1.ComplianceAttestation.attestation_type:type_name -> confirmate.orchestrator.v1.ComplianceAttestationType
 	87,  // 50: confirmate.orchestrator.v1.ComplianceAttestation.issued_at:type_name -> google.protobuf.Timestamp
@@ -5704,7 +5725,7 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	32,  // 91: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:input_type -> confirmate.orchestrator.v1.UpdateMetricImplementationRequest
 	33,  // 92: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:input_type -> confirmate.orchestrator.v1.GetMetricImplementationRequest
 	34,  // 93: confirmate.orchestrator.v1.Orchestrator.Subscribe:input_type -> confirmate.orchestrator.v1.SubscribeRequest
-	57,  // 94: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:input_type -> confirmate.orchestrator.v1.CreateComplianceAttestationRequest
+	57,  // 94: confirmate.orchestrator.v1.Orchestrator.InitiateComplianceAttestation:input_type -> confirmate.orchestrator.v1.InitiateComplianceAttestationRequest
 	51,  // 95: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:input_type -> confirmate.orchestrator.v1.GetComplianceAttestationRequest
 	52,  // 96: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListComplianceAttestationsRequest
 	54,  // 97: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:input_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsRequest
@@ -5750,7 +5771,7 @@ var file_api_orchestrator_orchestrator_proto_depIdxs = []int32{
 	86,  // 137: confirmate.orchestrator.v1.Orchestrator.UpdateMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
 	86,  // 138: confirmate.orchestrator.v1.Orchestrator.GetMetricImplementation:output_type -> confirmate.assessment.v1.MetricImplementation
 	35,  // 139: confirmate.orchestrator.v1.Orchestrator.Subscribe:output_type -> confirmate.orchestrator.v1.ChangeEvent
-	59,  // 140: confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
+	59,  // 140: confirmate.orchestrator.v1.Orchestrator.InitiateComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
 	59,  // 141: confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation:output_type -> confirmate.orchestrator.v1.ComplianceAttestation
 	53,  // 142: confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListComplianceAttestationsResponse
 	55,  // 143: confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations:output_type -> confirmate.orchestrator.v1.ListPublicComplianceAttestationsResponse
@@ -5792,6 +5813,7 @@ func file_api_orchestrator_orchestrator_proto_init() {
 		(*ChangeEvent_MetricConfiguration)(nil),
 		(*ChangeEvent_MetricImplementation)(nil),
 		(*ChangeEvent_AssessmentTool)(nil),
+		(*ChangeEvent_ComplianceAttestation)(nil),
 	}
 	file_api_orchestrator_orchestrator_proto_msgTypes[32].OneofWrappers = []any{}
 	file_api_orchestrator_orchestrator_proto_msgTypes[33].OneofWrappers = []any{}

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -172,8 +172,8 @@ func (RequestType) EnumDescriptor() ([]byte, []int) {
 	return file_api_orchestrator_orchestrator_proto_rawDescGZIP(), []int{1}
 }
 
-// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
-// and internal compliance declarations.
+// ComplianceAttestationType distinguishes formal compliance certificates,
+// third-party attestations, and internal compliance declarations.
 type ComplianceAttestationType int32
 
 const (
@@ -3590,8 +3590,8 @@ func (x *RemoveComplianceAttestationRequest) GetComplianceAttestationId() string
 	return ""
 }
 
-// ComplianceAttestation is the unified API resource for certificates, third-party
-// attestations, and internal compliance declarations.
+// ComplianceAttestation is the unified API resource for formal compliance
+// certificates, third-party attestations, and internal compliance declarations.
 type ComplianceAttestation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -3616,7 +3616,8 @@ type ComplianceAttestation struct {
 	// Audit scope this attestation belongs to. This binds the attestation to a
 	// specific target of evaluation and catalog combination.
 	AuditScopeId string `protobuf:"bytes,11,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
-	// Type of compliance attestation, e.g. certificate or attestation.
+	// Type of compliance attestation, e.g. formal certificate or third-party
+	// attestation.
 	AttestationType ComplianceAttestationType `protobuf:"varint,12,opt,name=attestation_type,json=attestationType,proto3,enum=confirmate.orchestrator.v1.ComplianceAttestationType" json:"attestation_type,omitempty"`
 	// Preferred canonical issuance timestamp for this compliance attestation.
 	IssuedAt *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=issued_at,json=issuedAt,proto3,oneof" json:"issued_at,omitempty" gorm:"serializer:timestamppb;type:timestamp"`

--- a/core/api/orchestrator/orchestrator.pb.go
+++ b/core/api/orchestrator/orchestrator.pb.go
@@ -227,6 +227,18 @@ func (ComplianceAttestationType) EnumDescriptor() ([]byte, []int) {
 }
 
 // AttestationState models the lifecycle of a compliance attestation.
+//
+// Recommended lifecycle progression:
+// APPLIED -> UNDER_REVIEW -> IN_PROGRESS -> ISSUED -> ACTIVE -> EXPIRED
+//
+// Temporary or terminal detours:
+// - SUSPENDED may occur from ACTIVE or ISSUED
+// - WITHDRAWN may occur from ACTIVE, ISSUED, or SUSPENDED
+// - REJECTED may occur from APPLIED, UNDER_REVIEW, or IN_PROGRESS
+//
+// The API currently documents these transitions but does not enforce them at
+// the protobuf layer. Service-side validation can be added later without
+// changing this contract.
 type AttestationState int32
 
 const (
@@ -3428,7 +3440,10 @@ func (x *ListPublicComplianceAttestationsResponse) GetNextPageToken() string {
 }
 
 type UpdateComplianceAttestationRequest struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// UpdateComplianceAttestation is also used for lifecycle transitions. When a
+	// transition is requested, clients should append a new state entry and keep
+	// compliance_status aligned with the latest state.
 	ComplianceAttestation *ComplianceAttestation `protobuf:"bytes,1,opt,name=compliance_attestation,json=complianceAttestation,proto3" json:"compliance_attestation,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
@@ -3571,7 +3586,8 @@ type ComplianceAttestation struct {
 	AssuranceLevel string                 `protobuf:"bytes,7,opt,name=assurance_level,json=assuranceLevel,proto3" json:"assurance_level,omitempty"`
 	Cab            string                 `protobuf:"bytes,8,opt,name=cab,proto3" json:"cab,omitempty"`
 	Description    string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
-	// A list of states at specific times
+	// Ordered lifecycle history. The newest entry should represent the current
+	// lifecycle state and should match compliance_status when both are present.
 	States []*ComplianceAttestationState `protobuf:"bytes,10,rep,name=states,proto3" json:"states,omitempty" gorm:"constraint:OnDelete:CASCADE"`
 	// Audit scope this attestation belongs to. This binds the attestation to a
 	// specific target of evaluation and catalog combination.
@@ -3585,7 +3601,8 @@ type ComplianceAttestation struct {
 	// Optional auditor / certification body information.
 	CertificationBody string `protobuf:"bytes,16,opt,name=certification_body,json=certificationBody,proto3" json:"certification_body,omitempty"`
 	Auditor           string `protobuf:"bytes,17,opt,name=auditor,proto3" json:"auditor,omitempty"`
-	// Current summarized compliance state. Detailed transitions live in states.
+	// Current summarized lifecycle / compliance state. Detailed transitions live
+	// in states. When states are present, this should mirror the latest entry.
 	ComplianceStatus AttestationState `protobuf:"varint,18,opt,name=compliance_status,json=complianceStatus,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"compliance_status,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -3744,10 +3761,11 @@ func (x *ComplianceAttestation) GetComplianceStatus() AttestationState {
 type ComplianceAttestationState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// An EUCS-defined or platform-defined attestation lifecycle state.
+	// Lifecycle state after the transition.
 	State AttestationState `protobuf:"varint,2,opt,name=state,proto3,enum=confirmate.orchestrator.v1.AttestationState" json:"state,omitempty"`
 	// Optional transparency log or external evidence tree reference.
-	TreeId    string                 `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
+	TreeId string `protobuf:"bytes,3,opt,name=tree_id,json=treeId,proto3" json:"tree_id,omitempty"`
+	// Time at which the transition became effective.
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty" gorm:"serializer:timestamppb;type:timestamp"`
 	// Reference to the compliance attestation.
 	ComplianceAttestationId string `protobuf:"bytes,5,opt,name=compliance_attestation_id,json=complianceAttestationId,proto3" json:"compliance_attestation_id,omitempty"`

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -571,6 +571,7 @@ enum EventCategory {
   EVENT_CATEGORY_AUDIT_SCOPE = 5;
   EVENT_CATEGORY_ASSESSMENT_RESULT = 6;
   EVENT_CATEGORY_ASSESSMENT_TOOL = 7;
+  EVENT_CATEGORY_COMPLIANCE_ATTESTATION = 8;
 }
 
 message SubscribeRequest {
@@ -642,6 +643,7 @@ message ChangeEvent {
     confirmate.assessment.v1.MetricConfiguration metric_configuration = 14;
     confirmate.assessment.v1.MetricImplementation metric_implementation = 15;
     AssessmentTool assessment_tool = 16;
+      ComplianceAttestation compliance_attestation = 17;
   }
 }
 

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -200,40 +200,40 @@ service Orchestrator {
   // Subscribes to change events in the orchestrator
   rpc Subscribe(SubscribeRequest) returns (stream ChangeEvent) {}
 
-  // Creates a new certificate
-  rpc CreateCertificate(CreateCertificateRequest) returns (Certificate) {
+  // Creates a new compliance attestation
+  rpc CreateComplianceAttestation(CreateComplianceAttestationRequest) returns (ComplianceAttestation) {
     option (google.api.http) = {
-      post: "/v1/orchestrator/certificates"
-      body: "certificate"
+      post: "/v1/orchestrator/compliance_attestations"
+      body: "compliance_attestation"
     };
   }
 
-  // Retrieves a certificate
-  rpc GetCertificate(GetCertificateRequest) returns (Certificate) {
-    option (google.api.http) = {get: "/v1/orchestrator/certificates/{certificate_id}"};
+  // Retrieves a compliance attestation
+  rpc GetComplianceAttestation(GetComplianceAttestationRequest) returns (ComplianceAttestation) {
+    option (google.api.http) = {get: "/v1/orchestrator/compliance_attestations/{compliance_attestation_id}"};
   }
 
-  // Lists all target certificates
-  rpc ListCertificates(ListCertificatesRequest) returns (ListCertificatesResponse) {
-    option (google.api.http) = {get: "/v1/orchestrator/certificates"};
+  // Lists all compliance attestations
+  rpc ListComplianceAttestations(ListComplianceAttestationsRequest) returns (ListComplianceAttestationsResponse) {
+    option (google.api.http) = {get: "/v1/orchestrator/compliance_attestations"};
   }
 
-  // Lists all target certificates without state history
-  rpc ListPublicCertificates(ListPublicCertificatesRequest) returns (ListPublicCertificatesResponse) {
-    option (google.api.http) = {get: "/v1/orchestrator/public/certificates"};
+  // Lists all public compliance attestations without state history
+  rpc ListPublicComplianceAttestations(ListPublicComplianceAttestationsRequest) returns (ListPublicComplianceAttestationsResponse) {
+    option (google.api.http) = {get: "/v1/orchestrator/public/compliance_attestations"};
   }
 
-  // Updates an existing certificate
-  rpc UpdateCertificate(UpdateCertificateRequest) returns (Certificate) {
+  // Updates an existing compliance attestation
+  rpc UpdateComplianceAttestation(UpdateComplianceAttestationRequest) returns (ComplianceAttestation) {
     option (google.api.http) = {
-      put: "/v1/orchestrator/certificates/{certificate.id}"
-      body: "certificate"
+      put: "/v1/orchestrator/compliance_attestations/{compliance_attestation.id}"
+      body: "compliance_attestation"
     };
   }
 
-  // Removes a certificate
-  rpc RemoveCertificate(RemoveCertificateRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {delete: "/v1/orchestrator/certificates/{certificate_id}"};
+  // Removes a compliance attestation
+  rpc RemoveComplianceAttestation(RemoveComplianceAttestationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/orchestrator/compliance_attestations/{compliance_attestation_id}"};
   }
 
   // Creates a new security controls catalog
@@ -954,42 +954,136 @@ message UpdateAuditScopeRequest {
   ];
 }
 
-message GetCertificateRequest {
-  string certificate_id = 1 [
+message GetComplianceAttestationRequest {
+  string compliance_attestation_id = 1 [
     (buf.validate.field).string.min_len = 1,
     (google.api.field_behavior) = REQUIRED
   ];
 }
 
-message ListCertificatesRequest {
+message ListComplianceAttestationsRequest {
   int32 page_size = 10;
   string page_token = 11;
   string order_by = 12;
   bool asc = 13;
 }
 
-message ListCertificatesResponse {
-  repeated Certificate certificates = 1;
+message ListComplianceAttestationsResponse {
+  repeated ComplianceAttestation compliance_attestations = 1;
   string next_page_token = 2;
 }
 
-message ListPublicCertificatesRequest {
+message ListPublicComplianceAttestationsRequest {
   int32 page_size = 10;
   string page_token = 11;
   string order_by = 12;
   bool asc = 13;
 }
 
-message ListPublicCertificatesResponse {
-  repeated Certificate certificates = 1;
+message ListPublicComplianceAttestationsResponse {
+  repeated ComplianceAttestation compliance_attestations = 1;
   string next_page_token = 2;
 }
 
-message UpdateCertificateRequest {
-  Certificate certificate = 1 [
+message UpdateComplianceAttestationRequest {
+  ComplianceAttestation compliance_attestation = 1 [
     (buf.validate.field).required = true,
     (google.api.field_behavior) = REQUIRED
   ];
+}
+
+message CreateComplianceAttestationRequest {
+  ComplianceAttestation compliance_attestation = 1 [
+    (buf.validate.field).required = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+message RemoveComplianceAttestationRequest {
+  string compliance_attestation_id = 1 [
+    (buf.validate.field).string.min_len = 1,
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
+// and internal compliance declarations.
+enum ComplianceAttestationType {
+  COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED = 0;
+  COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE = 1;
+  COMPLIANCE_ATTESTATION_TYPE_ATTESTATION = 2;
+  COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION = 3;
+}
+
+// AttestationState models the lifecycle of a compliance attestation.
+enum AttestationState {
+  ATTESTATION_STATE_UNSPECIFIED = 0;
+  ATTESTATION_STATE_IN_PROGRESS = 1;
+  ATTESTATION_STATE_ACTIVE = 2;
+  ATTESTATION_STATE_ISSUED = 3;
+  ATTESTATION_STATE_SUSPENDED = 4;
+  ATTESTATION_STATE_WITHDRAWN = 5;
+  ATTESTATION_STATE_EXPIRED = 6;
+  ATTESTATION_STATE_APPLIED = 7;
+  ATTESTATION_STATE_UNDER_REVIEW = 8;
+  ATTESTATION_STATE_REJECTED = 9;
+}
+
+// ComplianceAttestation is the unified API resource for certificates, third-party
+// attestations, and internal compliance declarations.
+message ComplianceAttestation {
+  string id = 1 [
+    (buf.validate.field).string.min_len = 1,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  string name = 2 [
+    (buf.validate.field).string.min_len = 1,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  string issue_date = 4;
+  string expiration_date = 5;
+  string standard = 6;
+  string assurance_level = 7;
+  string cab = 8;
+  string description = 9;
+  // A list of states at specific times
+  repeated ComplianceAttestationState states = 10 [(tagger.tags) = "gorm:\"constraint:OnDelete:CASCADE\""];
+
+  // Audit scope this attestation belongs to. This binds the attestation to a
+  // specific target of evaluation and catalog combination.
+  string audit_scope_id = 11 [
+    (buf.validate.field).string.uuid = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // Type of compliance attestation, e.g. certificate or attestation.
+  ComplianceAttestationType attestation_type = 12 [(buf.validate.field).enum.defined_only = true];
+
+  // Structured validity timestamps for lifecycle-aware consumers.
+  optional google.protobuf.Timestamp issued_at = 13 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  optional google.protobuf.Timestamp valid_from = 14 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  optional google.protobuf.Timestamp valid_until = 15 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+
+  // Optional auditor / certification body information.
+  string certification_body = 16;
+  string auditor = 17;
+
+  // Current summarized compliance state. Detailed transitions live in states.
+  AttestationState compliance_status = 18 [(buf.validate.field).enum.defined_only = true];
+}
+
+// ComplianceAttestationState records a lifecycle transition of a compliance attestation.
+message ComplianceAttestationState {
+  string id = 1;
+  // An EUCS-defined or platform-defined attestation lifecycle state.
+  AttestationState state = 2 [(buf.validate.field).enum.defined_only = true];
+  // Optional transparency log or external evidence tree reference.
+  string tree_id = 3;
+  google.protobuf.Timestamp timestamp = 4 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  // Reference to the compliance attestation.
+  string compliance_attestation_id = 5;
+  // Optional human-readable reason for the state transition.
+  string reason = 6;
 }
 
 message CreateCatalogRequest {
@@ -1080,97 +1174,3 @@ message ListControlsResponse {
   string next_page_token = 2;
 }
 
-message CreateCertificateRequest {
-  Certificate certificate = 1 [
-    (buf.validate.field).required = true,
-    (google.api.field_behavior) = REQUIRED
-  ];
-}
-
-message RemoveCertificateRequest {
-  string certificate_id = 1 [
-    (buf.validate.field).string.min_len = 1,
-    (google.api.field_behavior) = REQUIRED
-  ];
-}
-
-// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
-// and internal compliance declarations.
-enum ComplianceAttestationType {
-  COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED = 0;
-  COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE = 1;
-  COMPLIANCE_ATTESTATION_TYPE_ATTESTATION = 2;
-  COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION = 3;
-}
-
-// AttestationState models the lifecycle of a compliance attestation.
-enum AttestationState {
-  ATTESTATION_STATE_UNSPECIFIED = 0;
-  ATTESTATION_STATE_IN_PROGRESS = 1;
-  ATTESTATION_STATE_ACTIVE = 2;
-  ATTESTATION_STATE_ISSUED = 3;
-  ATTESTATION_STATE_SUSPENDED = 4;
-  ATTESTATION_STATE_WITHDRAWN = 5;
-  ATTESTATION_STATE_EXPIRED = 6;
-  ATTESTATION_STATE_APPLIED = 7;
-  ATTESTATION_STATE_UNDER_REVIEW = 8;
-  ATTESTATION_STATE_REJECTED = 9;
-}
-
-// Certificate is the legacy API name for a compliance attestation.
-// It represents an assertion that a target of evaluation complies with a catalog
-// in the scope of a specific audit scope.
-message Certificate {
-  string id = 1 [
-    (buf.validate.field).string.min_len = 1,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  string name = 2 [
-    (buf.validate.field).string.min_len = 1,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  string issue_date = 4;
-  string expiration_date = 5;
-  string standard = 6;
-  string assurance_level = 7;
-  string cab = 8;
-  string description = 9;
-  // A list of states at specific times
-  repeated State states = 10 [(tagger.tags) = "gorm:\"constraint:OnDelete:CASCADE\""];
-
-  // Audit scope this attestation belongs to. This binds the attestation to a
-  // specific target of evaluation and catalog combination.
-  string audit_scope_id = 11 [
-    (buf.validate.field).string.uuid = true,
-    (google.api.field_behavior) = REQUIRED
-  ];
-
-  // Type of compliance attestation, e.g. certificate or attestation.
-  ComplianceAttestationType attestation_type = 12 [(buf.validate.field).enum.defined_only = true];
-
-  // Structured validity timestamps for lifecycle-aware consumers.
-  optional google.protobuf.Timestamp issued_at = 13 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
-  optional google.protobuf.Timestamp valid_from = 14 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
-  optional google.protobuf.Timestamp valid_until = 15 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
-
-  // Optional auditor / certification body information.
-  string certification_body = 16;
-  string auditor = 17;
-
-  // Current summarized compliance state. Detailed transitions live in states.
-  AttestationState compliance_status = 18 [(buf.validate.field).enum.defined_only = true];
-}
-
-// State is the legacy API name for a compliance attestation state transition.
-message State {
-  string id = 1;
-  // An EUCS-defined or platform-defined attestation lifecycle state.
-  AttestationState state = 2 [(buf.validate.field).enum.defined_only = true];
-  // Optional transparency log or external evidence tree reference.
-  string tree_id = 3;
-  google.protobuf.Timestamp timestamp = 4 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
-  // Reference to the certificate / compliance attestation.
-  string certificate_id = 5;
-  // Optional human-readable reason for the state transition.
-  string reason = 6;
-}

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -1077,8 +1077,12 @@ message ComplianceAttestation {
     (buf.validate.field).string.min_len = 1,
     (google.api.field_behavior) = REQUIRED
   ];
-  string issue_date = 4;
-  string expiration_date = 5;
+  // Deprecated: legacy string issue date kept for backward compatibility.
+  // Prefer issued_at for new integrations.
+  string issue_date = 4 [deprecated = true];
+  // Deprecated: legacy string expiration date kept for backward compatibility.
+  // Prefer valid_until for new integrations.
+  string expiration_date = 5 [deprecated = true];
   string standard = 6;
   string assurance_level = 7;
   string cab = 8;
@@ -1097,9 +1101,11 @@ message ComplianceAttestation {
   // Type of compliance attestation, e.g. certificate or attestation.
   ComplianceAttestationType attestation_type = 12 [(buf.validate.field).enum.defined_only = true];
 
-  // Structured validity timestamps for lifecycle-aware consumers.
+  // Preferred canonical issuance timestamp for this compliance attestation.
   optional google.protobuf.Timestamp issued_at = 13 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  // Preferred canonical start of the attestation validity period.
   optional google.protobuf.Timestamp valid_from = 14 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  // Preferred canonical end of the attestation validity period.
   optional google.protobuf.Timestamp valid_until = 15 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
 
   // Optional auditor / certification body information.

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -200,13 +200,9 @@ service Orchestrator {
   // Subscribes to change events in the orchestrator
   rpc Subscribe(SubscribeRequest) returns (stream ChangeEvent) {}
 
-  // Creates a new compliance attestation
-  rpc CreateComplianceAttestation(CreateComplianceAttestationRequest) returns (ComplianceAttestation) {
-    option (google.api.http) = {
-      post: "/v1/orchestrator/compliance_attestations"
-      body: "compliance_attestation"
-    };
-  }
+  // Initiates a compliance attestation for a specific audit scope if not already started, otherwise returns the existing one
+  rpc InitiateComplianceAttestation(InitiateComplianceAttestationRequest)
+      returns (ComplianceAttestation);
 
   // Retrieves a compliance attestation
   rpc GetComplianceAttestation(GetComplianceAttestationRequest) returns (ComplianceAttestation) {
@@ -1019,9 +1015,9 @@ message UpdateComplianceAttestationRequest {
   ];
 }
 
-message CreateComplianceAttestationRequest {
-  ComplianceAttestation compliance_attestation = 1 [
-    (buf.validate.field).required = true,
+message InitiateComplianceAttestationRequest {
+  string audit_scope_id = 1 [
+    (buf.validate.field).string.uuid = true,
     (google.api.field_behavior) = REQUIRED
   ];
 }

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -261,7 +261,7 @@ service Orchestrator {
     option (google.api.http) = {delete: "/v1/orchestrator/catalogs/{catalog_id}"};
   }
 
-  // Updates an existing certificate
+  // Updates an existing catalog
   rpc UpdateCatalog(UpdateCatalogRequest) returns (Catalog) {
     option (google.api.http) = {
       put: "/v1/orchestrator/catalogs/{catalog.id}"
@@ -1031,8 +1031,8 @@ message RemoveComplianceAttestationRequest {
   ];
 }
 
-// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
-// and internal compliance declarations.
+// ComplianceAttestationType distinguishes formal compliance certificates,
+// third-party attestations, and internal compliance declarations.
 enum ComplianceAttestationType {
   COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED = 0;
   COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE = 1;
@@ -1066,8 +1066,8 @@ enum AttestationState {
   ATTESTATION_STATE_REJECTED = 9;
 }
 
-// ComplianceAttestation is the unified API resource for certificates, third-party
-// attestations, and internal compliance declarations.
+// ComplianceAttestation is the unified API resource for formal compliance
+// certificates, third-party attestations, and internal compliance declarations.
 message ComplianceAttestation {
   string id = 1 [
     (buf.validate.field).string.min_len = 1,
@@ -1098,7 +1098,8 @@ message ComplianceAttestation {
     (google.api.field_behavior) = REQUIRED
   ];
 
-  // Type of compliance attestation, e.g. certificate or attestation.
+  // Type of compliance attestation, e.g. formal certificate or third-party
+  // attestation.
   ComplianceAttestationType attestation_type = 12 [(buf.validate.field).enum.defined_only = true];
 
   // Preferred canonical issuance timestamp for this compliance attestation.

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -986,6 +986,9 @@ message ListPublicComplianceAttestationsResponse {
 }
 
 message UpdateComplianceAttestationRequest {
+  // UpdateComplianceAttestation is also used for lifecycle transitions. When a
+  // transition is requested, clients should append a new state entry and keep
+  // compliance_status aligned with the latest state.
   ComplianceAttestation compliance_attestation = 1 [
     (buf.validate.field).required = true,
     (google.api.field_behavior) = REQUIRED
@@ -1016,6 +1019,18 @@ enum ComplianceAttestationType {
 }
 
 // AttestationState models the lifecycle of a compliance attestation.
+//
+// Recommended lifecycle progression:
+// APPLIED -> UNDER_REVIEW -> IN_PROGRESS -> ISSUED -> ACTIVE -> EXPIRED
+//
+// Temporary or terminal detours:
+// - SUSPENDED may occur from ACTIVE or ISSUED
+// - WITHDRAWN may occur from ACTIVE, ISSUED, or SUSPENDED
+// - REJECTED may occur from APPLIED, UNDER_REVIEW, or IN_PROGRESS
+//
+// The API currently documents these transitions but does not enforce them at
+// the protobuf layer. Service-side validation can be added later without
+// changing this contract.
 enum AttestationState {
   ATTESTATION_STATE_UNSPECIFIED = 0;
   ATTESTATION_STATE_IN_PROGRESS = 1;
@@ -1046,7 +1061,8 @@ message ComplianceAttestation {
   string assurance_level = 7;
   string cab = 8;
   string description = 9;
-  // A list of states at specific times
+  // Ordered lifecycle history. The newest entry should represent the current
+  // lifecycle state and should match compliance_status when both are present.
   repeated ComplianceAttestationState states = 10 [(tagger.tags) = "gorm:\"constraint:OnDelete:CASCADE\""];
 
   // Audit scope this attestation belongs to. This binds the attestation to a
@@ -1068,17 +1084,19 @@ message ComplianceAttestation {
   string certification_body = 16;
   string auditor = 17;
 
-  // Current summarized compliance state. Detailed transitions live in states.
+  // Current summarized lifecycle / compliance state. Detailed transitions live
+  // in states. When states are present, this should mirror the latest entry.
   AttestationState compliance_status = 18 [(buf.validate.field).enum.defined_only = true];
 }
 
 // ComplianceAttestationState records a lifecycle transition of a compliance attestation.
 message ComplianceAttestationState {
   string id = 1;
-  // An EUCS-defined or platform-defined attestation lifecycle state.
+  // Lifecycle state after the transition.
   AttestationState state = 2 [(buf.validate.field).enum.defined_only = true];
   // Optional transparency log or external evidence tree reference.
   string tree_id = 3;
+  // Time at which the transition became effective.
   google.protobuf.Timestamp timestamp = 4 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
   // Reference to the compliance attestation.
   string compliance_attestation_id = 5;

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -1094,7 +1094,32 @@ message RemoveCertificateRequest {
   ];
 }
 
-// An ISO17021-based certificate
+// ComplianceAttestationType distinguishes formal certificates, third-party attestations,
+// and internal compliance declarations.
+enum ComplianceAttestationType {
+  COMPLIANCE_ATTESTATION_TYPE_UNSPECIFIED = 0;
+  COMPLIANCE_ATTESTATION_TYPE_CERTIFICATE = 1;
+  COMPLIANCE_ATTESTATION_TYPE_ATTESTATION = 2;
+  COMPLIANCE_ATTESTATION_TYPE_INTERNAL_ATTESTATION = 3;
+}
+
+// AttestationState models the lifecycle of a compliance attestation.
+enum AttestationState {
+  ATTESTATION_STATE_UNSPECIFIED = 0;
+  ATTESTATION_STATE_IN_PROGRESS = 1;
+  ATTESTATION_STATE_ACTIVE = 2;
+  ATTESTATION_STATE_ISSUED = 3;
+  ATTESTATION_STATE_SUSPENDED = 4;
+  ATTESTATION_STATE_WITHDRAWN = 5;
+  ATTESTATION_STATE_EXPIRED = 6;
+  ATTESTATION_STATE_APPLIED = 7;
+  ATTESTATION_STATE_UNDER_REVIEW = 8;
+  ATTESTATION_STATE_REJECTED = 9;
+}
+
+// Certificate is the legacy API name for a compliance attestation.
+// It represents an assertion that a target of evaluation complies with a catalog
+// in the scope of a specific audit scope.
 message Certificate {
   string id = 1 [
     (buf.validate.field).string.min_len = 1,
@@ -1102,10 +1127,6 @@ message Certificate {
   ];
   string name = 2 [
     (buf.validate.field).string.min_len = 1,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  string target_of_evaluation_id = 3 [
-    (buf.validate.field).string.uuid = true,
     (google.api.field_behavior) = REQUIRED
   ];
   string issue_date = 4;
@@ -1116,15 +1137,40 @@ message Certificate {
   string description = 9;
   // A list of states at specific times
   repeated State states = 10 [(tagger.tags) = "gorm:\"constraint:OnDelete:CASCADE\""];
+
+  // Audit scope this attestation belongs to. This binds the attestation to a
+  // specific target of evaluation and catalog combination.
+  string audit_scope_id = 11 [
+    (buf.validate.field).string.uuid = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // Type of compliance attestation, e.g. certificate or attestation.
+  ComplianceAttestationType attestation_type = 12 [(buf.validate.field).enum.defined_only = true];
+
+  // Structured validity timestamps for lifecycle-aware consumers.
+  optional google.protobuf.Timestamp issued_at = 13 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  optional google.protobuf.Timestamp valid_from = 14 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  optional google.protobuf.Timestamp valid_until = 15 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+
+  // Optional auditor / certification body information.
+  string certification_body = 16;
+  string auditor = 17;
+
+  // Current summarized compliance state. Detailed transitions live in states.
+  AttestationState compliance_status = 18 [(buf.validate.field).enum.defined_only = true];
 }
 
-// A state of a certificate at a given time
+// State is the legacy API name for a compliance attestation state transition.
 message State {
   string id = 1;
-  // An EUCS-defined state, e.g. `new`, `suspended` or `withdrawn`
-  string state = 2;
+  // An EUCS-defined or platform-defined attestation lifecycle state.
+  AttestationState state = 2 [(buf.validate.field).enum.defined_only = true];
+  // Optional transparency log or external evidence tree reference.
   string tree_id = 3;
-  string timestamp = 4;
-  // Reference to the certificate
+  google.protobuf.Timestamp timestamp = 4 [(tagger.tags) = "gorm:\"serializer:timestamppb;type:timestamp\""];
+  // Reference to the certificate / compliance attestation.
   string certificate_id = 5;
+  // Optional human-readable reason for the state transition.
+  string reason = 6;
 }

--- a/core/api/orchestrator/orchestrator.proto
+++ b/core/api/orchestrator/orchestrator.proto
@@ -962,6 +962,17 @@ message GetComplianceAttestationRequest {
 }
 
 message ListComplianceAttestationsRequest {
+  message Filter {
+    // Optional. List only compliance attestations for a specific audit scope.
+    optional string audit_scope_id = 1 [(buf.validate.field).string.uuid = true];
+    // Optional. List only compliance attestations of the specified type.
+    optional ComplianceAttestationType attestation_type = 2 [(buf.validate.field).enum.defined_only = true];
+    // Optional. List only compliance attestations in the specified lifecycle state.
+    optional AttestationState compliance_status = 3 [(buf.validate.field).enum.defined_only = true];
+  }
+
+  optional Filter filter = 1;
+
   int32 page_size = 10;
   string page_token = 11;
   string order_by = 12;
@@ -974,6 +985,17 @@ message ListComplianceAttestationsResponse {
 }
 
 message ListPublicComplianceAttestationsRequest {
+  message Filter {
+    // Optional. List only compliance attestations for a specific audit scope.
+    optional string audit_scope_id = 1 [(buf.validate.field).string.uuid = true];
+    // Optional. List only compliance attestations of the specified type.
+    optional ComplianceAttestationType attestation_type = 2 [(buf.validate.field).enum.defined_only = true];
+    // Optional. List only compliance attestations in the specified lifecycle state.
+    optional AttestationState compliance_status = 3 [(buf.validate.field).enum.defined_only = true];
+  }
+
+  optional Filter filter = 1;
+
   int32 page_size = 10;
   string page_token = 11;
   string order_by = 12;

--- a/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
+++ b/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
@@ -268,7 +268,7 @@ type OrchestratorClient interface {
 	GetCatalog(context.Context, *connect.Request[orchestrator.GetCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Removes a catalog
 	RemoveCatalog(context.Context, *connect.Request[orchestrator.RemoveCatalogRequest]) (*connect.Response[emptypb.Empty], error)
-	// Updates an existing certificate
+	// Updates an existing catalog
 	UpdateCatalog(context.Context, *connect.Request[orchestrator.UpdateCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Retrieves a category of a catalog specified by the catalog ID and the
 	// category name. It includes the first level of controls within each
@@ -957,7 +957,7 @@ type OrchestratorHandler interface {
 	GetCatalog(context.Context, *connect.Request[orchestrator.GetCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Removes a catalog
 	RemoveCatalog(context.Context, *connect.Request[orchestrator.RemoveCatalogRequest]) (*connect.Response[emptypb.Empty], error)
-	// Updates an existing certificate
+	// Updates an existing catalog
 	UpdateCatalog(context.Context, *connect.Request[orchestrator.UpdateCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Retrieves a category of a catalog specified by the catalog ID and the
 	// category name. It includes the first level of controls within each

--- a/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
+++ b/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
@@ -126,24 +126,24 @@ const (
 	OrchestratorGetMetricImplementationProcedure = "/confirmate.orchestrator.v1.Orchestrator/GetMetricImplementation"
 	// OrchestratorSubscribeProcedure is the fully-qualified name of the Orchestrator's Subscribe RPC.
 	OrchestratorSubscribeProcedure = "/confirmate.orchestrator.v1.Orchestrator/Subscribe"
-	// OrchestratorCreateCertificateProcedure is the fully-qualified name of the Orchestrator's
-	// CreateCertificate RPC.
-	OrchestratorCreateCertificateProcedure = "/confirmate.orchestrator.v1.Orchestrator/CreateCertificate"
-	// OrchestratorGetCertificateProcedure is the fully-qualified name of the Orchestrator's
-	// GetCertificate RPC.
-	OrchestratorGetCertificateProcedure = "/confirmate.orchestrator.v1.Orchestrator/GetCertificate"
-	// OrchestratorListCertificatesProcedure is the fully-qualified name of the Orchestrator's
-	// ListCertificates RPC.
-	OrchestratorListCertificatesProcedure = "/confirmate.orchestrator.v1.Orchestrator/ListCertificates"
-	// OrchestratorListPublicCertificatesProcedure is the fully-qualified name of the Orchestrator's
-	// ListPublicCertificates RPC.
-	OrchestratorListPublicCertificatesProcedure = "/confirmate.orchestrator.v1.Orchestrator/ListPublicCertificates"
-	// OrchestratorUpdateCertificateProcedure is the fully-qualified name of the Orchestrator's
-	// UpdateCertificate RPC.
-	OrchestratorUpdateCertificateProcedure = "/confirmate.orchestrator.v1.Orchestrator/UpdateCertificate"
-	// OrchestratorRemoveCertificateProcedure is the fully-qualified name of the Orchestrator's
-	// RemoveCertificate RPC.
-	OrchestratorRemoveCertificateProcedure = "/confirmate.orchestrator.v1.Orchestrator/RemoveCertificate"
+	// OrchestratorCreateComplianceAttestationProcedure is the fully-qualified name of the
+	// Orchestrator's CreateComplianceAttestation RPC.
+	OrchestratorCreateComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/CreateComplianceAttestation"
+	// OrchestratorGetComplianceAttestationProcedure is the fully-qualified name of the Orchestrator's
+	// GetComplianceAttestation RPC.
+	OrchestratorGetComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/GetComplianceAttestation"
+	// OrchestratorListComplianceAttestationsProcedure is the fully-qualified name of the Orchestrator's
+	// ListComplianceAttestations RPC.
+	OrchestratorListComplianceAttestationsProcedure = "/confirmate.orchestrator.v1.Orchestrator/ListComplianceAttestations"
+	// OrchestratorListPublicComplianceAttestationsProcedure is the fully-qualified name of the
+	// Orchestrator's ListPublicComplianceAttestations RPC.
+	OrchestratorListPublicComplianceAttestationsProcedure = "/confirmate.orchestrator.v1.Orchestrator/ListPublicComplianceAttestations"
+	// OrchestratorUpdateComplianceAttestationProcedure is the fully-qualified name of the
+	// Orchestrator's UpdateComplianceAttestation RPC.
+	OrchestratorUpdateComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/UpdateComplianceAttestation"
+	// OrchestratorRemoveComplianceAttestationProcedure is the fully-qualified name of the
+	// Orchestrator's RemoveComplianceAttestation RPC.
+	OrchestratorRemoveComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/RemoveComplianceAttestation"
 	// OrchestratorCreateCatalogProcedure is the fully-qualified name of the Orchestrator's
 	// CreateCatalog RPC.
 	OrchestratorCreateCatalogProcedure = "/confirmate.orchestrator.v1.Orchestrator/CreateCatalog"
@@ -246,18 +246,18 @@ type OrchestratorClient interface {
 	GetMetricImplementation(context.Context, *connect.Request[orchestrator.GetMetricImplementationRequest]) (*connect.Response[assessment.MetricImplementation], error)
 	// Subscribes to change events in the orchestrator
 	Subscribe(context.Context, *connect.Request[orchestrator.SubscribeRequest]) (*connect.ServerStreamForClient[orchestrator.ChangeEvent], error)
-	// Creates a new certificate
-	CreateCertificate(context.Context, *connect.Request[orchestrator.CreateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Retrieves a certificate
-	GetCertificate(context.Context, *connect.Request[orchestrator.GetCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Lists all target certificates
-	ListCertificates(context.Context, *connect.Request[orchestrator.ListCertificatesRequest]) (*connect.Response[orchestrator.ListCertificatesResponse], error)
-	// Lists all target certificates without state history
-	ListPublicCertificates(context.Context, *connect.Request[orchestrator.ListPublicCertificatesRequest]) (*connect.Response[orchestrator.ListPublicCertificatesResponse], error)
-	// Updates an existing certificate
-	UpdateCertificate(context.Context, *connect.Request[orchestrator.UpdateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Removes a certificate
-	RemoveCertificate(context.Context, *connect.Request[orchestrator.RemoveCertificateRequest]) (*connect.Response[emptypb.Empty], error)
+	// Creates a new compliance attestation
+	CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Retrieves a compliance attestation
+	GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Lists all compliance attestations
+	ListComplianceAttestations(context.Context, *connect.Request[orchestrator.ListComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListComplianceAttestationsResponse], error)
+	// Lists all public compliance attestations without state history
+	ListPublicComplianceAttestations(context.Context, *connect.Request[orchestrator.ListPublicComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], error)
+	// Updates an existing compliance attestation
+	UpdateComplianceAttestation(context.Context, *connect.Request[orchestrator.UpdateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Removes a compliance attestation
+	RemoveComplianceAttestation(context.Context, *connect.Request[orchestrator.RemoveComplianceAttestationRequest]) (*connect.Response[emptypb.Empty], error)
 	// Creates a new security controls catalog
 	CreateCatalog(context.Context, *connect.Request[orchestrator.CreateCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Lists all security controls catalogs. Each catalog includes a list of its
@@ -464,40 +464,40 @@ func NewOrchestratorClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(orchestratorMethods.ByName("Subscribe")),
 			connect.WithClientOptions(opts...),
 		),
-		createCertificate: connect.NewClient[orchestrator.CreateCertificateRequest, orchestrator.Certificate](
+		createComplianceAttestation: connect.NewClient[orchestrator.CreateComplianceAttestationRequest, orchestrator.ComplianceAttestation](
 			httpClient,
-			baseURL+OrchestratorCreateCertificateProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("CreateCertificate")),
+			baseURL+OrchestratorCreateComplianceAttestationProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("CreateComplianceAttestation")),
 			connect.WithClientOptions(opts...),
 		),
-		getCertificate: connect.NewClient[orchestrator.GetCertificateRequest, orchestrator.Certificate](
+		getComplianceAttestation: connect.NewClient[orchestrator.GetComplianceAttestationRequest, orchestrator.ComplianceAttestation](
 			httpClient,
-			baseURL+OrchestratorGetCertificateProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("GetCertificate")),
+			baseURL+OrchestratorGetComplianceAttestationProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("GetComplianceAttestation")),
 			connect.WithClientOptions(opts...),
 		),
-		listCertificates: connect.NewClient[orchestrator.ListCertificatesRequest, orchestrator.ListCertificatesResponse](
+		listComplianceAttestations: connect.NewClient[orchestrator.ListComplianceAttestationsRequest, orchestrator.ListComplianceAttestationsResponse](
 			httpClient,
-			baseURL+OrchestratorListCertificatesProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("ListCertificates")),
+			baseURL+OrchestratorListComplianceAttestationsProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("ListComplianceAttestations")),
 			connect.WithClientOptions(opts...),
 		),
-		listPublicCertificates: connect.NewClient[orchestrator.ListPublicCertificatesRequest, orchestrator.ListPublicCertificatesResponse](
+		listPublicComplianceAttestations: connect.NewClient[orchestrator.ListPublicComplianceAttestationsRequest, orchestrator.ListPublicComplianceAttestationsResponse](
 			httpClient,
-			baseURL+OrchestratorListPublicCertificatesProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("ListPublicCertificates")),
+			baseURL+OrchestratorListPublicComplianceAttestationsProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("ListPublicComplianceAttestations")),
 			connect.WithClientOptions(opts...),
 		),
-		updateCertificate: connect.NewClient[orchestrator.UpdateCertificateRequest, orchestrator.Certificate](
+		updateComplianceAttestation: connect.NewClient[orchestrator.UpdateComplianceAttestationRequest, orchestrator.ComplianceAttestation](
 			httpClient,
-			baseURL+OrchestratorUpdateCertificateProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("UpdateCertificate")),
+			baseURL+OrchestratorUpdateComplianceAttestationProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("UpdateComplianceAttestation")),
 			connect.WithClientOptions(opts...),
 		),
-		removeCertificate: connect.NewClient[orchestrator.RemoveCertificateRequest, emptypb.Empty](
+		removeComplianceAttestation: connect.NewClient[orchestrator.RemoveComplianceAttestationRequest, emptypb.Empty](
 			httpClient,
-			baseURL+OrchestratorRemoveCertificateProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("RemoveCertificate")),
+			baseURL+OrchestratorRemoveComplianceAttestationProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("RemoveComplianceAttestation")),
 			connect.WithClientOptions(opts...),
 		),
 		createCatalog: connect.NewClient[orchestrator.CreateCatalogRequest, orchestrator.Catalog](
@@ -589,52 +589,52 @@ func NewOrchestratorClient(httpClient connect.HTTPClient, baseURL string, opts .
 
 // orchestratorClient implements OrchestratorClient.
 type orchestratorClient struct {
-	registerAssessmentTool          *connect.Client[orchestrator.RegisterAssessmentToolRequest, orchestrator.AssessmentTool]
-	listAssessmentTools             *connect.Client[orchestrator.ListAssessmentToolsRequest, orchestrator.ListAssessmentToolsResponse]
-	getAssessmentTool               *connect.Client[orchestrator.GetAssessmentToolRequest, orchestrator.AssessmentTool]
-	updateAssessmentTool            *connect.Client[orchestrator.UpdateAssessmentToolRequest, orchestrator.AssessmentTool]
-	deregisterAssessmentTool        *connect.Client[orchestrator.DeregisterAssessmentToolRequest, emptypb.Empty]
-	storeAssessmentResult           *connect.Client[orchestrator.StoreAssessmentResultRequest, orchestrator.StoreAssessmentResultResponse]
-	storeAssessmentResults          *connect.Client[orchestrator.StoreAssessmentResultRequest, orchestrator.StoreAssessmentResultsResponse]
-	getAssessmentResult             *connect.Client[orchestrator.GetAssessmentResultRequest, assessment.AssessmentResult]
-	listAssessmentResults           *connect.Client[orchestrator.ListAssessmentResultsRequest, orchestrator.ListAssessmentResultsResponse]
-	createMetric                    *connect.Client[orchestrator.CreateMetricRequest, assessment.Metric]
-	updateMetric                    *connect.Client[orchestrator.UpdateMetricRequest, assessment.Metric]
-	getMetric                       *connect.Client[orchestrator.GetMetricRequest, assessment.Metric]
-	listMetrics                     *connect.Client[orchestrator.ListMetricsRequest, orchestrator.ListMetricsResponse]
-	removeMetric                    *connect.Client[orchestrator.RemoveMetricRequest, emptypb.Empty]
-	createTargetOfEvaluation        *connect.Client[orchestrator.CreateTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
-	updateTargetOfEvaluation        *connect.Client[orchestrator.UpdateTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
-	getTargetOfEvaluation           *connect.Client[orchestrator.GetTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
-	listTargetsOfEvaluation         *connect.Client[orchestrator.ListTargetsOfEvaluationRequest, orchestrator.ListTargetsOfEvaluationResponse]
-	removeTargetOfEvaluation        *connect.Client[orchestrator.RemoveTargetOfEvaluationRequest, emptypb.Empty]
-	getTargetOfEvaluationStatistics *connect.Client[orchestrator.GetTargetOfEvaluationStatisticsRequest, orchestrator.GetTargetOfEvaluationStatisticsResponse]
-	updateMetricConfiguration       *connect.Client[orchestrator.UpdateMetricConfigurationRequest, assessment.MetricConfiguration]
-	getMetricConfiguration          *connect.Client[orchestrator.GetMetricConfigurationRequest, assessment.MetricConfiguration]
-	listMetricConfigurations        *connect.Client[orchestrator.ListMetricConfigurationRequest, orchestrator.ListMetricConfigurationResponse]
-	updateMetricImplementation      *connect.Client[orchestrator.UpdateMetricImplementationRequest, assessment.MetricImplementation]
-	getMetricImplementation         *connect.Client[orchestrator.GetMetricImplementationRequest, assessment.MetricImplementation]
-	subscribe                       *connect.Client[orchestrator.SubscribeRequest, orchestrator.ChangeEvent]
-	createCertificate               *connect.Client[orchestrator.CreateCertificateRequest, orchestrator.Certificate]
-	getCertificate                  *connect.Client[orchestrator.GetCertificateRequest, orchestrator.Certificate]
-	listCertificates                *connect.Client[orchestrator.ListCertificatesRequest, orchestrator.ListCertificatesResponse]
-	listPublicCertificates          *connect.Client[orchestrator.ListPublicCertificatesRequest, orchestrator.ListPublicCertificatesResponse]
-	updateCertificate               *connect.Client[orchestrator.UpdateCertificateRequest, orchestrator.Certificate]
-	removeCertificate               *connect.Client[orchestrator.RemoveCertificateRequest, emptypb.Empty]
-	createCatalog                   *connect.Client[orchestrator.CreateCatalogRequest, orchestrator.Catalog]
-	listCatalogs                    *connect.Client[orchestrator.ListCatalogsRequest, orchestrator.ListCatalogsResponse]
-	getCatalog                      *connect.Client[orchestrator.GetCatalogRequest, orchestrator.Catalog]
-	removeCatalog                   *connect.Client[orchestrator.RemoveCatalogRequest, emptypb.Empty]
-	updateCatalog                   *connect.Client[orchestrator.UpdateCatalogRequest, orchestrator.Catalog]
-	getCategory                     *connect.Client[orchestrator.GetCategoryRequest, orchestrator.Category]
-	listControls                    *connect.Client[orchestrator.ListControlsRequest, orchestrator.ListControlsResponse]
-	getControl                      *connect.Client[orchestrator.GetControlRequest, orchestrator.Control]
-	createAuditScope                *connect.Client[orchestrator.CreateAuditScopeRequest, orchestrator.AuditScope]
-	getAuditScope                   *connect.Client[orchestrator.GetAuditScopeRequest, orchestrator.AuditScope]
-	listAuditScopes                 *connect.Client[orchestrator.ListAuditScopesRequest, orchestrator.ListAuditScopesResponse]
-	updateAuditScope                *connect.Client[orchestrator.UpdateAuditScopeRequest, orchestrator.AuditScope]
-	removeAuditScope                *connect.Client[orchestrator.RemoveAuditScopeRequest, emptypb.Empty]
-	getRuntimeInfo                  *connect.Client[common.GetRuntimeInfoRequest, common.Runtime]
+	registerAssessmentTool           *connect.Client[orchestrator.RegisterAssessmentToolRequest, orchestrator.AssessmentTool]
+	listAssessmentTools              *connect.Client[orchestrator.ListAssessmentToolsRequest, orchestrator.ListAssessmentToolsResponse]
+	getAssessmentTool                *connect.Client[orchestrator.GetAssessmentToolRequest, orchestrator.AssessmentTool]
+	updateAssessmentTool             *connect.Client[orchestrator.UpdateAssessmentToolRequest, orchestrator.AssessmentTool]
+	deregisterAssessmentTool         *connect.Client[orchestrator.DeregisterAssessmentToolRequest, emptypb.Empty]
+	storeAssessmentResult            *connect.Client[orchestrator.StoreAssessmentResultRequest, orchestrator.StoreAssessmentResultResponse]
+	storeAssessmentResults           *connect.Client[orchestrator.StoreAssessmentResultRequest, orchestrator.StoreAssessmentResultsResponse]
+	getAssessmentResult              *connect.Client[orchestrator.GetAssessmentResultRequest, assessment.AssessmentResult]
+	listAssessmentResults            *connect.Client[orchestrator.ListAssessmentResultsRequest, orchestrator.ListAssessmentResultsResponse]
+	createMetric                     *connect.Client[orchestrator.CreateMetricRequest, assessment.Metric]
+	updateMetric                     *connect.Client[orchestrator.UpdateMetricRequest, assessment.Metric]
+	getMetric                        *connect.Client[orchestrator.GetMetricRequest, assessment.Metric]
+	listMetrics                      *connect.Client[orchestrator.ListMetricsRequest, orchestrator.ListMetricsResponse]
+	removeMetric                     *connect.Client[orchestrator.RemoveMetricRequest, emptypb.Empty]
+	createTargetOfEvaluation         *connect.Client[orchestrator.CreateTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
+	updateTargetOfEvaluation         *connect.Client[orchestrator.UpdateTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
+	getTargetOfEvaluation            *connect.Client[orchestrator.GetTargetOfEvaluationRequest, orchestrator.TargetOfEvaluation]
+	listTargetsOfEvaluation          *connect.Client[orchestrator.ListTargetsOfEvaluationRequest, orchestrator.ListTargetsOfEvaluationResponse]
+	removeTargetOfEvaluation         *connect.Client[orchestrator.RemoveTargetOfEvaluationRequest, emptypb.Empty]
+	getTargetOfEvaluationStatistics  *connect.Client[orchestrator.GetTargetOfEvaluationStatisticsRequest, orchestrator.GetTargetOfEvaluationStatisticsResponse]
+	updateMetricConfiguration        *connect.Client[orchestrator.UpdateMetricConfigurationRequest, assessment.MetricConfiguration]
+	getMetricConfiguration           *connect.Client[orchestrator.GetMetricConfigurationRequest, assessment.MetricConfiguration]
+	listMetricConfigurations         *connect.Client[orchestrator.ListMetricConfigurationRequest, orchestrator.ListMetricConfigurationResponse]
+	updateMetricImplementation       *connect.Client[orchestrator.UpdateMetricImplementationRequest, assessment.MetricImplementation]
+	getMetricImplementation          *connect.Client[orchestrator.GetMetricImplementationRequest, assessment.MetricImplementation]
+	subscribe                        *connect.Client[orchestrator.SubscribeRequest, orchestrator.ChangeEvent]
+	createComplianceAttestation      *connect.Client[orchestrator.CreateComplianceAttestationRequest, orchestrator.ComplianceAttestation]
+	getComplianceAttestation         *connect.Client[orchestrator.GetComplianceAttestationRequest, orchestrator.ComplianceAttestation]
+	listComplianceAttestations       *connect.Client[orchestrator.ListComplianceAttestationsRequest, orchestrator.ListComplianceAttestationsResponse]
+	listPublicComplianceAttestations *connect.Client[orchestrator.ListPublicComplianceAttestationsRequest, orchestrator.ListPublicComplianceAttestationsResponse]
+	updateComplianceAttestation      *connect.Client[orchestrator.UpdateComplianceAttestationRequest, orchestrator.ComplianceAttestation]
+	removeComplianceAttestation      *connect.Client[orchestrator.RemoveComplianceAttestationRequest, emptypb.Empty]
+	createCatalog                    *connect.Client[orchestrator.CreateCatalogRequest, orchestrator.Catalog]
+	listCatalogs                     *connect.Client[orchestrator.ListCatalogsRequest, orchestrator.ListCatalogsResponse]
+	getCatalog                       *connect.Client[orchestrator.GetCatalogRequest, orchestrator.Catalog]
+	removeCatalog                    *connect.Client[orchestrator.RemoveCatalogRequest, emptypb.Empty]
+	updateCatalog                    *connect.Client[orchestrator.UpdateCatalogRequest, orchestrator.Catalog]
+	getCategory                      *connect.Client[orchestrator.GetCategoryRequest, orchestrator.Category]
+	listControls                     *connect.Client[orchestrator.ListControlsRequest, orchestrator.ListControlsResponse]
+	getControl                       *connect.Client[orchestrator.GetControlRequest, orchestrator.Control]
+	createAuditScope                 *connect.Client[orchestrator.CreateAuditScopeRequest, orchestrator.AuditScope]
+	getAuditScope                    *connect.Client[orchestrator.GetAuditScopeRequest, orchestrator.AuditScope]
+	listAuditScopes                  *connect.Client[orchestrator.ListAuditScopesRequest, orchestrator.ListAuditScopesResponse]
+	updateAuditScope                 *connect.Client[orchestrator.UpdateAuditScopeRequest, orchestrator.AuditScope]
+	removeAuditScope                 *connect.Client[orchestrator.RemoveAuditScopeRequest, emptypb.Empty]
+	getRuntimeInfo                   *connect.Client[common.GetRuntimeInfoRequest, common.Runtime]
 }
 
 // RegisterAssessmentTool calls confirmate.orchestrator.v1.Orchestrator.RegisterAssessmentTool.
@@ -770,34 +770,39 @@ func (c *orchestratorClient) Subscribe(ctx context.Context, req *connect.Request
 	return c.subscribe.CallServerStream(ctx, req)
 }
 
-// CreateCertificate calls confirmate.orchestrator.v1.Orchestrator.CreateCertificate.
-func (c *orchestratorClient) CreateCertificate(ctx context.Context, req *connect.Request[orchestrator.CreateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return c.createCertificate.CallUnary(ctx, req)
+// CreateComplianceAttestation calls
+// confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation.
+func (c *orchestratorClient) CreateComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return c.createComplianceAttestation.CallUnary(ctx, req)
 }
 
-// GetCertificate calls confirmate.orchestrator.v1.Orchestrator.GetCertificate.
-func (c *orchestratorClient) GetCertificate(ctx context.Context, req *connect.Request[orchestrator.GetCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return c.getCertificate.CallUnary(ctx, req)
+// GetComplianceAttestation calls confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation.
+func (c *orchestratorClient) GetComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return c.getComplianceAttestation.CallUnary(ctx, req)
 }
 
-// ListCertificates calls confirmate.orchestrator.v1.Orchestrator.ListCertificates.
-func (c *orchestratorClient) ListCertificates(ctx context.Context, req *connect.Request[orchestrator.ListCertificatesRequest]) (*connect.Response[orchestrator.ListCertificatesResponse], error) {
-	return c.listCertificates.CallUnary(ctx, req)
+// ListComplianceAttestations calls
+// confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations.
+func (c *orchestratorClient) ListComplianceAttestations(ctx context.Context, req *connect.Request[orchestrator.ListComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListComplianceAttestationsResponse], error) {
+	return c.listComplianceAttestations.CallUnary(ctx, req)
 }
 
-// ListPublicCertificates calls confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates.
-func (c *orchestratorClient) ListPublicCertificates(ctx context.Context, req *connect.Request[orchestrator.ListPublicCertificatesRequest]) (*connect.Response[orchestrator.ListPublicCertificatesResponse], error) {
-	return c.listPublicCertificates.CallUnary(ctx, req)
+// ListPublicComplianceAttestations calls
+// confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations.
+func (c *orchestratorClient) ListPublicComplianceAttestations(ctx context.Context, req *connect.Request[orchestrator.ListPublicComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], error) {
+	return c.listPublicComplianceAttestations.CallUnary(ctx, req)
 }
 
-// UpdateCertificate calls confirmate.orchestrator.v1.Orchestrator.UpdateCertificate.
-func (c *orchestratorClient) UpdateCertificate(ctx context.Context, req *connect.Request[orchestrator.UpdateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return c.updateCertificate.CallUnary(ctx, req)
+// UpdateComplianceAttestation calls
+// confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation.
+func (c *orchestratorClient) UpdateComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.UpdateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return c.updateComplianceAttestation.CallUnary(ctx, req)
 }
 
-// RemoveCertificate calls confirmate.orchestrator.v1.Orchestrator.RemoveCertificate.
-func (c *orchestratorClient) RemoveCertificate(ctx context.Context, req *connect.Request[orchestrator.RemoveCertificateRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.removeCertificate.CallUnary(ctx, req)
+// RemoveComplianceAttestation calls
+// confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation.
+func (c *orchestratorClient) RemoveComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.RemoveComplianceAttestationRequest]) (*connect.Response[emptypb.Empty], error) {
+	return c.removeComplianceAttestation.CallUnary(ctx, req)
 }
 
 // CreateCatalog calls confirmate.orchestrator.v1.Orchestrator.CreateCatalog.
@@ -930,18 +935,18 @@ type OrchestratorHandler interface {
 	GetMetricImplementation(context.Context, *connect.Request[orchestrator.GetMetricImplementationRequest]) (*connect.Response[assessment.MetricImplementation], error)
 	// Subscribes to change events in the orchestrator
 	Subscribe(context.Context, *connect.Request[orchestrator.SubscribeRequest], *connect.ServerStream[orchestrator.ChangeEvent]) error
-	// Creates a new certificate
-	CreateCertificate(context.Context, *connect.Request[orchestrator.CreateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Retrieves a certificate
-	GetCertificate(context.Context, *connect.Request[orchestrator.GetCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Lists all target certificates
-	ListCertificates(context.Context, *connect.Request[orchestrator.ListCertificatesRequest]) (*connect.Response[orchestrator.ListCertificatesResponse], error)
-	// Lists all target certificates without state history
-	ListPublicCertificates(context.Context, *connect.Request[orchestrator.ListPublicCertificatesRequest]) (*connect.Response[orchestrator.ListPublicCertificatesResponse], error)
-	// Updates an existing certificate
-	UpdateCertificate(context.Context, *connect.Request[orchestrator.UpdateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error)
-	// Removes a certificate
-	RemoveCertificate(context.Context, *connect.Request[orchestrator.RemoveCertificateRequest]) (*connect.Response[emptypb.Empty], error)
+	// Creates a new compliance attestation
+	CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Retrieves a compliance attestation
+	GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Lists all compliance attestations
+	ListComplianceAttestations(context.Context, *connect.Request[orchestrator.ListComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListComplianceAttestationsResponse], error)
+	// Lists all public compliance attestations without state history
+	ListPublicComplianceAttestations(context.Context, *connect.Request[orchestrator.ListPublicComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], error)
+	// Updates an existing compliance attestation
+	UpdateComplianceAttestation(context.Context, *connect.Request[orchestrator.UpdateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Removes a compliance attestation
+	RemoveComplianceAttestation(context.Context, *connect.Request[orchestrator.RemoveComplianceAttestationRequest]) (*connect.Response[emptypb.Empty], error)
 	// Creates a new security controls catalog
 	CreateCatalog(context.Context, *connect.Request[orchestrator.CreateCatalogRequest]) (*connect.Response[orchestrator.Catalog], error)
 	// Lists all security controls catalogs. Each catalog includes a list of its
@@ -1144,40 +1149,40 @@ func NewOrchestratorHandler(svc OrchestratorHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(orchestratorMethods.ByName("Subscribe")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorCreateCertificateHandler := connect.NewUnaryHandler(
-		OrchestratorCreateCertificateProcedure,
-		svc.CreateCertificate,
-		connect.WithSchema(orchestratorMethods.ByName("CreateCertificate")),
+	orchestratorCreateComplianceAttestationHandler := connect.NewUnaryHandler(
+		OrchestratorCreateComplianceAttestationProcedure,
+		svc.CreateComplianceAttestation,
+		connect.WithSchema(orchestratorMethods.ByName("CreateComplianceAttestation")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorGetCertificateHandler := connect.NewUnaryHandler(
-		OrchestratorGetCertificateProcedure,
-		svc.GetCertificate,
-		connect.WithSchema(orchestratorMethods.ByName("GetCertificate")),
+	orchestratorGetComplianceAttestationHandler := connect.NewUnaryHandler(
+		OrchestratorGetComplianceAttestationProcedure,
+		svc.GetComplianceAttestation,
+		connect.WithSchema(orchestratorMethods.ByName("GetComplianceAttestation")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorListCertificatesHandler := connect.NewUnaryHandler(
-		OrchestratorListCertificatesProcedure,
-		svc.ListCertificates,
-		connect.WithSchema(orchestratorMethods.ByName("ListCertificates")),
+	orchestratorListComplianceAttestationsHandler := connect.NewUnaryHandler(
+		OrchestratorListComplianceAttestationsProcedure,
+		svc.ListComplianceAttestations,
+		connect.WithSchema(orchestratorMethods.ByName("ListComplianceAttestations")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorListPublicCertificatesHandler := connect.NewUnaryHandler(
-		OrchestratorListPublicCertificatesProcedure,
-		svc.ListPublicCertificates,
-		connect.WithSchema(orchestratorMethods.ByName("ListPublicCertificates")),
+	orchestratorListPublicComplianceAttestationsHandler := connect.NewUnaryHandler(
+		OrchestratorListPublicComplianceAttestationsProcedure,
+		svc.ListPublicComplianceAttestations,
+		connect.WithSchema(orchestratorMethods.ByName("ListPublicComplianceAttestations")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorUpdateCertificateHandler := connect.NewUnaryHandler(
-		OrchestratorUpdateCertificateProcedure,
-		svc.UpdateCertificate,
-		connect.WithSchema(orchestratorMethods.ByName("UpdateCertificate")),
+	orchestratorUpdateComplianceAttestationHandler := connect.NewUnaryHandler(
+		OrchestratorUpdateComplianceAttestationProcedure,
+		svc.UpdateComplianceAttestation,
+		connect.WithSchema(orchestratorMethods.ByName("UpdateComplianceAttestation")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorRemoveCertificateHandler := connect.NewUnaryHandler(
-		OrchestratorRemoveCertificateProcedure,
-		svc.RemoveCertificate,
-		connect.WithSchema(orchestratorMethods.ByName("RemoveCertificate")),
+	orchestratorRemoveComplianceAttestationHandler := connect.NewUnaryHandler(
+		OrchestratorRemoveComplianceAttestationProcedure,
+		svc.RemoveComplianceAttestation,
+		connect.WithSchema(orchestratorMethods.ByName("RemoveComplianceAttestation")),
 		connect.WithHandlerOptions(opts...),
 	)
 	orchestratorCreateCatalogHandler := connect.NewUnaryHandler(
@@ -1318,18 +1323,18 @@ func NewOrchestratorHandler(svc OrchestratorHandler, opts ...connect.HandlerOpti
 			orchestratorGetMetricImplementationHandler.ServeHTTP(w, r)
 		case OrchestratorSubscribeProcedure:
 			orchestratorSubscribeHandler.ServeHTTP(w, r)
-		case OrchestratorCreateCertificateProcedure:
-			orchestratorCreateCertificateHandler.ServeHTTP(w, r)
-		case OrchestratorGetCertificateProcedure:
-			orchestratorGetCertificateHandler.ServeHTTP(w, r)
-		case OrchestratorListCertificatesProcedure:
-			orchestratorListCertificatesHandler.ServeHTTP(w, r)
-		case OrchestratorListPublicCertificatesProcedure:
-			orchestratorListPublicCertificatesHandler.ServeHTTP(w, r)
-		case OrchestratorUpdateCertificateProcedure:
-			orchestratorUpdateCertificateHandler.ServeHTTP(w, r)
-		case OrchestratorRemoveCertificateProcedure:
-			orchestratorRemoveCertificateHandler.ServeHTTP(w, r)
+		case OrchestratorCreateComplianceAttestationProcedure:
+			orchestratorCreateComplianceAttestationHandler.ServeHTTP(w, r)
+		case OrchestratorGetComplianceAttestationProcedure:
+			orchestratorGetComplianceAttestationHandler.ServeHTTP(w, r)
+		case OrchestratorListComplianceAttestationsProcedure:
+			orchestratorListComplianceAttestationsHandler.ServeHTTP(w, r)
+		case OrchestratorListPublicComplianceAttestationsProcedure:
+			orchestratorListPublicComplianceAttestationsHandler.ServeHTTP(w, r)
+		case OrchestratorUpdateComplianceAttestationProcedure:
+			orchestratorUpdateComplianceAttestationHandler.ServeHTTP(w, r)
+		case OrchestratorRemoveComplianceAttestationProcedure:
+			orchestratorRemoveComplianceAttestationHandler.ServeHTTP(w, r)
 		case OrchestratorCreateCatalogProcedure:
 			orchestratorCreateCatalogHandler.ServeHTTP(w, r)
 		case OrchestratorListCatalogsProcedure:
@@ -1471,28 +1476,28 @@ func (UnimplementedOrchestratorHandler) Subscribe(context.Context, *connect.Requ
 	return connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.Subscribe is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) CreateCertificate(context.Context, *connect.Request[orchestrator.CreateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.CreateCertificate is not implemented"))
+func (UnimplementedOrchestratorHandler) CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) GetCertificate(context.Context, *connect.Request[orchestrator.GetCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.GetCertificate is not implemented"))
+func (UnimplementedOrchestratorHandler) GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) ListCertificates(context.Context, *connect.Request[orchestrator.ListCertificatesRequest]) (*connect.Response[orchestrator.ListCertificatesResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.ListCertificates is not implemented"))
+func (UnimplementedOrchestratorHandler) ListComplianceAttestations(context.Context, *connect.Request[orchestrator.ListComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListComplianceAttestationsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.ListComplianceAttestations is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) ListPublicCertificates(context.Context, *connect.Request[orchestrator.ListPublicCertificatesRequest]) (*connect.Response[orchestrator.ListPublicCertificatesResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.ListPublicCertificates is not implemented"))
+func (UnimplementedOrchestratorHandler) ListPublicComplianceAttestations(context.Context, *connect.Request[orchestrator.ListPublicComplianceAttestationsRequest]) (*connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.ListPublicComplianceAttestations is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) UpdateCertificate(context.Context, *connect.Request[orchestrator.UpdateCertificateRequest]) (*connect.Response[orchestrator.Certificate], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.UpdateCertificate is not implemented"))
+func (UnimplementedOrchestratorHandler) UpdateComplianceAttestation(context.Context, *connect.Request[orchestrator.UpdateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.UpdateComplianceAttestation is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) RemoveCertificate(context.Context, *connect.Request[orchestrator.RemoveCertificateRequest]) (*connect.Response[emptypb.Empty], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.RemoveCertificate is not implemented"))
+func (UnimplementedOrchestratorHandler) RemoveComplianceAttestation(context.Context, *connect.Request[orchestrator.RemoveComplianceAttestationRequest]) (*connect.Response[emptypb.Empty], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.RemoveComplianceAttestation is not implemented"))
 }
 
 func (UnimplementedOrchestratorHandler) CreateCatalog(context.Context, *connect.Request[orchestrator.CreateCatalogRequest]) (*connect.Response[orchestrator.Catalog], error) {

--- a/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
+++ b/core/api/orchestrator/orchestratorconnect/orchestrator.connect.go
@@ -126,9 +126,9 @@ const (
 	OrchestratorGetMetricImplementationProcedure = "/confirmate.orchestrator.v1.Orchestrator/GetMetricImplementation"
 	// OrchestratorSubscribeProcedure is the fully-qualified name of the Orchestrator's Subscribe RPC.
 	OrchestratorSubscribeProcedure = "/confirmate.orchestrator.v1.Orchestrator/Subscribe"
-	// OrchestratorCreateComplianceAttestationProcedure is the fully-qualified name of the
-	// Orchestrator's CreateComplianceAttestation RPC.
-	OrchestratorCreateComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/CreateComplianceAttestation"
+	// OrchestratorInitiateComplianceAttestationProcedure is the fully-qualified name of the
+	// Orchestrator's InitiateComplianceAttestation RPC.
+	OrchestratorInitiateComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/InitiateComplianceAttestation"
 	// OrchestratorGetComplianceAttestationProcedure is the fully-qualified name of the Orchestrator's
 	// GetComplianceAttestation RPC.
 	OrchestratorGetComplianceAttestationProcedure = "/confirmate.orchestrator.v1.Orchestrator/GetComplianceAttestation"
@@ -246,8 +246,8 @@ type OrchestratorClient interface {
 	GetMetricImplementation(context.Context, *connect.Request[orchestrator.GetMetricImplementationRequest]) (*connect.Response[assessment.MetricImplementation], error)
 	// Subscribes to change events in the orchestrator
 	Subscribe(context.Context, *connect.Request[orchestrator.SubscribeRequest]) (*connect.ServerStreamForClient[orchestrator.ChangeEvent], error)
-	// Creates a new compliance attestation
-	CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Initiates a compliance attestation for a specific audit scope if not already started, otherwise returns the existing one
+	InitiateComplianceAttestation(context.Context, *connect.Request[orchestrator.InitiateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
 	// Retrieves a compliance attestation
 	GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
 	// Lists all compliance attestations
@@ -464,10 +464,10 @@ func NewOrchestratorClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(orchestratorMethods.ByName("Subscribe")),
 			connect.WithClientOptions(opts...),
 		),
-		createComplianceAttestation: connect.NewClient[orchestrator.CreateComplianceAttestationRequest, orchestrator.ComplianceAttestation](
+		initiateComplianceAttestation: connect.NewClient[orchestrator.InitiateComplianceAttestationRequest, orchestrator.ComplianceAttestation](
 			httpClient,
-			baseURL+OrchestratorCreateComplianceAttestationProcedure,
-			connect.WithSchema(orchestratorMethods.ByName("CreateComplianceAttestation")),
+			baseURL+OrchestratorInitiateComplianceAttestationProcedure,
+			connect.WithSchema(orchestratorMethods.ByName("InitiateComplianceAttestation")),
 			connect.WithClientOptions(opts...),
 		),
 		getComplianceAttestation: connect.NewClient[orchestrator.GetComplianceAttestationRequest, orchestrator.ComplianceAttestation](
@@ -615,7 +615,7 @@ type orchestratorClient struct {
 	updateMetricImplementation       *connect.Client[orchestrator.UpdateMetricImplementationRequest, assessment.MetricImplementation]
 	getMetricImplementation          *connect.Client[orchestrator.GetMetricImplementationRequest, assessment.MetricImplementation]
 	subscribe                        *connect.Client[orchestrator.SubscribeRequest, orchestrator.ChangeEvent]
-	createComplianceAttestation      *connect.Client[orchestrator.CreateComplianceAttestationRequest, orchestrator.ComplianceAttestation]
+	initiateComplianceAttestation    *connect.Client[orchestrator.InitiateComplianceAttestationRequest, orchestrator.ComplianceAttestation]
 	getComplianceAttestation         *connect.Client[orchestrator.GetComplianceAttestationRequest, orchestrator.ComplianceAttestation]
 	listComplianceAttestations       *connect.Client[orchestrator.ListComplianceAttestationsRequest, orchestrator.ListComplianceAttestationsResponse]
 	listPublicComplianceAttestations *connect.Client[orchestrator.ListPublicComplianceAttestationsRequest, orchestrator.ListPublicComplianceAttestationsResponse]
@@ -770,10 +770,10 @@ func (c *orchestratorClient) Subscribe(ctx context.Context, req *connect.Request
 	return c.subscribe.CallServerStream(ctx, req)
 }
 
-// CreateComplianceAttestation calls
-// confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation.
-func (c *orchestratorClient) CreateComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
-	return c.createComplianceAttestation.CallUnary(ctx, req)
+// InitiateComplianceAttestation calls
+// confirmate.orchestrator.v1.Orchestrator.InitiateComplianceAttestation.
+func (c *orchestratorClient) InitiateComplianceAttestation(ctx context.Context, req *connect.Request[orchestrator.InitiateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return c.initiateComplianceAttestation.CallUnary(ctx, req)
 }
 
 // GetComplianceAttestation calls confirmate.orchestrator.v1.Orchestrator.GetComplianceAttestation.
@@ -935,8 +935,8 @@ type OrchestratorHandler interface {
 	GetMetricImplementation(context.Context, *connect.Request[orchestrator.GetMetricImplementationRequest]) (*connect.Response[assessment.MetricImplementation], error)
 	// Subscribes to change events in the orchestrator
 	Subscribe(context.Context, *connect.Request[orchestrator.SubscribeRequest], *connect.ServerStream[orchestrator.ChangeEvent]) error
-	// Creates a new compliance attestation
-	CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
+	// Initiates a compliance attestation for a specific audit scope if not already started, otherwise returns the existing one
+	InitiateComplianceAttestation(context.Context, *connect.Request[orchestrator.InitiateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
 	// Retrieves a compliance attestation
 	GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error)
 	// Lists all compliance attestations
@@ -1149,10 +1149,10 @@ func NewOrchestratorHandler(svc OrchestratorHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(orchestratorMethods.ByName("Subscribe")),
 		connect.WithHandlerOptions(opts...),
 	)
-	orchestratorCreateComplianceAttestationHandler := connect.NewUnaryHandler(
-		OrchestratorCreateComplianceAttestationProcedure,
-		svc.CreateComplianceAttestation,
-		connect.WithSchema(orchestratorMethods.ByName("CreateComplianceAttestation")),
+	orchestratorInitiateComplianceAttestationHandler := connect.NewUnaryHandler(
+		OrchestratorInitiateComplianceAttestationProcedure,
+		svc.InitiateComplianceAttestation,
+		connect.WithSchema(orchestratorMethods.ByName("InitiateComplianceAttestation")),
 		connect.WithHandlerOptions(opts...),
 	)
 	orchestratorGetComplianceAttestationHandler := connect.NewUnaryHandler(
@@ -1323,8 +1323,8 @@ func NewOrchestratorHandler(svc OrchestratorHandler, opts ...connect.HandlerOpti
 			orchestratorGetMetricImplementationHandler.ServeHTTP(w, r)
 		case OrchestratorSubscribeProcedure:
 			orchestratorSubscribeHandler.ServeHTTP(w, r)
-		case OrchestratorCreateComplianceAttestationProcedure:
-			orchestratorCreateComplianceAttestationHandler.ServeHTTP(w, r)
+		case OrchestratorInitiateComplianceAttestationProcedure:
+			orchestratorInitiateComplianceAttestationHandler.ServeHTTP(w, r)
 		case OrchestratorGetComplianceAttestationProcedure:
 			orchestratorGetComplianceAttestationHandler.ServeHTTP(w, r)
 		case OrchestratorListComplianceAttestationsProcedure:
@@ -1476,8 +1476,8 @@ func (UnimplementedOrchestratorHandler) Subscribe(context.Context, *connect.Requ
 	return connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.Subscribe is not implemented"))
 }
 
-func (UnimplementedOrchestratorHandler) CreateComplianceAttestation(context.Context, *connect.Request[orchestrator.CreateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.CreateComplianceAttestation is not implemented"))
+func (UnimplementedOrchestratorHandler) InitiateComplianceAttestation(context.Context, *connect.Request[orchestrator.InitiateComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.orchestrator.v1.Orchestrator.InitiateComplianceAttestation is not implemented"))
 }
 
 func (UnimplementedOrchestratorHandler) GetComplianceAttestation(context.Context, *connect.Request[orchestrator.GetComplianceAttestationRequest]) (*connect.Response[orchestrator.ComplianceAttestation], error) {

--- a/core/api/orchestrator/request_extensions.go
+++ b/core/api/orchestrator/request_extensions.go
@@ -29,14 +29,14 @@ func (r *UpdateCatalogRequest) GetPayload() proto.Message {
 	return r.GetCatalog()
 }
 
-// GetPayload returns the embedded certificate from [CreateCertificateRequest].
-func (r *CreateCertificateRequest) GetPayload() proto.Message {
-	return r.GetCertificate()
+// GetPayload returns the embedded compliance attestation from [CreateComplianceAttestationRequest].
+func (r *CreateComplianceAttestationRequest) GetPayload() proto.Message {
+	return r.GetComplianceAttestation()
 }
 
-// GetPayload returns the embedded certificate from [UpdateCertificateRequest].
-func (r *UpdateCertificateRequest) GetPayload() proto.Message {
-	return r.GetCertificate()
+// GetPayload returns the embedded compliance attestation from [UpdateComplianceAttestationRequest].
+func (r *UpdateComplianceAttestationRequest) GetPayload() proto.Message {
+	return r.GetComplianceAttestation()
 }
 
 // GetPayload returns the embedded audit_scope from [CreateAuditScopeRequest].

--- a/core/api/orchestrator/request_extensions_test.go
+++ b/core/api/orchestrator/request_extensions_test.go
@@ -64,13 +64,13 @@ func TestGetPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "create certificate",
+			name: "create compliance attestation",
 			args: args{
 				get: func() proto.Message {
-					cert := &Certificate{Id: "cert-1"}
-					return (&CreateCertificateRequest{Certificate: cert}).GetPayload()
+					attestation := &ComplianceAttestation{Id: "cert-1"}
+					return (&CreateComplianceAttestationRequest{ComplianceAttestation: attestation}).GetPayload()
 				},
-				want: &Certificate{Id: "cert-1"},
+				want: &ComplianceAttestation{Id: "cert-1"},
 			},
 			want: func(t *testing.T, got proto.Message, msgAndArgs ...any) bool {
 				want := assert.Is[proto.Message](t, msgAndArgs[0])
@@ -78,13 +78,13 @@ func TestGetPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "update certificate",
+			name: "update compliance attestation",
 			args: args{
 				get: func() proto.Message {
-					cert := &Certificate{Id: "cert-2"}
-					return (&UpdateCertificateRequest{Certificate: cert}).GetPayload()
+					attestation := &ComplianceAttestation{Id: "cert-2"}
+					return (&UpdateComplianceAttestationRequest{ComplianceAttestation: attestation}).GetPayload()
 				},
-				want: &Certificate{Id: "cert-2"},
+				want: &ComplianceAttestation{Id: "cert-2"},
 			},
 			want: func(t *testing.T, got proto.Message, msgAndArgs ...any) bool {
 				want := assert.Is[proto.Message](t, msgAndArgs[0])

--- a/core/cli/commands/certificates.go
+++ b/core/cli/commands/certificates.go
@@ -32,7 +32,7 @@ func CertificatesListCommand() *cli.Command {
 		Flags: PaginationFlags(),
 		Action: func(ctx context.Context, c *cli.Command) error {
 			client := OrchestratorClient(ctx, c)
-			resp, err := client.ListCertificates(ctx, connect.NewRequest(&orchestrator.ListCertificatesRequest{
+			resp, err := client.ListComplianceAttestations(ctx, connect.NewRequest(&orchestrator.ListComplianceAttestationsRequest{
 				PageSize:  int32(c.Int("page-size")),
 				PageToken: c.String("page-token"),
 			}))
@@ -52,7 +52,7 @@ func CertificatesListPublicCommand() *cli.Command {
 		Flags:   PaginationFlags(),
 		Action: func(ctx context.Context, c *cli.Command) error {
 			client := OrchestratorClient(ctx, c)
-			resp, err := client.ListPublicCertificates(ctx, connect.NewRequest(&orchestrator.ListPublicCertificatesRequest{
+			resp, err := client.ListPublicComplianceAttestations(ctx, connect.NewRequest(&orchestrator.ListPublicComplianceAttestationsRequest{
 				PageSize:  int32(c.Int("page-size")),
 				PageToken: c.String("page-token"),
 			}))
@@ -76,8 +76,8 @@ func CertificatesGetCommand() *cli.Command {
 			certID := c.Args().Get(0)
 
 			client := OrchestratorClient(ctx, c)
-			resp, err := client.GetCertificate(ctx, connect.NewRequest(&orchestrator.GetCertificateRequest{
-				CertificateId: certID,
+			resp, err := client.GetComplianceAttestation(ctx, connect.NewRequest(&orchestrator.GetComplianceAttestationRequest{
+				ComplianceAttestationId: certID,
 			}))
 			if err != nil {
 				return err
@@ -100,8 +100,8 @@ func CertificatesRemoveCommand() *cli.Command {
 			certID := c.Args().Get(0)
 
 			client := OrchestratorClient(ctx, c)
-			_, err := client.RemoveCertificate(ctx, connect.NewRequest(&orchestrator.RemoveCertificateRequest{
-				CertificateId: certID,
+			_, err := client.RemoveComplianceAttestation(ctx, connect.NewRequest(&orchestrator.RemoveComplianceAttestationRequest{
+				ComplianceAttestationId: certID,
 			}))
 			if err != nil {
 				return err

--- a/core/cli/commands/certificates.go
+++ b/core/cli/commands/certificates.go
@@ -28,7 +28,7 @@ import (
 func CertificatesListCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "list",
-		Usage: "List all certificates",
+		Usage: "List all compliance attestations",
 		Flags: PaginationFlags(),
 		Action: func(ctx context.Context, c *cli.Command) error {
 			client := OrchestratorClient(ctx, c)
@@ -48,7 +48,7 @@ func CertificatesListPublicCommand() *cli.Command {
 	return &cli.Command{
 		Name:    "list-public",
 		Aliases: []string{"public"},
-		Usage:   "List all public certificates",
+		Usage:   "List all public compliance attestations",
 		Flags:   PaginationFlags(),
 		Action: func(ctx context.Context, c *cli.Command) error {
 			client := OrchestratorClient(ctx, c)
@@ -67,11 +67,11 @@ func CertificatesListPublicCommand() *cli.Command {
 func CertificatesGetCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "get",
-		Usage:     "Get a specific certificate by ID",
-		ArgsUsage: "<certificate-id>",
+		Usage:     "Get a specific compliance attestation by ID",
+		ArgsUsage: "<compliance-attestation-id>",
 		Action: func(ctx context.Context, c *cli.Command) error {
 			if c.Args().Len() < 1 {
-				return fmt.Errorf("certificate ID required")
+				return fmt.Errorf("compliance attestation ID required")
 			}
 			certID := c.Args().Get(0)
 
@@ -91,11 +91,11 @@ func CertificatesRemoveCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "remove",
 		Aliases:   []string{"rm"},
-		Usage:     "Delete a certificate by ID",
-		ArgsUsage: "<certificate-id>",
+		Usage:     "Delete a compliance attestation by ID",
+		ArgsUsage: "<compliance-attestation-id>",
 		Action: func(ctx context.Context, c *cli.Command) error {
 			if c.Args().Len() < 1 {
-				return fmt.Errorf("certificate ID required")
+				return fmt.Errorf("compliance attestation ID required")
 			}
 			certID := c.Args().Get(0)
 
@@ -106,7 +106,7 @@ func CertificatesRemoveCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Certificate %s deleted successfully\n", certID)
+			fmt.Printf("Compliance attestation %s deleted successfully\n", certID)
 			return nil
 		},
 	}

--- a/core/cli/commands/certificates_test.go
+++ b/core/cli/commands/certificates_test.go
@@ -47,6 +47,6 @@ func TestCertificatesCommands(t *testing.T) {
 	t.Run("remove", func(t *testing.T) {
 		output, err := commandstest.RunCLI(t, "certificates", "remove", orchestratortest.MockCertificateId2)
 		assert.NoError(t, err)
-		assert.Contains(t, output, "Certificate "+orchestratortest.MockCertificateId2+" deleted successfully")
+		assert.Contains(t, output, "Compliance attestation "+orchestratortest.MockCertificateId2+" deleted successfully")
 	})
 }

--- a/core/cli/commands/root.go
+++ b/core/cli/commands/root.go
@@ -130,7 +130,7 @@ func NewRootCommand() *cli.Command {
 			{
 				Name:    "certificates",
 				Aliases: []string{"certs"},
-				Usage:   "Certificate operations",
+				Usage:   "Compliance attestation operations",
 				Commands: []*cli.Command{
 					CertificatesListCommand(),
 					CertificatesListPublicCommand(),

--- a/core/service/authorization_test.go
+++ b/core/service/authorization_test.go
@@ -99,8 +99,8 @@ func TestCheckAccess_AutoTargetResolution(t *testing.T) {
 		{
 			name: "payload target id",
 			call: func(ctx context.Context, strategy *AuthorizationStrategyJWT) bool {
-				return CheckAccess(strategy, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, connect.NewRequest(&orchestrator.CreateCertificateRequest{
-					Certificate: &orchestrator.Certificate{TargetOfEvaluationId: "toe-1"},
+				return CheckAccess(strategy, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, connect.NewRequest(&orchestrator.CreateComplianceAttestationRequest{
+					ComplianceAttestation: &orchestrator.ComplianceAttestation{AuditScopeId: "11111111-1111-1111-1111-111111111111"},
 				}))
 			},
 			want: func(t *testing.T, got bool, _ ...any) bool {

--- a/core/service/authorization_test.go
+++ b/core/service/authorization_test.go
@@ -99,8 +99,8 @@ func TestCheckAccess_AutoTargetResolution(t *testing.T) {
 		{
 			name: "payload target id",
 			call: func(ctx context.Context, strategy *AuthorizationStrategyJWT) bool {
-				return CheckAccess(strategy, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, connect.NewRequest(&orchestrator.CreateComplianceAttestationRequest{
-					ComplianceAttestation: &orchestrator.ComplianceAttestation{AuditScopeId: "11111111-1111-1111-1111-111111111111"},
+				return CheckAccess(strategy, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, connect.NewRequest(&orchestrator.CreateAuditScopeRequest{
+					AuditScope: &orchestrator.AuditScope{TargetOfEvaluationId: "toe-1"},
 				}))
 			},
 			want: func(t *testing.T, got bool, _ ...any) bool {

--- a/core/service/orchestrator/certificates.go
+++ b/core/service/orchestrator/certificates.go
@@ -87,8 +87,12 @@ func (svc *Service) ListCertificates(
 	req *connect.Request[orchestrator.ListCertificatesRequest],
 ) (res *connect.Response[orchestrator.ListCertificatesResponse], err error) {
 	var (
-		certificates []*orchestrator.Certificate
-		npt          string
+		certificates  []*orchestrator.Certificate
+		npt           string
+		all           bool
+		allowed       []string
+		auditScopes   []*orchestrator.AuditScope
+		auditScopeIDs []string
 	)
 
 	// Validate the request
@@ -102,9 +106,23 @@ func (svc *Service) ListCertificates(
 		req.Msg.Asc = true
 	}
 
-	all, allowed := svc.allowedTargetOfEvaluations(ctx)
+	all, allowed = svc.allowedTargetOfEvaluations(ctx)
 	if !all {
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "target_of_evaluation_id IN ?", allowed)
+		err = svc.db.List(&auditScopes, "id", true, 0, -1, "target_of_evaluation_id IN ?", allowed)
+		if err = service.HandleDatabaseError(err); err != nil {
+			return nil, err
+		}
+
+		for _, auditScope := range auditScopes {
+			auditScopeIDs = append(auditScopeIDs, auditScope.Id)
+		}
+
+		if len(auditScopeIDs) == 0 {
+			res = connect.NewResponse(&orchestrator.ListCertificatesResponse{Certificates: []*orchestrator.Certificate{}})
+			return
+		}
+
+		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
 	} else {
 		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts)
 	}
@@ -125,8 +143,12 @@ func (svc *Service) ListPublicCertificates(
 	req *connect.Request[orchestrator.ListPublicCertificatesRequest],
 ) (res *connect.Response[orchestrator.ListPublicCertificatesResponse], err error) {
 	var (
-		certificates []*orchestrator.Certificate
-		npt          string
+		certificates  []*orchestrator.Certificate
+		npt           string
+		all           bool
+		allowed       []string
+		auditScopes   []*orchestrator.AuditScope
+		auditScopeIDs []string
 	)
 
 	// Validate the request
@@ -140,9 +162,23 @@ func (svc *Service) ListPublicCertificates(
 		req.Msg.Asc = true
 	}
 
-	all, allowed := svc.allowedTargetOfEvaluations(ctx)
+	all, allowed = svc.allowedTargetOfEvaluations(ctx)
 	if !all {
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "target_of_evaluation_id IN ?", allowed)
+		err = svc.db.List(&auditScopes, "id", true, 0, -1, "target_of_evaluation_id IN ?", allowed)
+		if err = service.HandleDatabaseError(err); err != nil {
+			return nil, err
+		}
+
+		for _, auditScope := range auditScopes {
+			auditScopeIDs = append(auditScopeIDs, auditScope.Id)
+		}
+
+		if len(auditScopeIDs) == 0 {
+			res = connect.NewResponse(&orchestrator.ListPublicCertificatesResponse{Certificates: []*orchestrator.Certificate{}})
+			return
+		}
+
+		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
 	} else {
 		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts)
 	}

--- a/core/service/orchestrator/certificates.go
+++ b/core/service/orchestrator/certificates.go
@@ -25,13 +25,13 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// CreateCertificate creates a new certificate.
-func (svc *Service) CreateCertificate(
+// CreateComplianceAttestation creates a new compliance attestation.
+func (svc *Service) CreateComplianceAttestation(
 	ctx context.Context,
-	req *connect.Request[orchestrator.CreateCertificateRequest],
-) (res *connect.Response[orchestrator.Certificate], err error) {
+	req *connect.Request[orchestrator.CreateComplianceAttestationRequest],
+) (res *connect.Response[orchestrator.ComplianceAttestation], err error) {
 	var (
-		cert *orchestrator.Certificate
+		attestation *orchestrator.ComplianceAttestation
 	)
 
 	// Validate the request
@@ -39,28 +39,28 @@ func (svc *Service) CreateCertificate(
 		return nil, err
 	}
 
-	cert = req.Msg.Certificate
+	attestation = req.Msg.ComplianceAttestation
 	if !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_CREATED, req) {
 		return nil, service.ErrPermissionDenied
 	}
 
-	// Persist the new certificate in the database
-	err = svc.db.Create(cert)
+	// Persist the new compliance attestation in the database
+	err = svc.db.Create(attestation)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
 
-	res = connect.NewResponse(cert)
+	res = connect.NewResponse(attestation)
 	return
 }
 
-// GetCertificate retrieves a certificate by ID.
-func (svc *Service) GetCertificate(
+// GetComplianceAttestation retrieves a compliance attestation by ID.
+func (svc *Service) GetComplianceAttestation(
 	ctx context.Context,
-	req *connect.Request[orchestrator.GetCertificateRequest],
-) (res *connect.Response[orchestrator.Certificate], err error) {
+	req *connect.Request[orchestrator.GetComplianceAttestationRequest],
+) (res *connect.Response[orchestrator.ComplianceAttestation], err error) {
 	var (
-		cert orchestrator.Certificate
+		attestation orchestrator.ComplianceAttestation
 	)
 
 	// Validate the request
@@ -68,26 +68,26 @@ func (svc *Service) GetCertificate(
 		return nil, err
 	}
 
-	err = svc.db.Get(&cert, "id = ?", req.Msg.CertificateId)
-	if err = service.HandleDatabaseError(err, service.ErrNotFound("certificate")); err != nil {
+	err = svc.db.Get(&attestation, "id = ?", req.Msg.ComplianceAttestationId)
+	if err = service.HandleDatabaseError(err, service.ErrNotFound("compliance attestation")); err != nil {
 		return nil, err
 	}
 
-	if !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_UNSPECIFIED, connect.NewRequest(&cert)) {
+	if !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_UNSPECIFIED, connect.NewRequest(&attestation)) {
 		return nil, service.ErrPermissionDenied
 	}
 
-	res = connect.NewResponse(&cert)
+	res = connect.NewResponse(&attestation)
 	return
 }
 
-// ListCertificates lists all certificates.
-func (svc *Service) ListCertificates(
+// ListComplianceAttestations lists all compliance attestations.
+func (svc *Service) ListComplianceAttestations(
 	ctx context.Context,
-	req *connect.Request[orchestrator.ListCertificatesRequest],
-) (res *connect.Response[orchestrator.ListCertificatesResponse], err error) {
+	req *connect.Request[orchestrator.ListComplianceAttestationsRequest],
+) (res *connect.Response[orchestrator.ListComplianceAttestationsResponse], err error) {
 	var (
-		certificates  []*orchestrator.Certificate
+		attestations  []*orchestrator.ComplianceAttestation
 		npt           string
 		all           bool
 		allowed       []string
@@ -118,32 +118,32 @@ func (svc *Service) ListCertificates(
 		}
 
 		if len(auditScopeIDs) == 0 {
-			res = connect.NewResponse(&orchestrator.ListCertificatesResponse{Certificates: []*orchestrator.Certificate{}})
+			res = connect.NewResponse(&orchestrator.ListComplianceAttestationsResponse{ComplianceAttestations: []*orchestrator.ComplianceAttestation{}})
 			return
 		}
 
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
+		attestations, npt, err = service.PaginateStorage[*orchestrator.ComplianceAttestation](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
 	} else {
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts)
+		attestations, npt, err = service.PaginateStorage[*orchestrator.ComplianceAttestation](req.Msg, svc.db, service.DefaultPaginationOpts)
 	}
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
 
-	res = connect.NewResponse(&orchestrator.ListCertificatesResponse{
-		Certificates:  certificates,
-		NextPageToken: npt,
+	res = connect.NewResponse(&orchestrator.ListComplianceAttestationsResponse{
+		ComplianceAttestations: attestations,
+		NextPageToken:          npt,
 	})
 	return
 }
 
-// ListPublicCertificates lists all certificates without state history.
-func (svc *Service) ListPublicCertificates(
+// ListPublicComplianceAttestations lists all compliance attestations without state history.
+func (svc *Service) ListPublicComplianceAttestations(
 	ctx context.Context,
-	req *connect.Request[orchestrator.ListPublicCertificatesRequest],
-) (res *connect.Response[orchestrator.ListPublicCertificatesResponse], err error) {
+	req *connect.Request[orchestrator.ListPublicComplianceAttestationsRequest],
+) (res *connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], err error) {
 	var (
-		certificates  []*orchestrator.Certificate
+		attestations  []*orchestrator.ComplianceAttestation
 		npt           string
 		all           bool
 		allowed       []string
@@ -174,80 +174,80 @@ func (svc *Service) ListPublicCertificates(
 		}
 
 		if len(auditScopeIDs) == 0 {
-			res = connect.NewResponse(&orchestrator.ListPublicCertificatesResponse{Certificates: []*orchestrator.Certificate{}})
+			res = connect.NewResponse(&orchestrator.ListPublicComplianceAttestationsResponse{ComplianceAttestations: []*orchestrator.ComplianceAttestation{}})
 			return
 		}
 
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
+		attestations, npt, err = service.PaginateStorage[*orchestrator.ComplianceAttestation](req.Msg, svc.db, service.DefaultPaginationOpts, "audit_scope_id IN ?", auditScopeIDs)
 	} else {
-		certificates, npt, err = service.PaginateStorage[*orchestrator.Certificate](req.Msg, svc.db, service.DefaultPaginationOpts)
+		attestations, npt, err = service.PaginateStorage[*orchestrator.ComplianceAttestation](req.Msg, svc.db, service.DefaultPaginationOpts)
 	}
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
 
-	// Remove state history from certificates
-	for i := range certificates {
-		certificates[i].States = nil
+	// Remove state history from compliance attestations
+	for i := range attestations {
+		attestations[i].States = nil
 	}
 
-	res = connect.NewResponse(&orchestrator.ListPublicCertificatesResponse{
-		Certificates:  certificates,
-		NextPageToken: npt,
+	res = connect.NewResponse(&orchestrator.ListPublicComplianceAttestationsResponse{
+		ComplianceAttestations: attestations,
+		NextPageToken:          npt,
 	})
 	return
 }
 
-// UpdateCertificate updates an existing certificate.
-func (svc *Service) UpdateCertificate(
+// UpdateComplianceAttestation updates an existing compliance attestation.
+func (svc *Service) UpdateComplianceAttestation(
 	ctx context.Context,
-	req *connect.Request[orchestrator.UpdateCertificateRequest],
-) (res *connect.Response[orchestrator.Certificate], err error) {
-	var cert *orchestrator.Certificate
+	req *connect.Request[orchestrator.UpdateComplianceAttestationRequest],
+) (res *connect.Response[orchestrator.ComplianceAttestation], err error) {
+	var attestation *orchestrator.ComplianceAttestation
 
 	// Validate the request
 	if err = service.Validate(req); err != nil {
 		return nil, err
 	}
 
-	cert = req.Msg.Certificate
-	if cert == nil || !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, req) {
+	attestation = req.Msg.ComplianceAttestation
+	if attestation == nil || !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_UPDATED, req) {
 		return nil, service.ErrPermissionDenied
 	}
 
-	// Update the certificate
-	err = svc.db.Update(cert, "id = ?", cert.Id)
-	if err = service.HandleDatabaseError(err, service.ErrNotFound("certificate")); err != nil {
+	// Update the compliance attestation
+	err = svc.db.Update(attestation, "id = ?", attestation.Id)
+	if err = service.HandleDatabaseError(err, service.ErrNotFound("compliance attestation")); err != nil {
 		return nil, err
 	}
 
-	res = connect.NewResponse(cert)
+	res = connect.NewResponse(attestation)
 	return
 }
 
-// RemoveCertificate removes a certificate by ID.
-func (svc *Service) RemoveCertificate(
+// RemoveComplianceAttestation removes a compliance attestation by ID.
+func (svc *Service) RemoveComplianceAttestation(
 	ctx context.Context,
-	req *connect.Request[orchestrator.RemoveCertificateRequest],
+	req *connect.Request[orchestrator.RemoveComplianceAttestationRequest],
 ) (res *connect.Response[emptypb.Empty], err error) {
 	// Validate the request
 	if err = service.Validate(req); err != nil {
 		return nil, err
 	}
 
-	var cert orchestrator.Certificate
+	var attestation orchestrator.ComplianceAttestation
 
-	err = svc.db.Get(&cert, "id = ?", req.Msg.CertificateId)
-	if err = service.HandleDatabaseError(err, service.ErrNotFound("certificate")); err != nil {
+	err = svc.db.Get(&attestation, "id = ?", req.Msg.ComplianceAttestationId)
+	if err = service.HandleDatabaseError(err, service.ErrNotFound("compliance attestation")); err != nil {
 		return nil, err
 	}
 
-	if !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_DELETED, connect.NewRequest(&cert)) {
+	if !service.CheckAccess(svc.authz, ctx, orchestrator.RequestType_REQUEST_TYPE_DELETED, connect.NewRequest(&attestation)) {
 		return nil, service.ErrPermissionDenied
 	}
 
-	// Delete the certificate
-	err = svc.db.Delete(&cert, "id = ?", req.Msg.CertificateId)
+	// Delete the compliance attestation
+	err = svc.db.Delete(&attestation, "id = ?", req.Msg.ComplianceAttestationId)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}

--- a/core/service/orchestrator/certificates_test.go
+++ b/core/service/orchestrator/certificates_test.go
@@ -96,7 +96,7 @@ func TestService_CreateCertificate(t *testing.T) {
 			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument) &&
-					assert.IsValidationError(t, err, "certificate.target_of_evaluation_id")
+					assert.IsValidationError(t, err, "certificate.audit_scope_id")
 			},
 			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool {
 				return true
@@ -107,9 +107,9 @@ func TestService_CreateCertificate(t *testing.T) {
 			args: args{
 				req: &orchestrator.CreateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockCertificate1.Id,
-						Name:                 orchestratortest.MockCertificate1.Name,
-						TargetOfEvaluationId: orchestratortest.MockCertificate1.TargetOfEvaluationId,
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         orchestratortest.MockCertificate1.Name,
+						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
 					},
 				},
 			},
@@ -171,9 +171,9 @@ func TestService_CreateCertificate_AuthorizationFailure(t *testing.T) {
 			args: args{
 				req: &orchestrator.CreateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockCertificate1.Id,
-						Name:                 orchestratortest.MockCertificate1.Name,
-						TargetOfEvaluationId: orchestratortest.MockCertificate1.TargetOfEvaluationId,
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         orchestratortest.MockCertificate1.Name,
+						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
 					},
 				},
 			},
@@ -330,7 +330,11 @@ func TestService_ListCertificates(t *testing.T) {
 			},
 			fields: fields{
 				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
+					err := d.Create(orchestratortest.MockAuditScope1)
+					assert.NoError(t, err)
+					err = d.Create(orchestratortest.MockAuditScope2)
+					assert.NoError(t, err)
+					err = d.Create(orchestratortest.MockCertificate1)
 					assert.NoError(t, err)
 					err = d.Create(orchestratortest.MockCertificate2)
 					assert.NoError(t, err)
@@ -392,18 +396,24 @@ func TestService_ListPublicCertificates(t *testing.T) {
 			},
 			fields: fields{
 				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(&orchestrator.Certificate{
-						Id:          orchestratortest.MockCertificate1.Id,
-						Name:        orchestratortest.MockCertificate1.Name,
-						Description: orchestratortest.MockCertificate1.Description,
-						States:      []*orchestrator.State{{State: "active"}},
+					err := d.Create(orchestratortest.MockAuditScope1)
+					assert.NoError(t, err)
+					err = d.Create(orchestratortest.MockAuditScope2)
+					assert.NoError(t, err)
+					err = d.Create(&orchestrator.Certificate{
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         orchestratortest.MockCertificate1.Name,
+						Description:  orchestratortest.MockCertificate1.Description,
+						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
+						States:       []*orchestrator.State{{State: orchestrator.AttestationState_ATTESTATION_STATE_ACTIVE}},
 					})
 					assert.NoError(t, err)
 					err = d.Create(&orchestrator.Certificate{
-						Id:          orchestratortest.MockCertificate2.Id,
-						Name:        orchestratortest.MockCertificate2.Name,
-						Description: orchestratortest.MockCertificate2.Description,
-						States:      []*orchestrator.State{{State: "pending"}},
+						Id:           orchestratortest.MockCertificate2.Id,
+						Name:         orchestratortest.MockCertificate2.Name,
+						Description:  orchestratortest.MockCertificate2.Description,
+						AuditScopeId: orchestratortest.MockCertificate2.AuditScopeId,
+						States:       []*orchestrator.State{{State: orchestrator.AttestationState_ATTESTATION_STATE_IN_PROGRESS}},
 					})
 					assert.NoError(t, err)
 				}),
@@ -456,10 +466,10 @@ func TestService_UpdateCertificate(t *testing.T) {
 			args: args{
 				req: &orchestrator.UpdateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockCertificate1.Id,
-						Name:                 "Updated Certificate",
-						Description:          "Updated description",
-						TargetOfEvaluationId: orchestratortest.MockToeId1,
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         "Updated Certificate",
+						Description:  "Updated description",
+						AuditScopeId: orchestratortest.MockScopeId1,
 					},
 				},
 			},
@@ -511,10 +521,10 @@ func TestService_UpdateCertificate(t *testing.T) {
 			args: args{
 				req: &orchestrator.UpdateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockNonExistentId,
-						Name:                 "Updated Certificate",
-						Description:          "Updated description",
-						TargetOfEvaluationId: orchestratortest.MockToeId1,
+						Id:           orchestratortest.MockNonExistentId,
+						Name:         "Updated Certificate",
+						Description:  "Updated description",
+						AuditScopeId: orchestratortest.MockScopeId1,
 					},
 				},
 			},
@@ -531,10 +541,10 @@ func TestService_UpdateCertificate(t *testing.T) {
 			args: args{
 				req: &orchestrator.UpdateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockCertificate1.Id,
-						Name:                 "Updated Certificate",
-						Description:          "Updated description",
-						TargetOfEvaluationId: orchestratortest.MockToeId1,
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         "Updated Certificate",
+						Description:  "Updated description",
+						AuditScopeId: orchestratortest.MockScopeId1,
 					},
 				},
 			},
@@ -552,10 +562,10 @@ func TestService_UpdateCertificate(t *testing.T) {
 			args: args{
 				req: &orchestrator.UpdateCertificateRequest{
 					Certificate: &orchestrator.Certificate{
-						Id:                   orchestratortest.MockCertificate1.Id,
-						Name:                 "Updated Certificate",
-						Description:          "Updated description",
-						TargetOfEvaluationId: orchestratortest.MockToeId1,
+						Id:           orchestratortest.MockCertificate1.Id,
+						Name:         "Updated Certificate",
+						Description:  "Updated description",
+						AuditScopeId: orchestratortest.MockScopeId1,
 					},
 				},
 			},

--- a/core/service/orchestrator/certificates_test.go
+++ b/core/service/orchestrator/certificates_test.go
@@ -30,9 +30,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func TestService_CreateCertificate(t *testing.T) {
+func TestService_CreateComplianceAttestation(t *testing.T) {
 	type args struct {
-		req *orchestrator.CreateCertificateRequest
+		req *orchestrator.CreateComplianceAttestationRequest
 	}
 	type fields struct {
 		db    persistence.DB
@@ -42,100 +42,63 @@ func TestService_CreateCertificate(t *testing.T) {
 		name    string
 		args    args
 		fields  fields
-		want    assert.Want[*connect.Response[orchestrator.Certificate]]
+		want    assert.Want[*connect.Response[orchestrator.ComplianceAttestation]]
 		wantErr assert.WantErr
 		wantDB  assert.Want[persistence.DB]
 	}{
 		{
-			name: "happy path",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{
-					Certificate: orchestratortest.MockCertificate1,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.Certificate], args ...any) bool {
+			name:   "happy path",
+			args:   args{req: &orchestrator.CreateComplianceAttestationRequest{ComplianceAttestation: orchestratortest.MockCertificate1}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables)},
+			want: func(t *testing.T, got *connect.Response[orchestrator.ComplianceAttestation], args ...any) bool {
 				assert.NotNil(t, got.Msg)
 				return assert.Equal(t, orchestratortest.MockCertificate1.Id, got.Msg.Id)
 			},
 			wantErr: assert.NoError,
 			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool {
-				cert := assert.InDB[orchestrator.Certificate](t, db, orchestratortest.MockCertificate1.Id)
-				assert.Equal(t, orchestratortest.MockCertificate1.Name, cert.Name)
+				attestation := assert.InDB[orchestrator.ComplianceAttestation](t, db, orchestratortest.MockCertificate1.Id)
+				assert.Equal(t, orchestratortest.MockCertificate1.Name, attestation.Name)
 				return true
 			},
 		},
 		{
-			name: "validation error - empty request",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			name:   "validation error - empty request",
+			args:   args{req: &orchestrator.CreateComplianceAttestationRequest{}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables)},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
 			},
-			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool {
-				return true
-			},
+			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool { return true },
 		},
 		{
-			name: "validation error - missing certificate",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{
-					Certificate: &orchestrator.Certificate{},
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			name:   "validation error - missing attestation",
+			args:   args{req: &orchestrator.CreateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{}}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables)},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument) &&
-					assert.IsValidationError(t, err, "certificate.audit_scope_id")
+					assert.IsValidationError(t, err, "compliance_attestation.audit_scope_id")
 			},
-			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool {
-				return true
-			},
+			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool { return true },
 		},
 		{
 			name: "authorization failure",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         orchestratortest.MockCertificate1.Name,
-						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
-					},
-				},
-			},
-			fields: fields{
-				db:    persistencetest.NewInMemoryDB(t, types, joinTables),
-				authz: &denyAuthorizationStrategy{},
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			args: args{req: &orchestrator.CreateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{
+				Id: orchestratortest.MockCertificate1.Id, Name: orchestratortest.MockCertificate1.Name, AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
+			}}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables), authz: &denyAuthorizationStrategy{}},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodePermissionDenied)
 			},
-			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool {
-				return true
-			},
+			wantDB: func(t *testing.T, db persistence.DB, msgAndArgs ...any) bool { return true },
 		},
 		{
-			name: "db error - unique constraint",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{
-					Certificate: orchestratortest.MockCertificate1,
-				},
-			},
-			fields: fields{
-				db: persistencetest.CreateErrorDB(t, persistence.ErrUniqueConstraintFailed, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			name:   "db error - unique constraint",
+			args:   args{req: &orchestrator.CreateComplianceAttestationRequest{ComplianceAttestation: orchestratortest.MockCertificate1}},
+			fields: fields{db: persistencetest.CreateErrorDB(t, persistence.ErrUniqueConstraintFailed, types, joinTables)},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeAlreadyExists)
 			},
@@ -145,11 +108,8 @@ func TestService_CreateCertificate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db:    tt.fields.db,
-				authz: tt.fields.authz,
-			}
-			res, err := svc.CreateCertificate(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.fields.db, authz: tt.fields.authz}
+			res, err := svc.CreateComplianceAttestation(context.Background(), connect.NewRequest(tt.args.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 			tt.wantDB(t, tt.fields.db)
@@ -157,9 +117,9 @@ func TestService_CreateCertificate(t *testing.T) {
 	}
 }
 
-func TestService_CreateCertificate_AuthorizationFailure(t *testing.T) {
+func TestService_CreateComplianceAttestation_AuthorizationFailure(t *testing.T) {
 	type args struct {
-		req *orchestrator.CreateCertificateRequest
+		req *orchestrator.CreateComplianceAttestationRequest
 	}
 	tests := []struct {
 		name    string
@@ -168,15 +128,9 @@ func TestService_CreateCertificate_AuthorizationFailure(t *testing.T) {
 	}{
 		{
 			name: "permission denied",
-			args: args{
-				req: &orchestrator.CreateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         orchestratortest.MockCertificate1.Name,
-						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
-					},
-				},
-			},
+			args: args{req: &orchestrator.CreateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{
+				Id: orchestratortest.MockCertificate1.Id, Name: orchestratortest.MockCertificate1.Name, AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
+			}}},
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodePermissionDenied)
 			},
@@ -185,21 +139,18 @@ func TestService_CreateCertificate_AuthorizationFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db:    persistencetest.NewInMemoryDB(t, types, joinTables),
-				authz: &denyAuthorizationStrategy{},
-			}
+			svc := &Service{db: persistencetest.NewInMemoryDB(t, types, joinTables), authz: &denyAuthorizationStrategy{}}
 
-			res, err := svc.CreateCertificate(context.Background(), connect.NewRequest(tt.args.req))
+			res, err := svc.CreateComplianceAttestation(context.Background(), connect.NewRequest(tt.args.req))
 			assert.Nil(t, res)
 			tt.wantErr(t, err)
 		})
 	}
 }
 
-func TestService_GetCertificate(t *testing.T) {
+func TestService_GetComplianceAttestation(t *testing.T) {
 	type args struct {
-		req *orchestrator.GetCertificateRequest
+		req *orchestrator.GetComplianceAttestationRequest
 	}
 	type fields struct {
 		db    persistence.DB
@@ -209,86 +160,36 @@ func TestService_GetCertificate(t *testing.T) {
 		name    string
 		args    args
 		fields  fields
-		want    assert.Want[*connect.Response[orchestrator.Certificate]]
+		want    assert.Want[*connect.Response[orchestrator.ComplianceAttestation]]
 		wantErr assert.WantErr
 	}{
 		{
 			name: "happy path",
-			args: args{
-				req: &orchestrator.GetCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-				}),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.Certificate], args ...any) bool {
+			args: args{req: &orchestrator.GetComplianceAttestationRequest{ComplianceAttestationId: orchestratortest.MockCertificate1.Id}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
+				err := d.Create(orchestratortest.MockCertificate1)
+				assert.NoError(t, err)
+			})},
+			want: func(t *testing.T, got *connect.Response[orchestrator.ComplianceAttestation], args ...any) bool {
 				assert.NotNil(t, got.Msg)
 				return assert.Equal(t, orchestratortest.MockCertificate1.Id, got.Msg.Id)
 			},
 			wantErr: assert.NoError,
 		},
 		{
-			name: "validation error - empty request",
-			args: args{
-				req: &orchestrator.GetCertificateRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			name:   "validation error - empty request",
+			args:   args{req: &orchestrator.GetComplianceAttestationRequest{}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables)},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
 			},
 		},
 		{
-			name: "not found",
-			args: args{
-				req: &orchestrator.GetCertificateRequest{
-					CertificateId: orchestratortest.MockNonExistentId,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
-			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
-				return assert.IsConnectError(t, err, connect.CodeNotFound)
-			},
-		},
-		{
-			name: "authorization failure",
-			args: args{
-				req: &orchestrator.GetCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-				}),
-				authz: &denyAuthorizationStrategy{},
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
-			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
-				return assert.IsConnectError(t, err, connect.CodePermissionDenied)
-			},
-		},
-		{
-			name: "db error - not found",
-			args: args{
-				req: &orchestrator.GetCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.GetErrorDB(t, persistence.ErrRecordNotFound, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			name:   "not found",
+			args:   args{req: &orchestrator.GetComplianceAttestationRequest{ComplianceAttestationId: orchestratortest.MockNonExistentId}},
+			fields: fields{db: persistencetest.NewInMemoryDB(t, types, joinTables)},
+			want:   assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeNotFound)
 			},
@@ -297,134 +198,89 @@ func TestService_GetCertificate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db:    tt.fields.db,
-				authz: tt.fields.authz,
-			}
-			res, err := svc.GetCertificate(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.fields.db, authz: tt.fields.authz}
+			res, err := svc.GetComplianceAttestation(context.Background(), connect.NewRequest(tt.args.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 		})
 	}
 }
 
-func TestService_ListCertificates(t *testing.T) {
-	type args struct {
-		req *orchestrator.ListCertificatesRequest
-	}
-	type fields struct {
-		db    persistence.DB
-		authz service.AuthorizationStrategy
-	}
+func TestService_ListComplianceAttestations(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    args
-		fields  fields
-		want    assert.Want[*connect.Response[orchestrator.ListCertificatesResponse]]
+		req     *orchestrator.ListComplianceAttestationsRequest
+		db      persistence.DB
+		want    assert.Want[*connect.Response[orchestrator.ListComplianceAttestationsResponse]]
 		wantErr assert.WantErr
 	}{
 		{
 			name: "list all",
-			args: args{
-				req: &orchestrator.ListCertificatesRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockAuditScope1)
-					assert.NoError(t, err)
-					err = d.Create(orchestratortest.MockAuditScope2)
-					assert.NoError(t, err)
-					err = d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-					err = d.Create(orchestratortest.MockCertificate2)
-					assert.NoError(t, err)
-				}),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.ListCertificatesResponse], args ...any) bool {
+			req:  &orchestrator.ListComplianceAttestationsRequest{},
+			db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
+				err := d.Create(orchestratortest.MockAuditScope1)
+				assert.NoError(t, err)
+				err = d.Create(orchestratortest.MockAuditScope2)
+				assert.NoError(t, err)
+				err = d.Create(orchestratortest.MockCertificate1)
+				assert.NoError(t, err)
+				err = d.Create(orchestratortest.MockCertificate2)
+				assert.NoError(t, err)
+			}),
+			want: func(t *testing.T, got *connect.Response[orchestrator.ListComplianceAttestationsResponse], args ...any) bool {
 				assert.NotNil(t, got.Msg)
-				return assert.Equal(t, 2, len(got.Msg.Certificates))
+				return assert.Equal(t, 2, len(got.Msg.ComplianceAttestations))
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "empty list",
-			args: args{
-				req: &orchestrator.ListCertificatesRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.ListCertificatesResponse], args ...any) bool {
+			req:  &orchestrator.ListComplianceAttestationsRequest{},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables),
+			want: func(t *testing.T, got *connect.Response[orchestrator.ListComplianceAttestationsResponse], args ...any) bool {
 				assert.NotNil(t, got.Msg)
-				return assert.Equal(t, 0, len(got.Msg.Certificates))
+				return assert.Equal(t, 0, len(got.Msg.ComplianceAttestations))
 			},
 			wantErr: assert.NoError,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db: tt.fields.db,
-			}
-			res, err := svc.ListCertificates(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.db}
+			res, err := svc.ListComplianceAttestations(context.Background(), connect.NewRequest(tt.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 		})
 	}
 }
 
-func TestService_ListPublicCertificates(t *testing.T) {
-	type args struct {
-		req *orchestrator.ListPublicCertificatesRequest
-	}
-	type fields struct {
-		db    persistence.DB
-		authz service.AuthorizationStrategy
-	}
+func TestService_ListPublicComplianceAttestations(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    args
-		fields  fields
-		want    assert.Want[*connect.Response[orchestrator.ListPublicCertificatesResponse]]
+		req     *orchestrator.ListPublicComplianceAttestationsRequest
+		db      persistence.DB
+		want    assert.Want[*connect.Response[orchestrator.ListPublicComplianceAttestationsResponse]]
 		wantErr assert.WantErr
 	}{
 		{
-			name: "list all public certificates",
-			args: args{
-				req: &orchestrator.ListPublicCertificatesRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockAuditScope1)
-					assert.NoError(t, err)
-					err = d.Create(orchestratortest.MockAuditScope2)
-					assert.NoError(t, err)
-					err = d.Create(&orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         orchestratortest.MockCertificate1.Name,
-						Description:  orchestratortest.MockCertificate1.Description,
-						AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId,
-						States:       []*orchestrator.State{{State: orchestrator.AttestationState_ATTESTATION_STATE_ACTIVE}},
-					})
-					assert.NoError(t, err)
-					err = d.Create(&orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate2.Id,
-						Name:         orchestratortest.MockCertificate2.Name,
-						Description:  orchestratortest.MockCertificate2.Description,
-						AuditScopeId: orchestratortest.MockCertificate2.AuditScopeId,
-						States:       []*orchestrator.State{{State: orchestrator.AttestationState_ATTESTATION_STATE_IN_PROGRESS}},
-					})
-					assert.NoError(t, err)
-				}),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.ListPublicCertificatesResponse], args ...any) bool {
-				if !assert.NotNil(t, got.Msg) || !assert.Equal(t, 2, len(got.Msg.Certificates)) {
+			name: "list all public attestations",
+			req:  &orchestrator.ListPublicComplianceAttestationsRequest{},
+			db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
+				err := d.Create(orchestratortest.MockAuditScope1)
+				assert.NoError(t, err)
+				err = d.Create(orchestratortest.MockAuditScope2)
+				assert.NoError(t, err)
+				err = d.Create(&orchestrator.ComplianceAttestation{Id: orchestratortest.MockCertificate1.Id, Name: orchestratortest.MockCertificate1.Name, Description: orchestratortest.MockCertificate1.Description, AuditScopeId: orchestratortest.MockCertificate1.AuditScopeId, States: []*orchestrator.ComplianceAttestationState{{State: orchestrator.AttestationState_ATTESTATION_STATE_ACTIVE}}})
+				assert.NoError(t, err)
+				err = d.Create(&orchestrator.ComplianceAttestation{Id: orchestratortest.MockCertificate2.Id, Name: orchestratortest.MockCertificate2.Name, Description: orchestratortest.MockCertificate2.Description, AuditScopeId: orchestratortest.MockCertificate2.AuditScopeId, States: []*orchestrator.ComplianceAttestationState{{State: orchestrator.AttestationState_ATTESTATION_STATE_IN_PROGRESS}}})
+				assert.NoError(t, err)
+			}),
+			want: func(t *testing.T, got *connect.Response[orchestrator.ListPublicComplianceAttestationsResponse], args ...any) bool {
+				if !assert.NotNil(t, got.Msg) || !assert.Equal(t, 2, len(got.Msg.ComplianceAttestations)) {
 					return false
 				}
-				// Verify that states are removed
-				for _, cert := range got.Msg.Certificates {
-					if !assert.Nil(t, cert.States) {
+				for _, att := range got.Msg.ComplianceAttestations {
+					if !assert.Nil(t, att.States) {
 						return false
 					}
 				}
@@ -433,53 +289,30 @@ func TestService_ListPublicCertificates(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db: tt.fields.db,
-			}
-			res, err := svc.ListPublicCertificates(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.db}
+			res, err := svc.ListPublicComplianceAttestations(context.Background(), connect.NewRequest(tt.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 		})
 	}
 }
 
-func TestService_UpdateCertificate(t *testing.T) {
-	type args struct {
-		req *orchestrator.UpdateCertificateRequest
-	}
-	type fields struct {
-		db    persistence.DB
-		authz service.AuthorizationStrategy
-	}
+func TestService_UpdateComplianceAttestation(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    args
-		fields  fields
-		want    assert.Want[*connect.Response[orchestrator.Certificate]]
+		req     *orchestrator.UpdateComplianceAttestationRequest
+		db      persistence.DB
+		authz   service.AuthorizationStrategy
+		want    assert.Want[*connect.Response[orchestrator.ComplianceAttestation]]
 		wantErr assert.WantErr
 	}{
 		{
 			name: "happy path",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         "Updated Certificate",
-						Description:  "Updated description",
-						AuditScopeId: orchestratortest.MockScopeId1,
-					},
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-				}),
-			},
-			want: func(t *testing.T, got *connect.Response[orchestrator.Certificate], args ...any) bool {
+			req:  &orchestrator.UpdateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{Id: orchestratortest.MockCertificate1.Id, Name: "Updated Certificate", Description: "Updated description", AuditScopeId: orchestratortest.MockScopeId1}},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) { err := d.Create(orchestratortest.MockCertificate1); assert.NoError(t, err) }),
+			want: func(t *testing.T, got *connect.Response[orchestrator.ComplianceAttestation], args ...any) bool {
 				assert.NotNil(t, got.Msg)
 				return assert.Equal(t, "Updated Certificate", got.Msg.Name)
 			},
@@ -487,139 +320,78 @@ func TestService_UpdateCertificate(t *testing.T) {
 		},
 		{
 			name: "validation error - empty request",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			req:  &orchestrator.UpdateComplianceAttestationRequest{},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables),
+			want: assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
 			},
 		},
 		{
 			name: "validation error - missing id",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Name: "Updated Certificate",
-					},
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			req:  &orchestrator.UpdateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{Name: "Updated Certificate"}},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables),
+			want: assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument) &&
-					assert.IsValidationError(t, err, "certificate.id")
+					assert.IsValidationError(t, err, "compliance_attestation.id")
 			},
 		},
 		{
 			name: "not found",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockNonExistentId,
-						Name:         "Updated Certificate",
-						Description:  "Updated description",
-						AuditScopeId: orchestratortest.MockScopeId1,
-					},
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			req: &orchestrator.UpdateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{
+				Id: orchestratortest.MockNonExistentId, Name: "Updated Certificate", Description: "Updated description", AuditScopeId: orchestratortest.MockScopeId1}},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables),
+			want: assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeNotFound)
 			},
 		},
 		{
 			name: "authorization failure",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         "Updated Certificate",
-						Description:  "Updated description",
-						AuditScopeId: orchestratortest.MockScopeId1,
-					},
-				},
-			},
-			fields: fields{
-				db:    persistencetest.NewInMemoryDB(t, types, joinTables),
-				authz: &denyAuthorizationStrategy{},
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			req: &orchestrator.UpdateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{
+				Id: orchestratortest.MockCertificate1.Id, Name: "Updated Certificate", Description: "Updated description", AuditScopeId: orchestratortest.MockScopeId1}},
+			db:    persistencetest.NewInMemoryDB(t, types, joinTables),
+			authz: &denyAuthorizationStrategy{},
+			want:  assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodePermissionDenied)
 			},
 		},
 		{
 			name: "db error - constraint",
-			args: args{
-				req: &orchestrator.UpdateCertificateRequest{
-					Certificate: &orchestrator.Certificate{
-						Id:           orchestratortest.MockCertificate1.Id,
-						Name:         "Updated Certificate",
-						Description:  "Updated description",
-						AuditScopeId: orchestratortest.MockScopeId1,
-					},
-				},
-			},
-			fields: fields{
-				db: persistencetest.UpdateErrorDB(t, persistence.ErrConstraintFailed, types, joinTables),
-			},
-			want: assert.Nil[*connect.Response[orchestrator.Certificate]],
+			req: &orchestrator.UpdateComplianceAttestationRequest{ComplianceAttestation: &orchestrator.ComplianceAttestation{
+				Id: orchestratortest.MockCertificate1.Id, Name: "Updated Certificate", Description: "Updated description", AuditScopeId: orchestratortest.MockScopeId1}},
+			db:   persistencetest.UpdateErrorDB(t, persistence.ErrConstraintFailed, types, joinTables),
+			want: assert.Nil[*connect.Response[orchestrator.ComplianceAttestation]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db:    tt.fields.db,
-				authz: tt.fields.authz,
-			}
-			res, err := svc.UpdateCertificate(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.db, authz: tt.authz}
+			res, err := svc.UpdateComplianceAttestation(context.Background(), connect.NewRequest(tt.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 		})
 	}
 }
 
-func TestService_RemoveCertificate(t *testing.T) {
-	type args struct {
-		req *orchestrator.RemoveCertificateRequest
-	}
-	type fields struct {
-		db    persistence.DB
-		authz service.AuthorizationStrategy
-	}
+func TestService_RemoveComplianceAttestation(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    args
-		fields  fields
+		req     *orchestrator.RemoveComplianceAttestationRequest
+		db      persistence.DB
+		authz   service.AuthorizationStrategy
 		want    assert.Want[*connect.Response[emptypb.Empty]]
 		wantErr assert.WantErr
 	}{
 		{
 			name: "happy path",
-			args: args{
-				req: &orchestrator.RemoveCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-				}),
-			},
+			req:  &orchestrator.RemoveComplianceAttestationRequest{ComplianceAttestationId: orchestratortest.MockCertificate1.Id},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) { err := d.Create(orchestratortest.MockCertificate1); assert.NoError(t, err) }),
 			want: func(t *testing.T, got *connect.Response[emptypb.Empty], args ...any) bool {
 				return assert.NotNil(t, got.Msg)
 			},
@@ -627,12 +399,8 @@ func TestService_RemoveCertificate(t *testing.T) {
 		},
 		{
 			name: "validation error - empty request",
-			args: args{
-				req: &orchestrator.RemoveCertificateRequest{},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables),
-			},
+			req:  &orchestrator.RemoveComplianceAttestationRequest{},
+			db:   persistencetest.NewInMemoryDB(t, types, joinTables),
 			want: assert.Nil[*connect.Response[emptypb.Empty]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
@@ -640,47 +408,31 @@ func TestService_RemoveCertificate(t *testing.T) {
 		},
 		{
 			name: "authorization failure",
-			args: args{
-				req: &orchestrator.RemoveCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					err := d.Create(orchestratortest.MockCertificate1)
-					assert.NoError(t, err)
-				}),
-				authz: &denyAuthorizationStrategy{},
-			},
-			want: assert.Nil[*connect.Response[emptypb.Empty]],
+			req:  &orchestrator.RemoveComplianceAttestationRequest{ComplianceAttestationId: orchestratortest.MockCertificate1.Id},
+			db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
+				err := d.Create(orchestratortest.MockCertificate1)
+				assert.NoError(t, err)
+			}),
+			authz: &denyAuthorizationStrategy{},
+			want:  assert.Nil[*connect.Response[emptypb.Empty]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodePermissionDenied)
 			},
 		},
 		{
 			name: "db error - not found",
-			args: args{
-				req: &orchestrator.RemoveCertificateRequest{
-					CertificateId: orchestratortest.MockCertificate1.Id,
-				},
-			},
-			fields: fields{
-				db: persistencetest.GetErrorDB(t, persistence.ErrRecordNotFound, types, joinTables),
-			},
+			req:  &orchestrator.RemoveComplianceAttestationRequest{ComplianceAttestationId: orchestratortest.MockCertificate1.Id},
+			db:   persistencetest.GetErrorDB(t, persistence.ErrRecordNotFound, types, joinTables),
 			want: assert.Nil[*connect.Response[emptypb.Empty]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeNotFound)
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				db:    tt.fields.db,
-				authz: tt.fields.authz,
-			}
-			res, err := svc.RemoveCertificate(context.Background(), connect.NewRequest(tt.args.req))
+			svc := &Service{db: tt.db, authz: tt.authz}
+			res, err := svc.RemoveComplianceAttestation(context.Background(), connect.NewRequest(tt.req))
 			tt.want(t, res)
 			tt.wantErr(t, err)
 		})

--- a/core/service/orchestrator/db.go
+++ b/core/service/orchestrator/db.go
@@ -24,8 +24,8 @@ import (
 // types contains all Orchestrator types that we need to auto-migrate into database tables
 var types = []any{
 	&orchestrator.TargetOfEvaluation{},
-	&orchestrator.Certificate{},
-	&orchestrator.State{},
+	&orchestrator.ComplianceAttestation{},
+	&orchestrator.ComplianceAttestationState{},
 	&orchestrator.Catalog{},
 	&orchestrator.Category{},
 	&orchestrator.Control{},

--- a/core/service/orchestrator/events_test.go
+++ b/core/service/orchestrator/events_test.go
@@ -36,8 +36,8 @@ import (
 // types contains all Orchestrator types that we need to auto-migrate into database tables
 var testTypes = []any{
 	&orchestrator.TargetOfEvaluation{},
-	&orchestrator.Certificate{},
-	&orchestrator.State{},
+	&orchestrator.ComplianceAttestation{},
+	&orchestrator.ComplianceAttestationState{},
 	&orchestrator.Catalog{},
 	&orchestrator.Category{},
 	&orchestrator.Control{},

--- a/core/service/orchestrator/orchestratortest/mock.go
+++ b/core/service/orchestrator/orchestratortest/mock.go
@@ -200,16 +200,16 @@ var (
 
 	// Mock Certificates
 	MockCertificate1 = &orchestrator.Certificate{
-		Id:                   MockCertificateId1,
-		Name:                 "Mock Certificate 1",
-		Description:          "Mock certificate description 1",
-		TargetOfEvaluationId: MockToeId1,
+		Id:           MockCertificateId1,
+		Name:         "Mock Certificate 1",
+		Description:  "Mock certificate description 1",
+		AuditScopeId: MockScopeId1,
 	}
 	MockCertificate2 = &orchestrator.Certificate{
-		Id:                   MockCertificateId2,
-		Name:                 "Mock Certificate 2",
-		Description:          "Mock certificate description 2",
-		TargetOfEvaluationId: MockToeId2,
+		Id:           MockCertificateId2,
+		Name:         "Mock Certificate 2",
+		Description:  "Mock certificate description 2",
+		AuditScopeId: MockScopeId2,
 	}
 
 	// Mock Assessment Tools

--- a/core/service/orchestrator/orchestratortest/mock.go
+++ b/core/service/orchestrator/orchestratortest/mock.go
@@ -199,13 +199,13 @@ var (
 	}
 
 	// Mock Certificates
-	MockCertificate1 = &orchestrator.Certificate{
+	MockCertificate1 = &orchestrator.ComplianceAttestation{
 		Id:           MockCertificateId1,
 		Name:         "Mock Certificate 1",
 		Description:  "Mock certificate description 1",
 		AuditScopeId: MockScopeId1,
 	}
-	MockCertificate2 = &orchestrator.Certificate{
+	MockCertificate2 = &orchestrator.ComplianceAttestation{
 		Id:           MockCertificateId2,
 		Name:         "Mock Certificate 2",
 		Description:  "Mock certificate description 2",


### PR DESCRIPTION
# Summary
This PR establishes the baseline API refactor in orchestrator.proto for compliance attestations. In particular we want to avoid the term certificate because not all standards result in a certificate but, e.g.  in an attestation.
# Changes
- **rename certificate resources to ComplianceAttestation**
- rename related RPCs, requests, and responses
- replace target_of_evaluation_id with audit_scope_id
- add ComplianceAttestationType
- add AttestationState
- add ComplianceAttestationState
- add attestation metadata fields such as:
  - attestation_type
  - issued_at
  - valid_from
  - valid_until
  - certification_body
  - auditor
  - compliance_status
- add baseline filter shapes to attestation list requests
- deprecate legacy string date fields:
  - issue_date
  - expiration_date
- align comments and terminology to “compliance attestation”
- regenerate protobuf/OpenAPI-related artifacts