### PR TITLE
service: fix stream ports

### DIFF
--- a/core/service/assessment/assessment.go
+++ b/core/service/assessment/assessment.go
@@ -45,7 +45,7 @@ var (
 	logger *slog.Logger
 )
 
-const DefaultOrchestratorURL = "http://localhost:9090"
+const DefaultOrchestratorURL = "http://localhost:8080"
 
 // DefaultConfig is the default configuration for the assessment [Service].
 var DefaultConfig = Config{

--- a/core/service/evaluation/service.go
+++ b/core/service/evaluation/service.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	DefaultOrchestratorURL = "http://localhost:9090"
+	DefaultOrchestratorURL = "http://localhost:8080"
 
 	// defaultInterval is the default interval time for the scheduler. If no interval is set in the StartEvaluationRequest, the default value is taken.
 	defaultInterval int = 5

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	DefaultAssessmentURL     = "http://localhost:9090"
+	DefaultAssessmentURL     = "http://localhost:8080"
 	defaultEvidenceQueueSize = 1024
 )
 


### PR DESCRIPTION
The default stream ports were wrong (9090 instead of 8080), causing weird `envelope failed` messages.