### PR TITLE
Set evidence queue size in confirmate command

### DIFF
--- a/core/server/commands/confirmate.go
+++ b/core/server/commands/confirmate.go
@@ -172,6 +172,7 @@ var ConfirmateCommand = &cli.Command{
 		evidenceOpts = append([]service.Option[evidence.Service]{
 			evidence.WithConfig(evidence.Config{
 				AssessmentAddress: cmd.String("evidence-assessment-address"),
+				EvidenceQueueSize: evidence.DefaultConfig.EvidenceQueueSize,
 				PersistenceConfig: persistence.Config{
 					Host:       cmd.String("db-host"),
 					Port:       cmd.Int("db-port"),


### PR DESCRIPTION
This PR sets the evidence queue size in the confirmate command, as without this EvidenceQueueSize would fall back to zero instead of the service default.

