### PR TITLE
Orchestrator: Fix ListAssessmentResults (orderBy)

### DIFF
--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -121,7 +121,7 @@ func (svc *Service) ListAssessmentResults(
 
 	// Set default ordering
 	if req.Msg.OrderBy == "" {
-		req.Msg.OrderBy = "timestamp"
+		req.Msg.OrderBy = "created_at"
 		req.Msg.Asc = false
 	}
 


### PR DESCRIPTION
Closes #191 

The `orderBy` statement wrongly used `timestamp` as field which does not exist:
https://github.com/confirmate/confirmate/blob/90886e2cf87be64e979b63e29c45989469f2fa6f/core/service/orchestrator/assessment_results.go#L122-L126
The actuall field is `created_at`.

Note: It is only failing in prod with Postgres. Using RamSQL the error isn't apparent, to the contrary: All assessment results will just be listed and I guess the orderBy is ignored in RamSQL when the orderBy field does not exist (my local testing confirmed that).