### PR TITLE
policies: fix metric config skipping

### DIFF
--- a/core/policies/rego.go
+++ b/core/policies/rego.go
@@ -225,7 +225,7 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, r ontology.IsResource, rel
 				// Try to check if the metric implementation just does not exist.
 				if connect.CodeOf(err) == connect.CodeNotFound &&
 					(strings.Contains(err.Error(), "implementation for metric not found") ||
-						strings.Contains(err.Error(), "metric configuration not found for metric")) {
+						strings.Contains(err.Error(), "metric configuration not found")) {
 					continue
 				}
 

--- a/core/policies/rego_test.go
+++ b/core/policies/rego_test.go
@@ -16,6 +16,7 @@
 package policies
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -33,7 +34,41 @@ import (
 	"confirmate.io/core/service/evidence/evidencetest"
 	"confirmate.io/core/util/assert"
 	"confirmate.io/core/util/prototest"
+	"connectrpc.com/connect"
 )
+
+type metricsErrorSource struct{}
+
+func (m *metricsErrorSource) Metrics() (metrics []*assessment.Metric, err error) {
+	return nil, errors.New("boom")
+}
+
+func (m *metricsErrorSource) MetricConfiguration(targetID string, metric *assessment.Metric) (cfg *assessment.MetricConfiguration, err error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *metricsErrorSource) MetricImplementation(lang assessment.MetricImplementation_Language, metric *assessment.Metric) (impl *assessment.MetricImplementation, err error) {
+	return nil, errors.New("not implemented")
+}
+
+type missingConfigSource struct{}
+
+func (m *missingConfigSource) Metrics() (metrics []*assessment.Metric, err error) {
+	return []*assessment.Metric{{
+		Id:       "metric-1",
+		Name:     "MetricOne",
+		Category: "Category",
+	}}, nil
+}
+
+func (m *missingConfigSource) MetricConfiguration(targetID string, metric *assessment.Metric) (cfg *assessment.MetricConfiguration, err error) {
+	err = connect.NewError(connect.CodeNotFound, errors.New("metric configuration not found for target"))
+	return nil, err
+}
+
+func (m *missingConfigSource) MetricImplementation(lang assessment.MetricImplementation_Language, metric *assessment.Metric) (impl *assessment.MetricImplementation, err error) {
+	return nil, errors.New("not implemented")
+}
 
 func Test_regoEval_Eval(t *testing.T) {
 
@@ -381,6 +416,56 @@ func Test_regoEval_Eval(t *testing.T) {
 			assert.Equal(t, tt.compliant, compliants)
 		})
 	}
+}
+
+func Test_regoEval_Eval_MetricsError(t *testing.T) {
+	var (
+		pe      *regoEval
+		source  MetricsSource
+		results []*CombinedResult
+		err     error
+	)
+
+	pe = &regoEval{
+		qc:   newQueryCache(),
+		mrtc: &metricsCache{m: make(map[string][]*assessment.Metric)},
+		pkg:  DefaultRegoPackage,
+	}
+	source = &metricsErrorSource{}
+
+	results, err = pe.Eval(&evidence.Evidence{
+		Id:                   "11111111-1111-1111-1111-111111111111",
+		ToolId:               "tool-a",
+		TargetOfEvaluationId: "00000000-0000-0000-0000-000000000000",
+	}, &ontology.VirtualMachine{Id: "vm-1"}, nil, source)
+
+	assert.Nil(t, results)
+	assert.ErrorContains(t, err, "could not retrieve metric definitions")
+}
+
+func Test_regoEval_Eval_SkipMissingMetricConfiguration(t *testing.T) {
+	var (
+		pe      *regoEval
+		source  MetricsSource
+		results []*CombinedResult
+		err     error
+	)
+
+	pe = &regoEval{
+		qc:   newQueryCache(),
+		mrtc: &metricsCache{m: make(map[string][]*assessment.Metric)},
+		pkg:  DefaultRegoPackage,
+	}
+	source = &missingConfigSource{}
+
+	results, err = pe.Eval(&evidence.Evidence{
+		Id:                   "11111111-1111-1111-1111-111111111111",
+		ToolId:               "tool-a",
+		TargetOfEvaluationId: "00000000-0000-0000-0000-000000000000",
+	}, &ontology.VirtualMachine{Id: "vm-1"}, nil, source)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(results))
 }
 
 func Test_regoEval_evalMap(t *testing.T) {

--- a/core/policies/rego_test.go
+++ b/core/policies/rego_test.go
@@ -70,6 +70,25 @@ func (m *missingConfigSource) MetricImplementation(lang assessment.MetricImpleme
 	return nil, errors.New("not implemented")
 }
 
+type metricConfigErrorSource struct{}
+
+func (m *metricConfigErrorSource) Metrics() (metrics []*assessment.Metric, err error) {
+	return []*assessment.Metric{{
+		Id:       "metric-1",
+		Name:     "MetricOne",
+		Category: "Category",
+	}}, nil
+}
+
+func (m *metricConfigErrorSource) MetricConfiguration(targetID string, metric *assessment.Metric) (cfg *assessment.MetricConfiguration, err error) {
+	err = connect.NewError(connect.CodeInternal, errors.New("database unavailable"))
+	return nil, err
+}
+
+func (m *metricConfigErrorSource) MetricImplementation(lang assessment.MetricImplementation_Language, metric *assessment.Metric) (impl *assessment.MetricImplementation, err error) {
+	return nil, errors.New("not implemented")
+}
+
 func Test_regoEval_Eval(t *testing.T) {
 
 	type fields struct {
@@ -466,6 +485,44 @@ func Test_regoEval_Eval_SkipMissingMetricConfiguration(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(results))
+}
+
+func Test_regoEval_Eval_ReturnsNonSkippableMetricConfigurationError(t *testing.T) {
+	var (
+		pe      *regoEval
+		source  MetricsSource
+		results []*CombinedResult
+		err     error
+	)
+
+	pe = &regoEval{
+		qc:   newQueryCache(),
+		mrtc: &metricsCache{m: make(map[string][]*assessment.Metric)},
+		pkg:  DefaultRegoPackage,
+	}
+	source = &metricConfigErrorSource{}
+
+	results, err = pe.Eval(&evidence.Evidence{
+		Id:                   "11111111-1111-1111-1111-111111111111",
+		ToolId:               "tool-a",
+		TargetOfEvaluationId: "00000000-0000-0000-0000-000000000000",
+	}, &ontology.VirtualMachine{Id: "vm-1"}, nil, source)
+
+	assert.Nil(t, results)
+	assert.ErrorContains(t, err, "database unavailable")
+}
+
+func TestWithPackageName(t *testing.T) {
+	var (
+		re  *regoEval
+		opt RegoEvalOption
+	)
+
+	re = &regoEval{pkg: DefaultRegoPackage}
+	opt = WithPackageName("custom.package")
+	opt(re)
+
+	assert.Equal(t, "custom.package", re.pkg)
 }
 
 func Test_regoEval_evalMap(t *testing.T) {


### PR DESCRIPTION
Rego Eval currently skips missing metric configurations only when the error message exactly contains metric configuration not found for metric. In practice, wrapped NotFound errors can vary in wording. When the exact phrase does not match, Eval returns early and stops evaluating remaining metrics.

Instead of requiring a very specific error text, this PR now matches the base phrase metric configuration not found, while still requiring connect.CodeNotFound. This way, assessment continues for other metrics instead of aborting.

