### PR TITLE
evidence: rename Resource to ResourceSnapshot to fix OpenAPI collision

### DIFF
--- a/core/api/assessment/openapi.yaml
+++ b/core/api/assessment/openapi.yaml
@@ -38,6 +38,235 @@ paths:
                                 $ref: '#/components/schemas/Status'
 components:
     schemas:
+        ABAC:
+            type: object
+            properties: {}
+            description: ABAC is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        AccessRestriction:
+            type: object
+            properties:
+                l3Firewall:
+                    $ref: '#/components/schemas/L3Firewall'
+                webApplicationFirewall:
+                    $ref: '#/components/schemas/WebApplicationFirewall'
+                rateLimiting:
+                    $ref: '#/components/schemas/RateLimiting'
+            description: AccessRestriction is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        Account:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                assetInventory:
+                    $ref: '#/components/schemas/AssetInventory'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                Account is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This represents the cloud account as a whole, e.g., an Azure subscription.
+        ActivityLogging:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                monitoringLogDataEnabled:
+                    type: boolean
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                securityAlertsEnabled:
+                    type: boolean
+                loggingServiceIds:
+                    type: array
+                    items:
+                        type: string
+            description: ActivityLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Agnostic:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: |-
+                Agnostic is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an agnostic architecture, which is not tied to a specific operating system.
+        Allocate:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                memoryId:
+                    type: string
+            description: Allocate is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        AndRule:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                AndRule is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a rule that combines two other rules using a logical AND operation. This means that both rules must be satisfied for the combined rule to be satisfied.
+        AnomalyDetection:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                scope:
+                    type: string
+                applicationLogging:
+                    $ref: '#/components/schemas/ApplicationLogging'
+            description: |-
+                AnomalyDetection is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Analyzes the activity of a NetworkService (which includes DatabaseServices).
+                 Scope contains the resource ID of the protected resource.
+        Application:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                programmingLanguage:
+                    type: string
+                programmingVersion:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                translationUnits:
+                    type: array
+                    items:
+                        type: string
+                automaticUpdates:
+                    $ref: '#/components/schemas/AutomaticUpdates'
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                computeId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                libraryIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                Application is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This encapsulates the whole (source) code of an application.
+        ApplicationLogging:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                monitoringLogDataEnabled:
+                    type: boolean
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                securityAlertsEnabled:
+                    type: boolean
+                loggingServiceIds:
+                    type: array
+                    items:
+                        type: string
+            description: ApplicationLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         AssessEvidenceResponse:
             type: object
             properties:
@@ -53,6 +282,1491 @@ components:
                 AssessEvidenceResponse belongs to AssessEvidence, which uses a custom unary
                  RPC and therefore requires a response message according to the style
                  convention. Since no return values are required, this is empty.
+        AssetInventory:
+            type: object
+            properties:
+                allRequiredInformationRecorded:
+                    type: boolean
+                    description: Indicates whether all required information for an asset inventory entry has been recorded.
+                auditInterval:
+                    type: integer
+                    description: The time needed for an audit.
+                    format: int32
+                completedReviewPercentage:
+                    type: number
+                    description: Percentage of completed reviews and updates of asset inventory entries.
+                    format: float
+                status:
+                    type: string
+                storageFacility:
+                    type: string
+                type:
+                    type: string
+                updateDuration:
+                    type: integer
+                    description: The time needed for an update.
+                    format: int32
+                updateInterval:
+                    type: integer
+                    format: int32
+            description: |-
+                AssetInventory is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 AuditInterval contains the frequency of asset inventory audits in month.
+                 Class representing the inventory of assets.
+                 Status contains the status of the asset (e.g., active, inactive).
+                 StorageFacility contains the storage facility type of the asset (e.g., central, decentralized).
+                 Type: contains the type of the asset, e.g., digital
+                 UpdateInterval contains the frequency of asset inventory updates in month.
+        AsymmetricCipher:
+            type: object
+            properties:
+                blockSize:
+                    type: integer
+                    description: Block size of a cipher.
+                    format: int32
+                cipherName:
+                    type: string
+                    description: Name of a cryptographic cipher.
+                keySize:
+                    type: integer
+                    description: Key size refers to the length of a key used in an enryption.
+                    format: int32
+                padding:
+                    $ref: '#/components/schemas/Padding'
+            description: AsymmetricCipher is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        AtRestEncryption:
+            type: object
+            properties:
+                customerKeyEncryption:
+                    $ref: '#/components/schemas/CustomerKeyEncryption'
+                diskEncryption:
+                    $ref: '#/components/schemas/DiskEncryption'
+                managedKeyEncryption:
+                    $ref: '#/components/schemas/ManagedKeyEncryption'
+            description: AtRestEncryption is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        Authenticate:
+            type: object
+            properties:
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                credentialId:
+                    type: string
+            description: |-
+                Authenticate is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an authentication operation.
+        Authenticity:
+            type: object
+            properties:
+                certificateBasedAuthentication:
+                    $ref: '#/components/schemas/CertificateBasedAuthentication'
+                jwtAuthentication:
+                    $ref: '#/components/schemas/JwtAuthentication'
+                multiFactorAuthentiation:
+                    $ref: '#/components/schemas/MultiFactorAuthentiation'
+                noAuthentication:
+                    $ref: '#/components/schemas/NoAuthentication'
+                otpBasedAuthentication:
+                    $ref: '#/components/schemas/OTPBasedAuthentication'
+                passwordBasedAuthentication:
+                    $ref: '#/components/schemas/PasswordBasedAuthentication'
+                singleSignOn:
+                    $ref: '#/components/schemas/SingleSignOn'
+            description: Authenticity is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        Authorization:
+            type: object
+            properties:
+                abac:
+                    $ref: '#/components/schemas/ABAC'
+                l3Firewall:
+                    $ref: '#/components/schemas/L3Firewall'
+                webApplicationFirewall:
+                    $ref: '#/components/schemas/WebApplicationFirewall'
+                rateLimiting:
+                    $ref: '#/components/schemas/RateLimiting'
+                rbac:
+                    $ref: '#/components/schemas/RBAC'
+            description: Authorization is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        AuthorizeJwt:
+            type: object
+            properties:
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: |-
+                AuthorizeJwt is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an authorization operation based on JWT tokens.
+        AutomaticUpdates:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                interval:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: The interval refers to the update interval in days.
+                securityOnly:
+                    type: boolean
+            description: |-
+                AutomaticUpdates is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This feature is, e.g., available on some VM services to automatically update their software. It ensures that a resource is protected from tampering with its state.
+        AwarenessTraining:
+            type: object
+            properties:
+                annualUpdateCompleted:
+                    type: boolean
+                successfullyCompletedPercentage:
+                    type: boolean
+            description: AwarenessTraining is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Backup:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                interval:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: The interval refers to the update interval in days.
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                storageId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+            description: |-
+                Backup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 RetentionPeriod in hours
+        BlockStorage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                atRestEncryption:
+                    $ref: '#/components/schemas/AtRestEncryption'
+                backups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Backup'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                immutability:
+                    $ref: '#/components/schemas/Immutability'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: BlockStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        BlockStorageOperation:
+            type: object
+            properties:
+                blockStorageId:
+                    type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: BlockStorageOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        BootLogging:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                monitoringLogDataEnabled:
+                    type: boolean
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                securityAlertsEnabled:
+                    type: boolean
+                loggingServiceIds:
+                    type: array
+                    items:
+                        type: string
+            description: BootLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Boundary:
+            type: object
+            properties: {}
+            description: |-
+                Boundary is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a boundary in data processing, which can be used to define the scope of a policy or the separation between different policies. For example, a boundary could be defined around an [HttpEndpoint], so that the policy applies once data either comes in or goes out of the HTTP endpoint.
+        Certificate:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                enabled:
+                    type: boolean
+                expirationDate:
+                    type: string
+                    format: date-time
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                isManaged:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                notBeforeDate:
+                    type: string
+                    format: date-time
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                usedByMultiple:
+                    $ref: '#/components/schemas/Infrastructure'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Certificate is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CertificateBasedAuthentication:
+            type: object
+            properties:
+                contextIsChecked:
+                    type: boolean
+                enabled:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+            description: CertificateBasedAuthentication is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ChangeAndConfigurationManagement:
+            type: object
+            properties:
+                requestForChange:
+                    $ref: '#/components/schemas/RequestForChange'
+            description: ChangeAndConfigurationManagement is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CheckAccess:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                protectedAsset:
+                    $ref: '#/components/schemas/ProtectedAsset'
+            description: |-
+                CheckAccess is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation that checks whether a user or principal has access to a protected
+        Cipher:
+            type: object
+            properties:
+                asymmetricCipher:
+                    $ref: '#/components/schemas/AsymmetricCipher'
+                hybridCipher:
+                    $ref: '#/components/schemas/HybridCipher'
+                symmetricCipher:
+                    $ref: '#/components/schemas/SymmetricCipher'
+            description: |-
+                Cipher is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 Represents a cipher suite. E.g. `AES-XTS-plain64`.
+                 enum:cipherName=coolCipher,unCoolCipher
+        CipherSuite:
+            type: object
+            properties:
+                authenticationMechanism:
+                    type: string
+                    description: 'for example: RSA, ECDSA'
+                keyExchangeAlgorithm:
+                    type: string
+                macAlgorithm:
+                    type: string
+                    description: 'naming schema: SHA-256'
+                sessionCipher:
+                    type: string
+                    description: 'naming schema: AES-128-GCM'
+                ciphers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Cipher'
+            description: CipherSuite is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CodeRegion:
+            type: object
+            properties:
+                code:
+                    type: string
+                endColumn:
+                    type: integer
+                    format: int32
+                endLine:
+                    type: integer
+                    format: int32
+                file:
+                    type: string
+                startColumn:
+                    type: integer
+                    format: int32
+                startLine:
+                    type: integer
+                    format: int32
+            description: CodeRegion is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CodeRepository:
+            type: object
+            properties:
+                approvedCommitAuthorEnforced:
+                    type: boolean
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                numberOfRequiredReviewers:
+                    type: integer
+                    format: int32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                reviewPercentage:
+                    type: number
+                    format: float
+                reviewPercentageLastMonth:
+                    type: number
+                    format: float
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                codeSignoff:
+                    $ref: '#/components/schemas/CodeSignoff'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                signedCommits:
+                    $ref: '#/components/schemas/SignedCommits'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+                verifiedCommits:
+                    $ref: '#/components/schemas/VerifiedCommits'
+            description: |-
+                CodeRepository is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 ApprovedCommitAuthorEnforced verifies that code modifications are made by authorized developers whose changes have been validated, enhancing accountability and traceability.
+                 ReviewPercentage is the percentage of merged pull requests with code reviews.
+                 ReviewPercentageLastMonth is the percentage of merged pull requests with code reviews in the last 30 days.
+        CodeSignoff:
+            type: object
+            properties:
+                enforced:
+                    type: boolean
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "CodeSignoff is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n Percentage: Percentage of commits with \"Signed-off-by\" lines. \n PercentageLastMonth: Percentage of commits with \"Signed-off-by\" lines in the last 30 days. \n Signoffs enable users to affirm that a commit complies with the rules and licensing governing a repository"
+        Configuration:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                configurationGroupIds:
+                    type: array
+                    items:
+                        type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                Configuration is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents the abstract concept of a "configuration". This is a common pattern in many programming languages, where a data structure in code represents an aggregation of configuration values. For example, in Python, the [`configparser`](https://docs.python.org/3/library/configparser.html) module is used to read INI files, and the config values are represented as a dictionary-like object. Often, the configuration is loaded from multiple sources, such as INI files, environment variables, and command-line arguments.
+        ConfigurationDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: ConfigurationDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ConfigurationGroup:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                configurationId:
+                    type: string
+                configurationOptionIds:
+                    type: array
+                    items:
+                        type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                ConfigurationGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a group of configuration values within one [conf]. Depending on the type of configuration data structure, there might only be one group (e.g., a "default" one), or there might be several groups. For example, when loading a config from an INI file, each section would be mapped to a [ConfigurationGroup], and each key-value pair would be mapped to an [ConfigurationOption] within this group.
+        ConfigurationGroupSource:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                ConfigurationGroupSource is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a possible group source for a configuration group. For example, when loading an INI file with our INI file frontend, each section is presented as a [RecordDeclaration]. This record declaration would be the source of the configuration group.
+        ConfigurationOption:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                configurationGroupId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                keyId:
+                    type: string
+                parentId:
+                    type: string
+                valueId:
+                    type: string
+            description: |-
+                ConfigurationOption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a configuration option within one [group]. Usually there is one option for each entry in a configuration data structure.
+        ConfigurationOptionSource:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                ConfigurationOptionSource is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a possible option source for a configuration option. For example, when loading an INI file with our INI file frontend, each key-value pair is presented as a [FieldDeclaration]. This field declaration would be the source to the configuration option.
+        ConfigurationSource:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                configurationGroupSourceIds:
+                    type: array
+                    items:
+                        type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                ConfigurationSource is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a possible source for a configuration. For example, when loading an INI file with our INI file frontend, the whole file would be represented as a [TranslationUnitDeclaration]. This translation unit declaration would be the source of the configuration.
+        ContactPerson:
+            type: object
+            properties:
+                emailAddress:
+                    type: string
+                jobTitle:
+                    type: string
+                phoneNumber:
+                    type: string
+            description: ContactPerson is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Container:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                encryptionInUse:
+                    $ref: '#/components/schemas/EncryptionInUse'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                imageId:
+                    type: string
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkInterfaceIds:
+                    type: array
+                    items:
+                        type: string
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                remoteAttestation:
+                    $ref: '#/components/schemas/RemoteAttestation'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Container is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ContainerImage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                applicationId:
+                    type: string
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: ContainerImage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ContainerOrchestration:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                managementUrl:
+                    type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                containerIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: ContainerOrchestration is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ContainerRegistry:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: ContainerRegistry is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Context:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                Context is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a context in which a policy is applied. Typically, a context contains information about a user or some other form of identity (e.g. a [Principal]).
+        CoordinatedVulnerabilityDisclosurePolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: CoordinatedVulnerabilityDisclosurePolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CreateEncryptedDisk:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                diskEncryption:
+                    $ref: '#/components/schemas/DiskEncryption'
+            description: CreateEncryptedDisk is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CreateSecret:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                secretId:
+                    type: string
+            description: CreateSecret is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CryptographicHash:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                errors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Error'
+            description: CryptographicHash is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CustomHttpPattern:
+            type: object
+            properties:
+                kind:
+                    type: string
+                    description: The name of this custom HTTP verb.
+                path:
+                    type: string
+                    description: The path matched by this custom verb.
+            description: A custom pattern is used for defining custom HTTP verb.
+        CustomerKeyEncryption:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                enabled:
+                    type: boolean
+                keyUrl:
+                    type: string
+                basedOn:
+                    $ref: '#/components/schemas/Cipher'
+                secretId:
+                    type: string
+            description: CustomerKeyEncryption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        CyberSecurityRiskAssessmentDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: CyberSecurityRiskAssessmentDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DDoSProtection:
+            type: object
+            properties: {}
+            description: DDoSProtection is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Darwin:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: |-
+                Darwin is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a Darwin architecture, commonly found on macOS systems. macOS is a certified. [UNIX](https://www.opengroup.org/openbrand/register/apple.htm) and is (mostly) POSIX compatible.
+        DataConfidentialitySDNPolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                isDefined:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                DataConfidentialitySDNPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a policy section within a [PolicyDocument] describing data confidentiality requirements for Software Defined Networking (SDN). isDefined: whether this policy section is present and defined.
+        DataLocation:
+            type: object
+            properties:
+                localDataLocation:
+                    $ref: '#/components/schemas/LocalDataLocation'
+                remoteDataLocation:
+                    $ref: '#/components/schemas/RemoteDataLocation'
+            description: |-
+                DataLocation is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 path: Describes either local path or path in URL format
+        DatabaseConnect:
+            type: object
+            properties:
+                calls:
+                    type: array
+                    items:
+                        type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                databaseServiceIds:
+                    type: array
+                    items:
+                        type: string
+                databaseStorageId:
+                    type: string
+            description: DatabaseConnect is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DatabaseQuery:
+            type: object
+            properties:
+                calls:
+                    type: array
+                    items:
+                        type: string
+                modify:
+                    type: boolean
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                databaseServiceIds:
+                    type: array
+                    items:
+                        type: string
+                databaseStorageId:
+                    type: string
+            description: DatabaseQuery is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DatabaseStorage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                ttl:
+                    type: number
+                    format: double
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                atRestEncryption:
+                    $ref: '#/components/schemas/AtRestEncryption'
+                backups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Backup'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                immutability:
+                    $ref: '#/components/schemas/Immutability'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                DatabaseStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 describes the actual database or a table in a database
+        DeAllocate:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                memoryId:
+                    type: string
+            description: |-
+                DeAllocate is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a memory de-allocation operation. This can be done using `free` in C or `delete` in C++ or by calling a destructor in managed languages.
+        Decryption:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                cipher:
+                    $ref: '#/components/schemas/Cipher'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                secretId:
+                    type: string
+            description: Decryption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DeviceProvisioningService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: DeviceProvisioningService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DiskEncryption:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                enabled:
+                    type: boolean
+                keyUrl:
+                    type: string
+                usedBy:
+                    $ref: '#/components/schemas/BlockStorage'
+                basedOn:
+                    $ref: '#/components/schemas/Cipher'
+                secretId:
+                    type: string
+            description: DiskEncryption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DistributionOfUpdatesDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: DistributionOfUpdatesDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DocumentDatabaseService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                anomalyDetections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnomalyDetection'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: DocumentDatabaseService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DocumentSignature:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                errors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Error'
+            description: DocumentSignature is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        DynamicLoading:
+            type: object
+            properties: {}
+            description: |-
+                DynamicLoading is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an entity that loads a piece of code dynamically during runtime. Examples include a class loader in Java, loading shared library code in C++. Interpreters, such as Python can also load code dynamically during runtime.
+        EUDeclarationOfConformity:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: EUDeclarationOfConformity is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Encryption:
+            type: object
+            properties:
+                customerKeyEncryption:
+                    $ref: '#/components/schemas/CustomerKeyEncryption'
+                diskEncryption:
+                    $ref: '#/components/schemas/DiskEncryption'
+                managedKeyEncryption:
+                    $ref: '#/components/schemas/ManagedKeyEncryption'
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+            description: |-
+                Encryption is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 This represents an encryption.
+        EncryptionInUse:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: EncryptionInUse is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        EncryptionOperation:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                encryption:
+                    $ref: '#/components/schemas/Encryption'
+                secretId:
+                    type: string
+            description: EncryptionOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        EntryPoint:
+            type: object
+            properties:
+                libraryEntryPoint:
+                    $ref: '#/components/schemas/LibraryEntryPoint'
+                main:
+                    $ref: '#/components/schemas/Main'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+            description: |-
+                EntryPoint is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 Represents an entry point into the execution of the program. This can be a "local" entry point, such as a main function, a library initialization function or a "remote" entry point, such as a network endpoint.
+        EqualityCheck:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                policyId:
+                    type: string
+                leftPrincipal:
+                    $ref: '#/components/schemas/Principal'
+                rightPrincipal:
+                    $ref: '#/components/schemas/Principal'
+            description: |-
+                EqualityCheck is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation that checks whether two principals are equal.
+        Error:
+            type: object
+            properties:
+                message:
+                    type: string
+            description: Error is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Evidence:
             type: object
             properties:
@@ -84,6 +1798,557 @@ components:
                          assessment and are recent enough. In the future, this will be replaced with information in the "related" edges in
                          the resource. For now, this needs to be set manually in the evidence.
             description: An evidence resource
+        ExitBoundaryOperation:
+            type: object
+            properties:
+                boundary:
+                    $ref: '#/components/schemas/Boundary'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: |-
+                ExitBoundaryOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an exit operation that is part of a [Boundary]. This operation is used to define the point at which data leaves the boundary.
+        ExplainableResults:
+            type: object
+            properties: {}
+            description: ExplainableResults is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        File:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: File is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        FileHandle:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                FileHandle is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This class represents a file handle.
+        FileOperation:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                fileId:
+                    type: string
+            description: FileOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        FileStorage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                publicAccess:
+                    type: boolean
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                atRestEncryption:
+                    $ref: '#/components/schemas/AtRestEncryption'
+                backups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Backup'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                immutability:
+                    $ref: '#/components/schemas/Immutability'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: FileStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        FileStorageService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                FileStorageService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 An file storage service represents the network service that is used to access a list of file storage shares. The storage itself is modelled as a FileStorage. The service has an http endpoint.
+        Function:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                runtimeLanguage:
+                    type: string
+                runtimeVersion:
+                    type: string
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                encryptionInUse:
+                    $ref: '#/components/schemas/EncryptionInUse'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkInterfaceIds:
+                    type: array
+                    items:
+                        type: string
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                remoteAttestation:
+                    $ref: '#/components/schemas/RemoteAttestation'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Function is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        FunctionService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                functionIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: FunctionService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Functionality:
+            type: object
+            properties:
+                boundary:
+                    $ref: '#/components/schemas/Boundary'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                asymmetricCipher:
+                    $ref: '#/components/schemas/AsymmetricCipher'
+                hybridCipher:
+                    $ref: '#/components/schemas/HybridCipher'
+                symmetricCipher:
+                    $ref: '#/components/schemas/SymmetricCipher'
+                cipherSuite:
+                    $ref: '#/components/schemas/CipherSuite'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                localDataLocation:
+                    $ref: '#/components/schemas/LocalDataLocation'
+                remoteDataLocation:
+                    $ref: '#/components/schemas/RemoteDataLocation'
+                dynamicLoading:
+                    $ref: '#/components/schemas/DynamicLoading'
+                libraryEntryPoint:
+                    $ref: '#/components/schemas/LibraryEntryPoint'
+                main:
+                    $ref: '#/components/schemas/Main'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                error:
+                    $ref: '#/components/schemas/Error'
+                contactPerson:
+                    $ref: '#/components/schemas/ContactPerson'
+                monitoringProcedure:
+                    $ref: '#/components/schemas/MonitoringProcedure'
+                awarenessTraining:
+                    $ref: '#/components/schemas/AwarenessTraining'
+                securityTraining:
+                    $ref: '#/components/schemas/SecurityTraining'
+                httpClient:
+                    $ref: '#/components/schemas/HttpClient'
+                httpRequestContext:
+                    $ref: '#/components/schemas/HttpRequestContext'
+                httpRequestHandler:
+                    $ref: '#/components/schemas/HttpRequestHandler'
+                initializationVector:
+                    $ref: '#/components/schemas/InitializationVector'
+                input:
+                    $ref: '#/components/schemas/Input'
+                keyDerivationFunction:
+                    $ref: '#/components/schemas/KeyDerivationFunction'
+                messageAuthenticationCode:
+                    $ref: '#/components/schemas/MessageAuthenticationCode'
+                authenticate:
+                    $ref: '#/components/schemas/Authenticate'
+                authorizeJwt:
+                    $ref: '#/components/schemas/AuthorizeJwt'
+                issueJwt:
+                    $ref: '#/components/schemas/IssueJwt'
+                validateJwt:
+                    $ref: '#/components/schemas/ValidateJwt'
+                blockStorageOperation:
+                    $ref: '#/components/schemas/BlockStorageOperation'
+                decryption:
+                    $ref: '#/components/schemas/Decryption'
+                loadConfiguration:
+                    $ref: '#/components/schemas/LoadConfiguration'
+                provideConfiguration:
+                    $ref: '#/components/schemas/ProvideConfiguration'
+                provideConfigurationGroup:
+                    $ref: '#/components/schemas/ProvideConfigurationGroup'
+                provideConfigurationOption:
+                    $ref: '#/components/schemas/ProvideConfigurationOption'
+                readConfigurationGroup:
+                    $ref: '#/components/schemas/ReadConfigurationGroup'
+                readConfigurationOption:
+                    $ref: '#/components/schemas/ReadConfigurationOption'
+                registerConfigurationGroup:
+                    $ref: '#/components/schemas/RegisterConfigurationGroup'
+                registerConfigurationOption:
+                    $ref: '#/components/schemas/RegisterConfigurationOption'
+                hashOperation:
+                    $ref: '#/components/schemas/HashOperation'
+                databaseConnect:
+                    $ref: '#/components/schemas/DatabaseConnect'
+                databaseQuery:
+                    $ref: '#/components/schemas/DatabaseQuery'
+                createEncryptedDisk:
+                    $ref: '#/components/schemas/CreateEncryptedDisk'
+                unlockEncryptedDisk:
+                    $ref: '#/components/schemas/UnlockEncryptedDisk'
+                encryptionOperation:
+                    $ref: '#/components/schemas/EncryptionOperation'
+                exitBoundaryOperation:
+                    $ref: '#/components/schemas/ExitBoundaryOperation'
+                fileOperation:
+                    $ref: '#/components/schemas/FileOperation'
+                getCurrentTimeOperation:
+                    $ref: '#/components/schemas/GetCurrentTimeOperation'
+                httpRequest:
+                    $ref: '#/components/schemas/HttpRequest'
+                httpEndpointOperation:
+                    $ref: '#/components/schemas/HttpEndpointOperation'
+                registerHttpEndpoint:
+                    $ref: '#/components/schemas/RegisterHttpEndpoint'
+                inputValidationOperation:
+                    $ref: '#/components/schemas/InputValidationOperation'
+                installUpdateOperation:
+                    $ref: '#/components/schemas/InstallUpdateOperation'
+                logGet:
+                    $ref: '#/components/schemas/LogGet'
+                logWrite:
+                    $ref: '#/components/schemas/LogWrite'
+                logOutput:
+                    $ref: '#/components/schemas/LogOutput'
+                allocate:
+                    $ref: '#/components/schemas/Allocate'
+                deAllocate:
+                    $ref: '#/components/schemas/DeAllocate'
+                loadLibrary:
+                    $ref: '#/components/schemas/LoadLibrary'
+                loadSymbol:
+                    $ref: '#/components/schemas/LoadSymbol'
+                objectStorageRequest:
+                    $ref: '#/components/schemas/ObjectStorageRequest'
+                equalityCheck:
+                    $ref: '#/components/schemas/EqualityCheck'
+                checkAccess:
+                    $ref: '#/components/schemas/CheckAccess'
+                createSecret:
+                    $ref: '#/components/schemas/CreateSecret'
+                getSecret:
+                    $ref: '#/components/schemas/GetSecret'
+                output:
+                    $ref: '#/components/schemas/Output'
+                padding:
+                    $ref: '#/components/schemas/Padding'
+                principal:
+                    $ref: '#/components/schemas/Principal'
+                protectedAsset:
+                    $ref: '#/components/schemas/ProtectedAsset'
+                requestForChange:
+                    $ref: '#/components/schemas/RequestForChange'
+                schemaValidation:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityAdvisoryFeed:
+                    $ref: '#/components/schemas/SecurityAdvisoryFeed'
+                time:
+                    $ref: '#/components/schemas/Time'
+                vulnerability:
+                    $ref: '#/components/schemas/Vulnerability'
+            description: Functionality is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        GenericNetworkService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                GenericNetworkService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A generic network service.
+        GeoLocation:
+            type: object
+            properties:
+                region:
+                    type: string
+            description: GeoLocation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        GeoRedundancy:
+            type: object
+            properties:
+                geoLocations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GeoLocation'
+            description: GeoRedundancy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        GetCurrentTimeOperation:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                time:
+                    $ref: '#/components/schemas/Time'
+            description: GetCurrentTimeOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        GetSecret:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                secretId:
+                    type: string
+            description: |-
+                GetSecret is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 An operation that retrieves a secret from a (remote) location. This can be a local keystore, a remote key server or a hardware device such as a TPM or HSM.
         GoogleProtobufAny:
             type: object
             properties:
@@ -92,43 +2357,3398 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        Resource:
-            required:
-                - id
-                - targetOfEvaluationId
-                - resourceType
-                - toolId
-                - properties
+        Governance:
             type: object
             properties:
+                contactPerson:
+                    $ref: '#/components/schemas/ContactPerson'
+                monitoringProcedure:
+                    $ref: '#/components/schemas/MonitoringProcedure'
+                awarenessTraining:
+                    $ref: '#/components/schemas/AwarenessTraining'
+                securityTraining:
+                    $ref: '#/components/schemas/SecurityTraining'
+            description: Governance is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        HashOperation:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                usesSalt:
+                    type: boolean
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                securityFeature:
+                    $ref: '#/components/schemas/SecurityFeature'
+            description: HashOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Http:
+            type: object
+            properties:
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/HttpRule'
+                    description: |-
+                        A list of HTTP configuration rules that apply to individual API methods.
+
+                         **NOTE:** All service configuration rules follow "last one wins" order.
+                fullyDecodeReservedExpansion:
+                    type: boolean
+                    description: |-
+                        When set to true, URL path parameters will be fully URI-decoded except in
+                         cases of single segment matches in reserved expansion, where "%2F" will be
+                         left encoded.
+
+                         The default behavior is to not decode RFC 6570 reserved characters in multi
+                         segment matches.
+            description: |-
+                Defines the HTTP configuration for an API service. It contains a list of
+                 [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+                 to one or more HTTP REST API methods.
+        HttpClient:
+            type: object
+            properties:
+                isTls:
+                    type: boolean
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                uses:
+                    $ref: '#/components/schemas/TransportEncryption'
+            description: |-
+                HttpClient is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 HTTP Client.
+        HttpEndpoint:
+            type: object
+            properties:
+                handler:
+                    type: string
+                inputSize:
+                    type: integer
+                    format: int32
+                method:
+                    type: string
+                path:
+                    type: string
+                url:
+                    type: string
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                authorization:
+                    $ref: '#/components/schemas/Authorization'
+                httpRequestContext:
+                    $ref: '#/components/schemas/HttpRequestContext'
+                rateLimiting:
+                    $ref: '#/components/schemas/RateLimiting'
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+            description: |-
+                HttpEndpoint is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 An HTTP endpoint can set the "proxyTarget" property, in case that is routed through a (reverse) proxy, e.g. a load balancer.
+                 Via the Authenticity relationship, the access type can be specified, e.g. public access (no authentication), password-based, etc.
+        HttpEndpointOperation:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                http:
+                    $ref: '#/components/schemas/Http'
+            description: |-
+                HttpEndpointOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Base class for operations on an [HttpEndpoint].
+        HttpRequest:
+            type: object
+            properties:
+                call:
+                    type: string
+                method:
+                    type: string
+                reqBody:
+                    type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                httpClient:
+                    $ref: '#/components/schemas/HttpClient'
+                httpEndpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/HttpEndpoint'
+            description: |-
+                HttpRequest is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 enum:method=GET,POST,PUT,HEAD,PATCH,OPTIONS,CONNECT,TRACE,DELETE,UNKNOWN
+        HttpRequestContext:
+            type: object
+            properties: {}
+            description: |-
+                HttpRequestContext is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an abstract concept of request context. This usually holds the contextual information of a specific HTTP request.
+        HttpRequestHandler:
+            type: object
+            properties:
+                path:
+                    type: string
+                applicationId:
+                    type: string
+                httpEndpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/HttpEndpoint'
+            description: HttpRequestHandler is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        HttpRule:
+            type: object
+            properties:
+                selector:
+                    type: string
+                    description: |-
+                        Selects a method to which this rule applies.
+
+                         Refer to [selector][google.api.DocumentationRule.selector] for syntax
+                         details.
+                get:
+                    type: string
+                    description: |-
+                        Maps to HTTP GET. Used for listing and getting information about
+                         resources.
+                put:
+                    type: string
+                    description: Maps to HTTP PUT. Used for replacing a resource.
+                post:
+                    type: string
+                    description: Maps to HTTP POST. Used for creating a resource or performing an action.
+                delete:
+                    type: string
+                    description: Maps to HTTP DELETE. Used for deleting a resource.
+                patch:
+                    type: string
+                    description: Maps to HTTP PATCH. Used for updating a resource.
+                custom:
+                    allOf:
+                        - $ref: '#/components/schemas/CustomHttpPattern'
+                    description: |-
+                        The custom pattern is used for specifying an HTTP method that is not
+                         included in the `pattern` field, such as HEAD, or "*" to leave the
+                         HTTP method unspecified for this rule. The wild-card rule is useful
+                         for services that provide content to Web (HTML) clients.
+                body:
+                    type: string
+                    description: |-
+                        The name of the request field whose value is mapped to the HTTP request
+                         body, or `*` for mapping all request fields not captured by the path
+                         pattern to the HTTP body, or omitted for not having any HTTP request body.
+
+                         NOTE: the referred field must be present at the top-level of the request
+                         message type.
+                responseBody:
+                    type: string
+                    description: |-
+                        Optional. The name of the response field whose value is mapped to the HTTP
+                         response body. When omitted, the entire response message will be used
+                         as the HTTP response body.
+
+                         NOTE: The referred field must be present at the top-level of the response
+                         message type.
+                additionalBindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/HttpRule'
+                    description: |-
+                        Additional HTTP bindings for the selector. Nested bindings must
+                         not contain an `additional_bindings` field themselves (that is,
+                         the nesting may only be one level deep).
+            description: |-
+                gRPC Transcoding
+
+                 gRPC Transcoding is a feature for mapping between a gRPC method and one or
+                 more HTTP REST endpoints. It allows developers to build a single API service
+                 that supports both gRPC APIs and REST APIs. Many systems, including [Google
+                 APIs](https://github.com/googleapis/googleapis),
+                 [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+                 Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+                 and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+                 and use it for large scale production services.
+
+                 `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+                 how different portions of the gRPC request message are mapped to the URL
+                 path, URL query parameters, and HTTP request body. It also controls how the
+                 gRPC response message is mapped to the HTTP response body. `HttpRule` is
+                 typically specified as an `google.api.http` annotation on the gRPC method.
+
+                 Each mapping specifies a URL path template and an HTTP method. The path
+                 template may refer to one or more fields in the gRPC request message, as long
+                 as each field is a non-repeated field with a primitive (non-message) type.
+                 The path template controls how fields of the request message are mapped to
+                 the URL path.
+
+                 Example:
+
+                     service Messaging {
+                       rpc GetMessage(GetMessageRequest) returns (Message) {
+                         option (google.api.http) = {
+                             get: "/v1/{name=messages/*}"
+                         };
+                       }
+                     }
+                     message GetMessageRequest {
+                       string name = 1; // Mapped to URL path.
+                     }
+                     message Message {
+                       string text = 1; // The resource content.
+                     }
+
+                 This enables an HTTP REST to gRPC mapping as below:
+
+                 - HTTP: `GET /v1/messages/123456`
+                 - gRPC: `GetMessage(name: "messages/123456")`
+
+                 Any fields in the request message which are not bound by the path template
+                 automatically become HTTP query parameters if there is no HTTP request body.
+                 For example:
+
+                     service Messaging {
+                       rpc GetMessage(GetMessageRequest) returns (Message) {
+                         option (google.api.http) = {
+                             get:"/v1/messages/{message_id}"
+                         };
+                       }
+                     }
+                     message GetMessageRequest {
+                       message SubMessage {
+                         string subfield = 1;
+                       }
+                       string message_id = 1; // Mapped to URL path.
+                       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+                       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+                     }
+
+                 This enables a HTTP JSON to RPC mapping as below:
+
+                 - HTTP: `GET /v1/messages/123456?revision=2&sub.subfield=foo`
+                 - gRPC: `GetMessage(message_id: "123456" revision: 2 sub:
+                 SubMessage(subfield: "foo"))`
+
+                 Note that fields which are mapped to URL query parameters must have a
+                 primitive type or a repeated primitive type or a non-repeated message type.
+                 In the case of a repeated type, the parameter can be repeated in the URL
+                 as `...?param=A&param=B`. In the case of a message type, each field of the
+                 message is mapped to a separate parameter, such as
+                 `...?foo.a=A&foo.b=B&foo.c=C`.
+
+                 For HTTP methods that allow a request body, the `body` field
+                 specifies the mapping. Consider a REST update method on the
+                 message resource collection:
+
+                     service Messaging {
+                       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+                         option (google.api.http) = {
+                           patch: "/v1/messages/{message_id}"
+                           body: "message"
+                         };
+                       }
+                     }
+                     message UpdateMessageRequest {
+                       string message_id = 1; // mapped to the URL
+                       Message message = 2;   // mapped to the body
+                     }
+
+                 The following HTTP JSON to RPC mapping is enabled, where the
+                 representation of the JSON in the request body is determined by
+                 protos JSON encoding:
+
+                 - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+                 - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+
+                 The special name `*` can be used in the body mapping to define that
+                 every field not bound by the path template should be mapped to the
+                 request body.  This enables the following alternative definition of
+                 the update method:
+
+                     service Messaging {
+                       rpc UpdateMessage(Message) returns (Message) {
+                         option (google.api.http) = {
+                           patch: "/v1/messages/{message_id}"
+                           body: "*"
+                         };
+                       }
+                     }
+                     message Message {
+                       string message_id = 1;
+                       string text = 2;
+                     }
+
+
+                 The following HTTP JSON to RPC mapping is enabled:
+
+                 - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+                 - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
+
+                 Note that when using `*` in the body mapping, it is not possible to
+                 have HTTP parameters, as all fields not bound by the path end in
+                 the body. This makes this option more rarely used in practice when
+                 defining REST APIs. The common usage of `*` is in custom methods
+                 which don't use the URL at all for transferring data.
+
+                 It is possible to define multiple HTTP methods for one RPC by using
+                 the `additional_bindings` option. Example:
+
+                     service Messaging {
+                       rpc GetMessage(GetMessageRequest) returns (Message) {
+                         option (google.api.http) = {
+                           get: "/v1/messages/{message_id}"
+                           additional_bindings {
+                             get: "/v1/users/{user_id}/messages/{message_id}"
+                           }
+                         };
+                       }
+                     }
+                     message GetMessageRequest {
+                       string message_id = 1;
+                       string user_id = 2;
+                     }
+
+                 This enables the following two alternative HTTP JSON to RPC mappings:
+
+                 - HTTP: `GET /v1/messages/123456`
+                 - gRPC: `GetMessage(message_id: "123456")`
+
+                 - HTTP: `GET /v1/users/me/messages/123456`
+                 - gRPC: `GetMessage(user_id: "me" message_id: "123456")`
+
+                 Rules for HTTP mapping
+
+                 1. Leaf request fields (recursive expansion nested messages in the request
+                    message) are classified into three categories:
+                    - Fields referred by the path template. They are passed via the URL path.
+                    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+                    are passed via the HTTP
+                      request body.
+                    - All other fields are passed via the URL query parameters, and the
+                      parameter name is the field path in the request message. A repeated
+                      field can be represented as multiple query parameters under the same
+                      name.
+                  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+                  query parameter, all fields
+                     are passed via URL path and HTTP request body.
+                  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+                  request body, all
+                     fields are passed via URL path and URL query parameters.
+
+                 Path template syntax
+
+                     Template = "/" Segments [ Verb ] ;
+                     Segments = Segment { "/" Segment } ;
+                     Segment  = "*" | "**" | LITERAL | Variable ;
+                     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+                     FieldPath = IDENT { "." IDENT } ;
+                     Verb     = ":" LITERAL ;
+
+                 The syntax `*` matches a single URL path segment. The syntax `**` matches
+                 zero or more URL path segments, which must be the last part of the URL path
+                 except the `Verb`.
+
+                 The syntax `Variable` matches part of the URL path as specified by its
+                 template. A variable template must not contain other variables. If a variable
+                 matches a single path segment, its template may be omitted, e.g. `{var}`
+                 is equivalent to `{var=*}`.
+
+                 The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+                 contains any reserved character, such characters should be percent-encoded
+                 before the matching.
+
+                 If a variable contains exactly one path segment, such as `"{var}"` or
+                 `"{var=*}"`, when such a variable is expanded into a URL path on the client
+                 side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+                 server side does the reverse decoding. Such variables show up in the
+                 [Discovery
+                 Document](https://developers.google.com/discovery/v1/reference/apis) as
+                 `{var}`.
+
+                 If a variable contains multiple path segments, such as `"{var=foo/*}"`
+                 or `"{var=**}"`, when such a variable is expanded into a URL path on the
+                 client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+                 The server side does the reverse decoding, except "%2F" and "%2f" are left
+                 unchanged. Such variables show up in the
+                 [Discovery
+                 Document](https://developers.google.com/discovery/v1/reference/apis) as
+                 `{+var}`.
+
+                 Using gRPC API Service Configuration
+
+                 gRPC API Service Configuration (service config) is a configuration language
+                 for configuring a gRPC service to become a user-facing product. The
+                 service config is simply the YAML representation of the `google.api.Service`
+                 proto message.
+
+                 As an alternative to annotating your proto file, you can configure gRPC
+                 transcoding in your service config YAML files. You do this by specifying a
+                 `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+                 effect as the proto annotation. This can be particularly useful if you
+                 have a proto that is reused in multiple services. Note that any transcoding
+                 specified in the service config will override any matching transcoding
+                 configuration in the proto.
+
+                 The following example selects a gRPC method and applies an `HttpRule` to it:
+
+                     http:
+                       rules:
+                         - selector: example.v1.Messaging.GetMessage
+                           get: /v1/messages/{message_id}/{sub.subfield}
+
+                 Special notes
+
+                 When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+                 proto to JSON conversion must follow the [proto3
+                 specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+
+                 While the single segment variable follows the semantics of
+                 [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+                 Expansion, the multi segment variable **does not** follow RFC 6570 Section
+                 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+                 does not expand special characters like `?` and `#`, which would lead
+                 to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+                 for multi segment variables.
+
+                 The path variables **must not** refer to any repeated or mapped field,
+                 because client libraries are not capable of handling such variable expansion.
+
+                 The path variables **must not** capture the leading "/" character. The reason
+                 is that the most common use case "{var}" does not capture the leading "/"
+                 character. For consistency, all path variables must share the same behavior.
+
+                 Repeated message fields must not be mapped to URL query parameters, because
+                 no client library can support such complicated mapping.
+
+                 If an API needs to use a JSON array for request or response body, it can map
+                 the request or response body to a repeated field. However, some gRPC
+                 Transcoding implementations may not support this feature.
+        HybridCipher:
+            type: object
+            properties:
+                blockSize:
+                    type: integer
+                    description: Block size of a cipher.
+                    format: int32
+                cipherName:
+                    type: string
+                    description: Name of a cryptographic cipher.
+                keySize:
+                    type: integer
+                    description: Key size refers to the length of a key used in an enryption.
+                    format: int32
+                uses:
+                    $ref: '#/components/schemas/AsymmetricCipher'
+                keyDerivationFunction:
+                    $ref: '#/components/schemas/KeyDerivationFunction'
+                messageAuthenticationCode:
+                    $ref: '#/components/schemas/MessageAuthenticationCode'
+                padding:
+                    $ref: '#/components/schemas/Padding'
+                symmetricCipher:
+                    $ref: '#/components/schemas/SymmetricCipher'
+            description: HybridCipher is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Identity:
+            type: object
+            properties:
+                activated:
+                    type: boolean
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                disablePasswordPolicy:
+                    type: boolean
+                enforceMfa:
+                    type: boolean
                 id:
                     type: string
-                    description: |-
-                        Id contains a unique ID for each resource. This is specific for the cloud
-                         provider this resource was gathered for and can for example be a resource
-                         URL.
-                targetOfEvaluationId:
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                lastActivity:
                     type: string
-                    description: |-
-                        TargetOfEvaluationId is the UUID for the target of evaluation to which this resource
-                         belongs to.
-                resourceType:
+                    format: date-time
+                loginDefenderEnabled:
+                    type: boolean
+                name:
                     type: string
-                    description: |-
-                        ResourceType contains a comma separated string of resource types according
-                         to our ontology.
-                toolId:
+                privileged:
+                    type: boolean
+                raw:
                     type: string
-                    description: Reference to the tool which provided the resource
-                properties:
-                    allOf:
-                        - $ref: '#/components/schemas/GoogleProtobufAny'
-                    description: |-
-                        Properties contains a protobuf message that describe the resource in the
-                         terms of our ontology.
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                authorization:
+                    $ref: '#/components/schemas/Authorization'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Identity is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Immutability:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: Immutability is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Infrastructure:
+            type: object
+            properties:
+                account:
+                    $ref: '#/components/schemas/Account'
+                job:
+                    $ref: '#/components/schemas/Job'
+                workflow:
+                    $ref: '#/components/schemas/Workflow'
+                codeRepository:
+                    $ref: '#/components/schemas/CodeRepository'
+                container:
+                    $ref: '#/components/schemas/Container'
+                function:
+                    $ref: '#/components/schemas/Function'
+                qpu:
+                    $ref: '#/components/schemas/QPU'
+                virtualMachine:
+                    $ref: '#/components/schemas/VirtualMachine'
+                containerOrchestration:
+                    $ref: '#/components/schemas/ContainerOrchestration'
+                containerRegistry:
+                    $ref: '#/components/schemas/ContainerRegistry'
+                certificate:
+                    $ref: '#/components/schemas/Certificate'
+                key:
+                    $ref: '#/components/schemas/Key'
+                secret:
+                    $ref: '#/components/schemas/Secret'
+                identity:
+                    $ref: '#/components/schemas/Identity'
+                roleAssignment:
+                    $ref: '#/components/schemas/RoleAssignment'
+                containerImage:
+                    $ref: '#/components/schemas/ContainerImage'
+                vmImage:
+                    $ref: '#/components/schemas/VMImage'
+                deviceProvisioningService:
+                    $ref: '#/components/schemas/DeviceProvisioningService'
+                messagingHub:
+                    $ref: '#/components/schemas/MessagingHub'
+                keyVault:
+                    $ref: '#/components/schemas/KeyVault'
+                networkInterface:
+                    $ref: '#/components/schemas/NetworkInterface'
+                networkSecurityGroup:
+                    $ref: '#/components/schemas/NetworkSecurityGroup'
+                functionService:
+                    $ref: '#/components/schemas/FunctionService'
+                genericNetworkService:
+                    $ref: '#/components/schemas/GenericNetworkService'
+                loadBalancer:
+                    $ref: '#/components/schemas/LoadBalancer'
+                loggingService:
+                    $ref: '#/components/schemas/LoggingService'
+                machineLearningService:
+                    $ref: '#/components/schemas/MachineLearningService'
+                securityAdvisoryService:
+                    $ref: '#/components/schemas/SecurityAdvisoryService'
+                documentDatabaseService:
+                    $ref: '#/components/schemas/DocumentDatabaseService'
+                keyValueDatabaseService:
+                    $ref: '#/components/schemas/KeyValueDatabaseService'
+                multiModalDatabaseService:
+                    $ref: '#/components/schemas/MultiModalDatabaseService'
+                relationalDatabaseService:
+                    $ref: '#/components/schemas/RelationalDatabaseService'
+                fileStorageService:
+                    $ref: '#/components/schemas/FileStorageService'
+                objectStorageService:
+                    $ref: '#/components/schemas/ObjectStorageService'
+                virtualNetwork:
+                    $ref: '#/components/schemas/VirtualNetwork'
+                virtualSubNetwork:
+                    $ref: '#/components/schemas/VirtualSubNetwork'
+                passwordPolicy:
+                    $ref: '#/components/schemas/PasswordPolicy'
+                resourceGroup:
+                    $ref: '#/components/schemas/ResourceGroup'
+                blockStorage:
+                    $ref: '#/components/schemas/BlockStorage'
+                databaseStorage:
+                    $ref: '#/components/schemas/DatabaseStorage'
+                fileStorage:
+                    $ref: '#/components/schemas/FileStorage'
+                objectStorage:
+                    $ref: '#/components/schemas/ObjectStorage'
+            description: Infrastructure is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        InitializationVector:
+            type: object
+            properties: {}
             description: |-
-                Resource is a wrapper around google.protobuf.Value that is needed for
-                 persistence reasons.
+                InitializationVector is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an Initialization Vector of a cipher.
+        Input:
+            type: object
+            properties: {}
+            description: |-
+                Input is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A certain Input for e.g. a function.
+        InputValidationOperation:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                input:
+                    $ref: '#/components/schemas/Input'
+                output:
+                    $ref: '#/components/schemas/Output'
+            description: InputValidationOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        InstallUpdateOperation:
+            type: object
+            properties:
+                automaticUpdates:
+                    $ref: '#/components/schemas/AutomaticUpdates'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: InstallUpdateOperation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        IssueJwt:
+            type: object
+            properties:
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: |-
+                IssueJwt is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to issue a new JWT token.
+        Job:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Job is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        JwtAuthentication:
+            type: object
+            properties:
+                contextIsChecked:
+                    type: boolean
+                enabled:
+                    type: boolean
+                enforced:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+                tokenId:
+                    type: string
+            description: |-
+                JwtAuthentication is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a JWT-based authentication, which extends the [TokenBasedAuth].
+        Key:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                enabled:
+                    type: boolean
+                expirationDate:
+                    type: string
+                    format: date-time
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                isManaged:
+                    type: boolean
+                keySize:
+                    type: integer
+                    description: Key size refers to the length of a key used in an enryption.
+                    format: int32
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                notBeforeDate:
+                    type: string
+                    format: date-time
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                usedByMultiple:
+                    $ref: '#/components/schemas/Infrastructure'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                Key is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A key used for encryption algorithms.
+                 The node that represents the "key" of this option. For example, in an INI file, this would be the [FieldDeclaration] node that represents the key.
+        KeyDerivationFunction:
+            type: object
+            properties:
+                type:
+                    type: string
+                input:
+                    $ref: '#/components/schemas/Input'
+            description: KeyDerivationFunction is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        KeyValueDatabaseService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                anomalyDetections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnomalyDetection'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: KeyValueDatabaseService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        KeyVault:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                credentialIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: KeyVault is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        L3Firewall:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                inbound:
+                    type: boolean
+                restrictedPorts:
+                    type: string
+            description: L3Firewall is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LeastPrivilegePolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                isDefined:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                LeastPrivilegePolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a policy section within a [PolicyDocument] describing least privilege requirements. isDefined: whether this policy section is present and defined.
+        Library:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                libraryIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+                vulnerabilities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Vulnerability'
+            description: Library is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LibraryEntryPoint:
+            type: object
+            properties:
+                usedBy:
+                    $ref: '#/components/schemas/OperatingSystemArchitecture'
+            description: |-
+                LibraryEntryPoint is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an entry point that is triggered if the code is loaded as a (dynamic) library.
+        LoadBalancer:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                url:
+                    type: string
+                accessRestriction:
+                    $ref: '#/components/schemas/AccessRestriction'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkServiceIds:
+                    type: array
+                    items:
+                        type: string
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                LoadBalancer is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A Load Balancer may have multiple access restriction features, e.g. a L3 firewall and a WAF
+        LoadConfiguration:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+            description: |-
+                LoadConfiguration is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to load a configuration from a source, such as a file.
+        LoadLibrary:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                entryPoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EntryPoint'
+                memoryId:
+                    type: string
+                operatingSystemArchitectureId:
+                    type: string
+            description: |-
+                LoadLibrary is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation that loads a shared library during runtime. A common example would be a call to `dlopen` in C/C++.
+        LoadSymbol:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                memoryId:
+                    type: string
+                operatingSystemArchitectureId:
+                    type: string
+            description: |-
+                LoadSymbol is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation that loads a symbol during runtime. A common example would be a call to`dlsym` in C/C++.
+        LocalAttestation:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: LocalAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LocalDataLocation:
+            type: object
+            properties:
+                path:
+                    type: string
+                atRestEncryption:
+                    $ref: '#/components/schemas/AtRestEncryption'
+                storageId:
+                    type: string
+            description: LocalDataLocation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LocalRedundancy:
+            type: object
+            properties:
+                geoLocations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GeoLocation'
+            description: LocalRedundancy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LogDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: LogDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        LogGet:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                logging:
+                    $ref: '#/components/schemas/Logging'
+            description: |-
+                LogGet is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A log get operation e.g. `logging.getLogger("...")`.
+        LogOutput:
+            type: object
+            properties:
+                call:
+                    type: string
+                value:
+                    type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                logging:
+                    $ref: '#/components/schemas/Logging'
+            description: |-
+                LogOutput is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A generic Logoutput.
+        LogWrite:
+            type: object
+            properties:
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                logging:
+                    $ref: '#/components/schemas/Logging'
+            description: |-
+                LogWrite is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A log write operation e.g. `loggint.warn("...")`.
+        Logging:
+            type: object
+            properties:
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                applicationLogging:
+                    $ref: '#/components/schemas/ApplicationLogging'
+                bootLogging:
+                    $ref: '#/components/schemas/BootLogging'
+                osLogging:
+                    $ref: '#/components/schemas/OSLogging'
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+            description: |-
+                Logging is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 enum:logLevel=DEBUG,INFO,WARN,ERROR
+        LoggingService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                LoggingService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A logging-as-a-service offering, e.g. for analyzing logs; has a Storage resource that stores the logs
+        MachineLearningDataset:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                size:
+                    type: integer
+                    format: int32
+                type:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: MachineLearningDataset is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        MachineLearningModel:
+            type: object
+            properties:
+                adversarialRobustnessScore:
+                    type: number
+                    format: float
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                evasionEfficacyLevel:
+                    type: number
+                    format: float
+                explainability:
+                    type: number
+                    format: float
+                explainabilityEnabled:
+                    type: boolean
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                membershipInferenceResilience:
+                    type: number
+                    format: float
+                modelStealResilience:
+                    type: number
+                    format: float
+                name:
+                    type: string
+                poisonedDataLevel:
+                    type: number
+                    format: float
+                poisoningResilienceLevel:
+                    type: number
+                    format: float
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+                vulnerabilities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Vulnerability'
+            description: MachineLearningModel is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        MachineLearningService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                machineLearningIds:
+                    type: array
+                    items:
+                        type: string
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: MachineLearningService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Main:
+            type: object
+            properties:
+                usedBy:
+                    $ref: '#/components/schemas/OperatingSystemArchitecture'
+            description: |-
+                Main is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 The main function of a program.
+        MalwareProtection:
+            type: object
+            properties:
+                durationSinceActive:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                enabled:
+                    type: boolean
+                numberOfThreatsFound:
+                    type: integer
+                    format: int32
+                applicationLogging:
+                    $ref: '#/components/schemas/ApplicationLogging'
+            description: |-
+                MalwareProtection is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 analyzes the activity within a Compute resource
+        ManagedKeyEncryption:
+            type: object
+            properties:
+                algorithm:
+                    type: string
+                enabled:
+                    type: boolean
+                keyUrl:
+                    type: string
+                basedOn:
+                    $ref: '#/components/schemas/Cipher'
+                secretId:
+                    type: string
+            description: ManagedKeyEncryption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Memory:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                mode:
+                    type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                parentId:
+                    type: string
+            description: |-
+                Memory is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A generic concept to describe memory operations with a program. This includes allocation and de-allocation of memory as well as copying memory regions.
+        MessageAuthenticationCode:
+            type: object
+            properties:
+                type:
+                    type: string
+                input:
+                    $ref: '#/components/schemas/Input'
+                keyId:
+                    type: string
+            description: MessageAuthenticationCode is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        MessagingHub:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: MessagingHub is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        MonitoringProcedure:
+            type: object
+            properties:
+                intervalMonths:
+                    type: integer
+                    description: The interval refers to the interval in months.
+                    format: int32
+            description: |-
+                MonitoringProcedure is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 intervalMonths: Review frequency (in months) for reviewing monitoring procedures
+        MultiFactorAuthentiation:
+            type: object
+            properties:
+                contextIsChecked:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+                authenticities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Authenticity'
+            description: MultiFactorAuthentiation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        MultiModalDatabaseService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                anomalyDetections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnomalyDetection'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                MultiModalDatabaseService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This class represents a database service that identifies itself as "multi-model", e.g., offers document storage as well as relational features.
+        NeedToKnowPolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                isDefined:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                NeedToKnowPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a policy section within a [PolicyDocument] describing need-to-know access control requirements. isDefined: whether this policy section is present and defined.
+        NetworkInterface:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                accessRestriction:
+                    $ref: '#/components/schemas/AccessRestriction'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkServiceId:
+                    type: string
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: NetworkInterface is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        NetworkSecurityGroup:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: NetworkSecurityGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        NoAuthentication:
+            type: object
+            properties:
+                contextIsChecked:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+            description: NoAuthentication is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        OSLogging:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                monitoringLogDataEnabled:
+                    type: boolean
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                securityAlertsEnabled:
+                    type: boolean
+                loggingServiceIds:
+                    type: array
+                    items:
+                        type: string
+            description: OSLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        OTPBasedAuthentication:
+            type: object
+            properties:
+                activated:
+                    type: boolean
+                contextIsChecked:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+            description: OTPBasedAuthentication is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ObjectStorage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                publicAccess:
+                    type: boolean
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                atRestEncryption:
+                    $ref: '#/components/schemas/AtRestEncryption'
+                backups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Backup'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                immutability:
+                    $ref: '#/components/schemas/Immutability'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: ObjectStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ObjectStorageRequest:
+            type: object
+            properties:
+                source:
+                    type: string
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                objectStorageIds:
+                    type: array
+                    items:
+                        type: string
+                storageId:
+                    type: string
+            description: ObjectStorageRequest is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ObjectStorageService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                ObjectStorageService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 An object storage service represents the network service that is used to access a list of object storage containers. The storage itself is modelled as a ObjectStorage. The service has an http endpoint.
+        OperatingSystemArchitecture:
+            type: object
+            properties:
+                agnostic:
+                    $ref: '#/components/schemas/Agnostic'
+                darwin:
+                    $ref: '#/components/schemas/Darwin'
+                posix:
+                    $ref: '#/components/schemas/POSIX'
+                win32:
+                    $ref: '#/components/schemas/Win32'
+            description: |-
+                OperatingSystemArchitecture is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+                 Represents an architecture of an operating system.
+        Output:
+            type: object
+            properties: {}
+            description: Output is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        POSIX:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: |-
+                POSIX is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a POSIX architecture, commonly found on Linux systems.
+        Package:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: |-
+                Package is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a grouping of (source) code into logical unit, for example a package for a namespace.
+        Padding:
+            type: object
+            properties:
+                scheme:
+                    type: string
+                    description: Describes a certain scheme e.g. a padding scheme.
+            description: |-
+                Padding is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A padding for a cipher.
+        PasswordBasedAuthentication:
+            type: object
+            properties:
+                activated:
+                    type: boolean
+                contextIsChecked:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+            description: PasswordBasedAuthentication is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        PasswordPolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: PasswordPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        PolicyDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataConfidentialitySdnPolicyId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                governances:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Governance'
+                leastPrivilegePolicyId:
+                    type: string
+                needToKnowPolicyId:
+                    type: string
+                parentId:
+                    type: string
+                sdnFunctionValidationPolicyId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+                separationOfDutiesPolicyId:
+                    type: string
+            description: PolicyDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Principal:
+            type: object
+            properties: {}
+            description: |-
+                Principal is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a principal that is allowed to access a resource. This can for example be a (structure representing) a user or a group of users.
+        Product:
+            type: object
+            properties:
+                contextOfUse:
+                    type: string
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                programmingVersion:
+                    type: string
+                purpose:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                supportEnds:
+                    type: string
+                    description: Support ends date for a certain resource.
+                    format: date-time
+                type:
+                    type: string
+                codeIds:
+                    type: array
+                    items:
+                        type: string
+                contactPerson:
+                    $ref: '#/components/schemas/ContactPerson'
+                dataIds:
+                    type: array
+                    items:
+                        type: string
+                governances:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Governance'
+                hardwareIds:
+                    type: array
+                    items:
+                        type: string
+                infrastructureIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: Product is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ProductionAndMonitoringProcessDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: ProductionAndMonitoringProcessDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ProtectedAsset:
+            type: object
+            properties:
+                policyIds:
+                    type: array
+                    items:
+                        type: string
+                protects:
+                    $ref: '#/components/schemas/Resource'
+            description: |-
+                ProtectedAsset is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an asset that is protected by a policy. This can be an in-memory data structure, a file, a database, or any other resource that requires access control.
+        ProvideConfiguration:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationSourceId:
+                    type: string
+            description: |-
+                ProvideConfiguration is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to provide a [Configuration], e.g., in the form of a configuration file (through a [ConfigurationSource]). When the configuration file is loaded, a [LoadConfiguration] operation would be found in the code component (matching the configuration file's name in [LoadConfiguration.fileExpression]) and the [ProvideConfiguration] operation would be found in the configuration component. But also other sources of configuration could be represented by a [ProvideConfiguration] operation, such as environment variables or command-line arguments. Note: The [ProvideConfiguration] operation is part of the [ConfigurationSource.ops] and not of the [Configuration.ops] as it's an operation of the source, not the target.
+        ProvideConfigurationGroup:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationGroupId:
+                    type: string
+                configurationGroupSourceId:
+                    type: string
+            description: ProvideConfigurationGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ProvideConfigurationOption:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationOptionId:
+                    type: string
+                configurationOptionSourceId:
+                    type: string
+            description: |-
+                ProvideConfigurationOption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to provide a [ConfigurationOption]. It connects a [ConfigurationOptionSource] with a [ConfigurationOption].
+        QPU:
+            type: object
+            properties:
+                oneQubitErrorRate:
+                    type: number
+                    format: float
+                spamErrorRate:
+                    type: number
+                    format: float
+                t1CoherenceTime:
+                    type: number
+                    description: Coherence times are a standard measure for the reliability of executing quantum circuits. T1 is the qubits's energy relaxation time (in seconds).
+                    format: float
+                t2CoherenceTime:
+                    type: number
+                    description: Coherence times are a standard measure for the reliability of executing quantum circuits. T1 is the qubits's energy dephasing time (in seconds).
+                    format: float
+                twoQubitErrorRate:
+                    type: number
+                    format: float
+                universalGateSetEnabled:
+                    type: boolean
+                    description: The physical operations shall include a finite set of gates capable of approximating any unitary operation on qubits. This is typically achieved through combinations of one-qubit gates and a two-qubit entangling gate, such as CNOT, enabling the execution of a broad range of quantum algorithms.
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                errorCorrectionEnabled:
+                    type: boolean
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                encryptionInUse:
+                    $ref: '#/components/schemas/EncryptionInUse'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkInterfaceIds:
+                    type: array
+                    items:
+                        type: string
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                remoteAttestation:
+                    $ref: '#/components/schemas/RemoteAttestation'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: QPU is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RBAC:
+            type: object
+            properties:
+                broadAssignments:
+                    type: number
+                    description: 'see Privacy Smells: Detecting Privacy Problems in Cloud Architectures (2020)'
+                    format: float
+                mixedDuties:
+                    type: number
+                    description: 'see Privacy Smells: Detecting Privacy Problems in Cloud Architectures (2020)'
+                    format: float
+            description: RBAC is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RateLimiting:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                maxRequests:
+                    type: integer
+                    format: int32
+                timeWindowSeconds:
+                    type: integer
+                    format: int32
+            description: |-
+                RateLimiting is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Rate limiting is used to control the frequency of incoming requests to prevent system overload
+        ReadConfigurationGroup:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationGroupId:
+                    type: string
+            description: |-
+                ReadConfigurationGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to read a specific configuration group. Often this is done with a member access or a subscript operation on the configuration object, such as`conf.GROUP` or`conf["GROUP"]`.
+        ReadConfigurationOption:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationOptionId:
+                    type: string
+            description: |-
+                ReadConfigurationOption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to read a specific configuration option. Often this is done with a member access such as `group.option` or a subscript operation such as `group["option"]`.
+        Redundancy:
+            type: object
+            properties:
+                geoRedundancy:
+                    $ref: '#/components/schemas/GeoRedundancy'
+                localRedundancy:
+                    $ref: '#/components/schemas/LocalRedundancy'
+                zoneRedundancy:
+                    $ref: '#/components/schemas/ZoneRedundancy'
+            description: Redundancy is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        RegisterConfigurationGroup:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationGroupId:
+                    type: string
+            description: |-
+                RegisterConfigurationGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to register a new [ConfigurationGroup]. This is often done with a call, such as `conf.registerGroup("group")`. This might not be necessary for all configuration frameworks, some might allow to directly read the group (via [ReadConfigurationGroup]) without registering it first, or it is done implicitly. When code and configuration is interacting, we expect that the configuration file (such as an INI file) contains the [ConfigurationGroup] node and the code contains the [RegisterConfigurationGroup] and [ReadConfigurationGroup] nodes.
+        RegisterConfigurationOption:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                configurationId:
+                    type: string
+                configurationOptionId:
+                    type: string
+            description: |-
+                RegisterConfigurationOption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to register a new [ConfigurationOption]. This is often done with a call, such as `conf.registerOption("option", "defaultValue")`. This might not be necessary for all configuration frameworks, some might allow to directly read the group (via  [RegisterConfigurationOption]) without registering it first, or it is done implicitly. When code and configuration is interacting, we expect that the configuration file (such as an INI file) contains the [ConfigurationOption] node and the code contains the [RegisterConfigurationOption] and [ReadConfigurationOption] nodes.
+        RegisterHttpEndpoint:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                httpRequestHandler:
+                    $ref: '#/components/schemas/HttpRequestHandler'
+            description: RegisterHttpEndpoint is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RelationalDatabaseService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                anomalyDetections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnomalyDetection'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                httpEndpoint:
+                    $ref: '#/components/schemas/HttpEndpoint'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                serviceMetadataDocumentId:
+                    type: string
+                storageIds:
+                    type: array
+                    items:
+                        type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: RelationalDatabaseService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RemoteAttestation:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                enabled:
+                    type: boolean
+                status:
+                    type: boolean
+            description: RemoteAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RemoteDataLocation:
+            type: object
+            properties:
+                path:
+                    type: string
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                storageId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+            description: RemoteDataLocation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ReportDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: ReportDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RequestForChange:
+            type: object
+            properties:
+                approvedBeforeDeployment:
+                    type: boolean
+            description: RequestForChange is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Resource:
+            type: object
+            properties:
+                account:
+                    $ref: '#/components/schemas/Account'
+                job:
+                    $ref: '#/components/schemas/Job'
+                workflow:
+                    $ref: '#/components/schemas/Workflow'
+                codeRepository:
+                    $ref: '#/components/schemas/CodeRepository'
+                container:
+                    $ref: '#/components/schemas/Container'
+                function:
+                    $ref: '#/components/schemas/Function'
+                qpu:
+                    $ref: '#/components/schemas/QPU'
+                virtualMachine:
+                    $ref: '#/components/schemas/VirtualMachine'
+                containerOrchestration:
+                    $ref: '#/components/schemas/ContainerOrchestration'
+                containerRegistry:
+                    $ref: '#/components/schemas/ContainerRegistry'
+                certificate:
+                    $ref: '#/components/schemas/Certificate'
+                key:
+                    $ref: '#/components/schemas/Key'
+                secret:
+                    $ref: '#/components/schemas/Secret'
+                identity:
+                    $ref: '#/components/schemas/Identity'
+                roleAssignment:
+                    $ref: '#/components/schemas/RoleAssignment'
+                containerImage:
+                    $ref: '#/components/schemas/ContainerImage'
+                vmImage:
+                    $ref: '#/components/schemas/VMImage'
+                deviceProvisioningService:
+                    $ref: '#/components/schemas/DeviceProvisioningService'
+                messagingHub:
+                    $ref: '#/components/schemas/MessagingHub'
+                keyVault:
+                    $ref: '#/components/schemas/KeyVault'
+                networkInterface:
+                    $ref: '#/components/schemas/NetworkInterface'
+                networkSecurityGroup:
+                    $ref: '#/components/schemas/NetworkSecurityGroup'
+                functionService:
+                    $ref: '#/components/schemas/FunctionService'
+                genericNetworkService:
+                    $ref: '#/components/schemas/GenericNetworkService'
+                loadBalancer:
+                    $ref: '#/components/schemas/LoadBalancer'
+                loggingService:
+                    $ref: '#/components/schemas/LoggingService'
+                machineLearningService:
+                    $ref: '#/components/schemas/MachineLearningService'
+                securityAdvisoryService:
+                    $ref: '#/components/schemas/SecurityAdvisoryService'
+                documentDatabaseService:
+                    $ref: '#/components/schemas/DocumentDatabaseService'
+                keyValueDatabaseService:
+                    $ref: '#/components/schemas/KeyValueDatabaseService'
+                multiModalDatabaseService:
+                    $ref: '#/components/schemas/MultiModalDatabaseService'
+                relationalDatabaseService:
+                    $ref: '#/components/schemas/RelationalDatabaseService'
+                fileStorageService:
+                    $ref: '#/components/schemas/FileStorageService'
+                objectStorageService:
+                    $ref: '#/components/schemas/ObjectStorageService'
+                virtualNetwork:
+                    $ref: '#/components/schemas/VirtualNetwork'
+                virtualSubNetwork:
+                    $ref: '#/components/schemas/VirtualSubNetwork'
+                passwordPolicy:
+                    $ref: '#/components/schemas/PasswordPolicy'
+                resourceGroup:
+                    $ref: '#/components/schemas/ResourceGroup'
+                blockStorage:
+                    $ref: '#/components/schemas/BlockStorage'
+                databaseStorage:
+                    $ref: '#/components/schemas/DatabaseStorage'
+                fileStorage:
+                    $ref: '#/components/schemas/FileStorage'
+                objectStorage:
+                    $ref: '#/components/schemas/ObjectStorage'
+                configuration:
+                    $ref: '#/components/schemas/Configuration'
+                configurationGroup:
+                    $ref: '#/components/schemas/ConfigurationGroup'
+                configurationGroupSource:
+                    $ref: '#/components/schemas/ConfigurationGroupSource'
+                configurationOption:
+                    $ref: '#/components/schemas/ConfigurationOption'
+                configurationOptionSource:
+                    $ref: '#/components/schemas/ConfigurationOptionSource'
+                configurationSource:
+                    $ref: '#/components/schemas/ConfigurationSource'
+                context:
+                    $ref: '#/components/schemas/Context'
+                configurationDocument:
+                    $ref: '#/components/schemas/ConfigurationDocument'
+                cyberSecurityRiskAssessmentDocument:
+                    $ref: '#/components/schemas/CyberSecurityRiskAssessmentDocument'
+                distributionOfUpdatesDocument:
+                    $ref: '#/components/schemas/DistributionOfUpdatesDocument'
+                euDeclarationOfConformity:
+                    $ref: '#/components/schemas/EUDeclarationOfConformity'
+                reportDocument:
+                    $ref: '#/components/schemas/ReportDocument'
+                logDocument:
+                    $ref: '#/components/schemas/LogDocument'
+                policyDocument:
+                    $ref: '#/components/schemas/PolicyDocument'
+                productionAndMonitoringProcessDocument:
+                    $ref: '#/components/schemas/ProductionAndMonitoringProcessDocument'
+                sbomDocument:
+                    $ref: '#/components/schemas/SBOMDocument'
+                securityAdvisoryDocument:
+                    $ref: '#/components/schemas/SecurityAdvisoryDocument'
+                serviceMetadataDocument:
+                    $ref: '#/components/schemas/ServiceMetadataDocument'
+                userInformationAndIntructionDocument:
+                    $ref: '#/components/schemas/UserInformationAndIntructionDocument'
+                file:
+                    $ref: '#/components/schemas/File'
+                fileHandle:
+                    $ref: '#/components/schemas/FileHandle'
+                machineLearningDataset:
+                    $ref: '#/components/schemas/MachineLearningDataset'
+                machineLearningModel:
+                    $ref: '#/components/schemas/MachineLearningModel'
+                coordinatedVulnerabilityDisclosurePolicy:
+                    $ref: '#/components/schemas/CoordinatedVulnerabilityDisclosurePolicy'
+                dataConfidentialitySdnPolicy:
+                    $ref: '#/components/schemas/DataConfidentialitySDNPolicy'
+                leastPrivilegePolicy:
+                    $ref: '#/components/schemas/LeastPrivilegePolicy'
+                needToKnowPolicy:
+                    $ref: '#/components/schemas/NeedToKnowPolicy'
+                sdnFunctionValidationPolicy:
+                    $ref: '#/components/schemas/SDNFunctionValidationPolicy'
+                separationOfDutiesPolicy:
+                    $ref: '#/components/schemas/SeparationOfDutiesPolicy'
+                andRule:
+                    $ref: '#/components/schemas/AndRule'
+                token:
+                    $ref: '#/components/schemas/Token'
+                value:
+                    $ref: '#/components/schemas/Value'
+                memory:
+                    $ref: '#/components/schemas/Memory'
+                product:
+                    $ref: '#/components/schemas/Product'
+                application:
+                    $ref: '#/components/schemas/Application'
+                library:
+                    $ref: '#/components/schemas/Library'
+                package:
+                    $ref: '#/components/schemas/Package'
+                sourceCodeFile:
+                    $ref: '#/components/schemas/SourceCodeFile'
+                agnostic:
+                    $ref: '#/components/schemas/Agnostic'
+                darwin:
+                    $ref: '#/components/schemas/Darwin'
+                posix:
+                    $ref: '#/components/schemas/POSIX'
+                win32:
+                    $ref: '#/components/schemas/Win32'
+            description: Resource is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        ResourceGroup:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: ResourceGroup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ResourceLogging:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                logLevel:
+                    type: string
+                    description: enum:logLevel=FATAL,CRITICAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+                monitoringLogDataEnabled:
+                    type: boolean
+                retentionPeriod:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                securityAlertsEnabled:
+                    type: boolean
+                loggingServiceIds:
+                    type: array
+                    items:
+                        type: string
+            description: ResourceLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RobustnessScore:
+            type: object
+            properties: {}
+            description: RobustnessScore is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        RoleAssignment:
+            type: object
+            properties:
+                activated:
+                    type: boolean
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                authorization:
+                    $ref: '#/components/schemas/Authorization'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: RoleAssignment is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SBOMDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: SBOMDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SDNFunctionValidationPolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                isDefined:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                SDNFunctionValidationPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a policy section within a [PolicyDocument] describing validation and testing requirements for SDN functions. isDefined: whether this policy section is present and defined.
+        SchemaValidation:
+            type: object
+            properties:
+                format:
+                    type: string
+                schemaUrl:
+                    type: string
+                errors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Error'
+            description: SchemaValidation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Secret:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                enabled:
+                    type: boolean
+                expirationDate:
+                    type: string
+                    format: date-time
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                isManaged:
+                    type: boolean
+                keySize:
+                    type: integer
+                    description: Key size refers to the length of a key used in an enryption.
+                    format: int32
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                notBeforeDate:
+                    type: string
+                    format: date-time
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                basedOn:
+                    $ref: '#/components/schemas/Cipher'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                usedByMultiple:
+                    $ref: '#/components/schemas/Infrastructure'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Secret is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SecurityAdvisoryDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+                vulnerabilities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Vulnerability'
+            description: SecurityAdvisoryDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SecurityAdvisoryFeed:
+            type: object
+            properties:
+                securityAdvisoryDocumentIds:
+                    type: array
+                    items:
+                        type: string
+            description: SecurityAdvisoryFeed is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SecurityAdvisoryService:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                ips:
+                    type: array
+                    items:
+                        type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                ports:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                computeIds:
+                    type: array
+                    items:
+                        type: string
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                keyIds:
+                    type: array
+                    items:
+                        type: string
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                securityAdvisoryFeeds:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityAdvisoryFeed'
+                serviceMetadataDocumentId:
+                    type: string
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: |-
+                SecurityAdvisoryService is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 This service discloses security advisories, e.g. according to the CSAF standard. It has one or more feeds that contain the actual advisories as well as multiple (public) keys that are used to sign the advisory documents.
+        SecurityFeature:
+            type: object
+            properties:
+                anomalyDetection:
+                    $ref: '#/components/schemas/AnomalyDetection'
+                assetInventory:
+                    $ref: '#/components/schemas/AssetInventory'
+                codeSignoff:
+                    $ref: '#/components/schemas/CodeSignoff'
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                applicationLogging:
+                    $ref: '#/components/schemas/ApplicationLogging'
+                bootLogging:
+                    $ref: '#/components/schemas/BootLogging'
+                osLogging:
+                    $ref: '#/components/schemas/OSLogging'
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+                certificateBasedAuthentication:
+                    $ref: '#/components/schemas/CertificateBasedAuthentication'
+                jwtAuthentication:
+                    $ref: '#/components/schemas/JwtAuthentication'
+                multiFactorAuthentiation:
+                    $ref: '#/components/schemas/MultiFactorAuthentiation'
+                noAuthentication:
+                    $ref: '#/components/schemas/NoAuthentication'
+                otpBasedAuthentication:
+                    $ref: '#/components/schemas/OTPBasedAuthentication'
+                passwordBasedAuthentication:
+                    $ref: '#/components/schemas/PasswordBasedAuthentication'
+                singleSignOn:
+                    $ref: '#/components/schemas/SingleSignOn'
+                abac:
+                    $ref: '#/components/schemas/ABAC'
+                l3Firewall:
+                    $ref: '#/components/schemas/L3Firewall'
+                webApplicationFirewall:
+                    $ref: '#/components/schemas/WebApplicationFirewall'
+                rateLimiting:
+                    $ref: '#/components/schemas/RateLimiting'
+                rbac:
+                    $ref: '#/components/schemas/RBAC'
+                backup:
+                    $ref: '#/components/schemas/Backup'
+                dDoSProtection:
+                    $ref: '#/components/schemas/DDoSProtection'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                geoRedundancy:
+                    $ref: '#/components/schemas/GeoRedundancy'
+                localRedundancy:
+                    $ref: '#/components/schemas/LocalRedundancy'
+                zoneRedundancy:
+                    $ref: '#/components/schemas/ZoneRedundancy'
+                customerKeyEncryption:
+                    $ref: '#/components/schemas/CustomerKeyEncryption'
+                diskEncryption:
+                    $ref: '#/components/schemas/DiskEncryption'
+                managedKeyEncryption:
+                    $ref: '#/components/schemas/ManagedKeyEncryption'
+                transportEncryption:
+                    $ref: '#/components/schemas/TransportEncryption'
+                encryptionInUse:
+                    $ref: '#/components/schemas/EncryptionInUse'
+                localAttestation:
+                    $ref: '#/components/schemas/LocalAttestation'
+                remoteAttestation:
+                    $ref: '#/components/schemas/RemoteAttestation'
+                automaticUpdates:
+                    $ref: '#/components/schemas/AutomaticUpdates'
+                cryptographicHash:
+                    $ref: '#/components/schemas/CryptographicHash'
+                immutability:
+                    $ref: '#/components/schemas/Immutability'
+                documentSignature:
+                    $ref: '#/components/schemas/DocumentSignature'
+                signedCommits:
+                    $ref: '#/components/schemas/SignedCommits'
+                verifiedCommits:
+                    $ref: '#/components/schemas/VerifiedCommits'
+                explainableResults:
+                    $ref: '#/components/schemas/ExplainableResults'
+                robustnessScore:
+                    $ref: '#/components/schemas/RobustnessScore'
+            description: SecurityFeature is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
+        SecurityTraining:
+            type: object
+            properties:
+                annualUpdateCompleted:
+                    type: boolean
+                successfullyCompletedPercentage:
+                    type: boolean
+            description: SecurityTraining is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SeparationOfDutiesPolicy:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                isDefined:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
+            description: |-
+                SeparationOfDutiesPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a policy section within a [PolicyDocument] describing separation of duties requirements. isDefined: whether this policy section is present and defined.
+        ServiceMetadataDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: ServiceMetadataDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SignedCommits:
+            type: object
+            properties:
+                enforced:
+                    type: boolean
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "SignedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  SignedCommits cryptographically verify the identity of the commit author.\n Percentage: Percentage of signed commits. \n PercentageLastMonth: Percentage of signed commits in the last 30 days."
+        SingleSignOn:
+            type: object
+            properties:
+                contextIsChecked:
+                    type: boolean
+                enabled:
+                    type: boolean
+                failedAuthenticationAttempts:
+                    type: integer
+                    format: int32
+                rotationInterval:
+                    type: integer
+                    description: Maximum password rotation interval in months
+                    format: int32
+            description: SingleSignOn is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SourceCodeFile:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: SourceCodeFile is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Status:
             type: object
             properties:
@@ -145,5 +5765,487 @@ components:
                         $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        SymmetricCipher:
+            type: object
+            properties:
+                authTagSize:
+                    type: integer
+                    description: AuthTagSize of a symmetric cipher
+                    format: int32
+                blockSize:
+                    type: integer
+                    description: Block size of a cipher.
+                    format: int32
+                cipherName:
+                    type: string
+                    description: Name of a cryptographic cipher.
+                keySize:
+                    type: integer
+                    description: Key size refers to the length of a key used in an enryption.
+                    format: int32
+                modus:
+                    type: string
+                    description: Describes a modus of something being executed. (e.g. used by an Encryption)
+                initializationVector:
+                    $ref: '#/components/schemas/InitializationVector'
+                padding:
+                    $ref: '#/components/schemas/Padding'
+            description: |-
+                SymmetricCipher is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a symmetric cipher.
+        Time:
+            type: object
+            properties: {}
+            description: Time is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Token:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                Token is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A Token used for TokenBasedAuthentication.
+        TransportEncryption:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                enforced:
+                    type: boolean
+                protocol:
+                    type: string
+                protocolVersion:
+                    type: number
+                    format: float
+                tlsSignatureAlgorithm:
+                    type: string
+                    description: 'tlsSignatureAlgorithm: e.g., rsa_pss_rsae_sha256/384/512, ecdsa_secp256r1_sha256, ed25519'
+                basedOn:
+                    $ref: '#/components/schemas/Cipher'
+                cipherSuites:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CipherSuite'
+                secretId:
+                    type: string
+            description: |-
+                TransportEncryption is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 enabled means the resource _can_ be reached via https, while enforced means it _can only_ be reached via https (or http traffic is redirected)
+        UnlockEncryptedDisk:
+            type: object
+            properties:
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+                diskEncryption:
+                    $ref: '#/components/schemas/DiskEncryption'
+            description: UnlockEncryptedDisk is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        UsageStatistics:
+            type: object
+            properties:
+                apiHitsPerMonth:
+                    type: integer
+                    format: int32
+            description: UsageStatistics is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        UserInformationAndIntructionDocument:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                filetype:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                cryptographicHashs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CryptographicHash'
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                documentSignatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DocumentSignature'
+                parentId:
+                    type: string
+                validatedBy:
+                    $ref: '#/components/schemas/SchemaValidation'
+                securityFeatures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SecurityFeature'
+            description: UserInformationAndIntructionDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        VMImage:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                applicationId:
+                    type: string
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: VMImage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ValidateJwt:
+            type: object
+            properties:
+                authenticity:
+                    $ref: '#/components/schemas/Authenticity'
+                codeRegion:
+                    $ref: '#/components/schemas/CodeRegion'
+            description: |-
+                ValidateJwt is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents an operation to check the validity of a JWT token.
+        Value:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                parentId:
+                    type: string
+            description: |-
+                Value is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 The node that represents the "value" of this option. For example, in an INI file, this would be the [FieldDeclaration.initializer] node that represents the value.
+        VerifiedCommits:
+            type: object
+            properties:
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "VerifiedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  VerifiedCommits ensure that cryptographic signatures on commits are successfully validated against trusted keys, confirming author authenticity and code integrity.\n Percentage: Percentage of verified commits. \n PercentageLastMonth: Percentage of verified commits in the last 30 days."
+        VirtualMachine:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                activityLogging:
+                    $ref: '#/components/schemas/ActivityLogging'
+                automaticUpdates:
+                    $ref: '#/components/schemas/AutomaticUpdates'
+                blockStorageIds:
+                    type: array
+                    items:
+                        type: string
+                bootLogging:
+                    $ref: '#/components/schemas/BootLogging'
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                encryptionInUse:
+                    $ref: '#/components/schemas/EncryptionInUse'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                networkInterfaceIds:
+                    type: array
+                    items:
+                        type: string
+                osLogging:
+                    $ref: '#/components/schemas/OSLogging'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                remoteAttestation:
+                    $ref: '#/components/schemas/RemoteAttestation'
+                parentId:
+                    type: string
+                resourceLogging:
+                    $ref: '#/components/schemas/ResourceLogging'
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: VirtualMachine is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        VirtualNetwork:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: VirtualNetwork is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        VirtualSubNetwork:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: VirtualSubNetwork is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        Vulnerability:
+            type: object
+            properties:
+                criticality:
+                    type: string
+                    description: 'criticality: Contains the criticality of a vulnerability, e.g., low, medium, high, critical'
+                cve:
+                    type: string
+                cwe:
+                    type: array
+                    items:
+                        type: string
+                description:
+                    type: string
+                exploitable:
+                    type: boolean
+                    description: 'exploitable: Indicates whether a vulnerability is exploitable for the given target of evaluation (TOE)'
+                url:
+                    type: string
+            description: |-
+                Vulnerability is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 cve: Common Vulnerabilities and Exposures
+                 cwe: Common Weakness Enumeration
+        WebApplicationFirewall:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: |-
+                WebApplicationFirewall is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 A WAF is a L7 firewall that includes L3 capabilities
+        Win32:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                codeModuleIds:
+                    type: array
+                    items:
+                        type: string
+                codeRepositoryId:
+                    type: string
+                functionalities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Functionality'
+                parentId:
+                    type: string
+            description: |-
+                Win32 is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Represents a Win32 architecture, commonly found on Windows systems.
+        Workflow:
+            type: object
+            properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
+                internetAccessibleEndpoint:
+                    type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                changeAndConfigurationManagement:
+                    $ref: '#/components/schemas/ChangeAndConfigurationManagement'
+                geoLocation:
+                    $ref: '#/components/schemas/GeoLocation'
+                loggings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Logging'
+                malwareProtection:
+                    $ref: '#/components/schemas/MalwareProtection'
+                redundancies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Redundancy'
+                parentId:
+                    type: string
+                usageStatistics:
+                    $ref: '#/components/schemas/UsageStatistics'
+            description: Workflow is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ZoneRedundancy:
+            type: object
+            properties:
+                geoLocations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GeoLocation'
+            description: ZoneRedundancy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 tags:
     - name: Assessment

--- a/core/api/evidence/evidence.go
+++ b/core/api/evidence/evidence.go
@@ -16,14 +16,10 @@ package evidence
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
 
 	"confirmate.io/core/api/ontology"
-
-	"google.golang.org/protobuf/proto"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 type EvidenceHookFunc func(ctx context.Context, evidence *Evidence, err error)
@@ -48,48 +44,16 @@ func (ev *Evidence) GetOntologyResource() ontology.IsResource {
 	return resource
 }
 
-// ToEvidenceResource converts a proto message that complies to the interface [ontology.IsResource] into a resource
-// that can be persisted in our database ([*discovery.Resource]).
-func ToEvidenceResource(resource ontology.IsResource, ctID, collectorID string) (r *Resource, err error) {
-	var (
-		a *anypb.Any
-	)
-
-	// Convert our ontology resource into an Any proto message
-	a, err = anypb.New(resource)
-	if err != nil {
-		return nil, fmt.Errorf("could not convert protobuf structure: %w", err)
-	}
-
-	// Build a resource struct. This will hold the latest sync state of the
-	// resource for our storage layer.
-	r = &Resource{
+// ToResourceSnapshot converts a proto message that complies to the interface [ontology.IsResource]
+// into a resource snapshot that can be persisted in our database ([*ResourceSnapshot]).
+func ToResourceSnapshot(resource ontology.IsResource, toeId string, toolId string) (r *ResourceSnapshot, err error) {
+	r = &ResourceSnapshot{
 		Id:                   string(resource.GetId()),
 		ResourceType:         strings.Join(ontology.ResourceTypes(resource), ","),
-		TargetOfEvaluationId: ctID,
-		ToolId:               collectorID,
-		Properties:           a,
+		TargetOfEvaluationId: toeId,
+		ToolId:               toolId,
+		Resource:             ontology.ProtoResource(resource),
 	}
 
 	return
-}
-
-// ToOntologyResource converts the content of the "properties" (which is an [*anypb.Any]) into an [ontology.IsResource].
-func (r *Resource) ToOntologyResource() (or ontology.IsResource, err error) {
-	var (
-		m  proto.Message
-		ok bool
-	)
-
-	m, err = r.Properties.UnmarshalNew()
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal resource properties: %w", err)
-	}
-
-	or, ok = m.(ontology.IsResource)
-	if !ok {
-		return nil, ontology.ErrNotOntologyResource
-	}
-
-	return or, nil
 }

--- a/core/api/evidence/evidence.pb.go
+++ b/core/api/evidence/evidence.pb.go
@@ -27,7 +27,6 @@ import (
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -136,9 +135,12 @@ func (x *Evidence) GetExperimentalRelatedResourceIds() []string {
 	return nil
 }
 
-// Resource is a wrapper around google.protobuf.Value that is needed for
-// persistence reasons.
-type Resource struct {
+// ResourceSnapshot is the persisted representation of a cloud resource.
+// It is distinct from confirmate.ontology.v1.Resource, which is the semantic
+// discriminated union of all concrete ontology types. ResourceSnapshot carries
+// metadata (id, resourceType, targetOfEvaluationId, toolId) plus the
+// serialised ontology properties.
+type ResourceSnapshot struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Id contains a unique ID for each resource. This is specific for the cloud
 	// provider this resource was gathered for and can for example be a resource
@@ -152,27 +154,26 @@ type Resource struct {
 	ResourceType string `protobuf:"bytes,3,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
 	// Reference to the tool which provided the resource
 	ToolId string `protobuf:"bytes,4,opt,name=tool_id,json=toolId,proto3" json:"tool_id,omitempty"`
-	// Properties contains a protobuf message that describe the resource in the
-	// terms of our ontology.
-	Properties    *anypb.Any `protobuf:"bytes,10,opt,name=properties,proto3" json:"properties,omitempty" gorm:"serializer:anypb;type:json"`
+	// Semantic representation of the Cloud resource according to our defined ontology
+	Resource      *ontology.Resource `protobuf:"bytes,6,opt,name=resource,proto3" json:"resource,omitempty" gorm:"serializer:json"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *Resource) Reset() {
-	*x = Resource{}
+func (x *ResourceSnapshot) Reset() {
+	*x = ResourceSnapshot{}
 	mi := &file_api_evidence_evidence_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *Resource) String() string {
+func (x *ResourceSnapshot) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Resource) ProtoMessage() {}
+func (*ResourceSnapshot) ProtoMessage() {}
 
-func (x *Resource) ProtoReflect() protoreflect.Message {
+func (x *ResourceSnapshot) ProtoReflect() protoreflect.Message {
 	mi := &file_api_evidence_evidence_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -184,49 +185,49 @@ func (x *Resource) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Resource.ProtoReflect.Descriptor instead.
-func (*Resource) Descriptor() ([]byte, []int) {
+// Deprecated: Use ResourceSnapshot.ProtoReflect.Descriptor instead.
+func (*ResourceSnapshot) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *Resource) GetId() string {
+func (x *ResourceSnapshot) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *Resource) GetTargetOfEvaluationId() string {
+func (x *ResourceSnapshot) GetTargetOfEvaluationId() string {
 	if x != nil {
 		return x.TargetOfEvaluationId
 	}
 	return ""
 }
 
-func (x *Resource) GetResourceType() string {
+func (x *ResourceSnapshot) GetResourceType() string {
 	if x != nil {
 		return x.ResourceType
 	}
 	return ""
 }
 
-func (x *Resource) GetToolId() string {
+func (x *ResourceSnapshot) GetToolId() string {
 	if x != nil {
 		return x.ToolId
 	}
 	return ""
 }
 
-func (x *Resource) GetProperties() *anypb.Any {
+func (x *ResourceSnapshot) GetResource() *ontology.Resource {
 	if x != nil {
-		return x.Properties
+		return x.Resource
 	}
 	return nil
 }
 
 type UpdateResourceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Resource      *Resource              `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
+	Resource      *ResourceSnapshot      `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -261,7 +262,7 @@ func (*UpdateResourceRequest) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *UpdateResourceRequest) GetResource() *Resource {
+func (x *UpdateResourceRequest) GetResource() *ResourceSnapshot {
 	if x != nil {
 		return x.Resource
 	}
@@ -460,28 +461,25 @@ var File_api_evidence_evidence_proto protoreflect.FileDescriptor
 
 const file_api_evidence_evidence_proto_rawDesc = "" +
 	"\n" +
-	"\x1bapi/evidence/evidence.proto\x12\x16confirmate.evidence.v1\x1a4policies/security-metrics/ontology/v1/ontology.proto\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19google/protobuf/any.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x13tagger/tagger.proto\"\xbe\x03\n" +
+	"\x1bapi/evidence/evidence.proto\x12\x16confirmate.evidence.v1\x1a4policies/security-metrics/ontology/v1/ontology.proto\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x13tagger/tagger.proto\"\xbe\x03\n" +
 	"\bEvidence\x12\x18\n" +
 	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12q\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampB7\xbaH\x03\xc8\x01\x01\x9a\x84\x9e\x03,gorm:\"serializer:timestamppb;type:timestamp\"R\ttimestamp\x12?\n" +
 	"\x17target_of_evaluation_id\x18\x03 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x14targetOfEvaluationId\x12 \n" +
 	"\atool_id\x18\x04 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06toolId\x12Y\n" +
 	"\bresource\x18\x06 \x01(\v2 .confirmate.ontology.v1.ResourceB\x1b\x9a\x84\x9e\x03\x16gorm:\"serializer:json\"R\bresource\x12g\n" +
-	"!experimental_related_resource_ids\x18\xe7\a \x03(\tB\x1b\x9a\x84\x9e\x03\x16gorm:\"serializer:json\"R\x1eexperimentalRelatedResourceIds\"\xa7\x02\n" +
-	"\bResource\x12\x1a\n" +
+	"!experimental_related_resource_ids\x18\xe7\a \x03(\tB\x1b\x9a\x84\x9e\x03\x16gorm:\"serializer:json\"R\x1eexperimentalRelatedResourceIds\"\xa3\x02\n" +
+	"\x10ResourceSnapshot\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x02id\x12B\n" +
 	"\x17target_of_evaluation_id\x18\x02 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x14targetOfEvaluationId\x12/\n" +
 	"\rresource_type\x18\x03 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\fresourceType\x12#\n" +
 	"\atool_id\x18\x04 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06toolId\x12e\n" +
-	"\n" +
-	"properties\x18\n" +
-	" \x01(\v2\x14.google.protobuf.AnyB/\xe0A\x02\xbaH\x03\xc8\x01\x01\x9a\x84\x9e\x03!gorm:\"serializer:anypb;type:json\"R\n" +
-	"properties\"Z\n" +
-	"\x15UpdateResourceRequest\x12A\n" +
-	"\bresource\x18\x01 \x01(\v2 .confirmate.evidence.v1.ResourceB\x03\xe0A\x02R\bresource\"\x80\x01\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06toolId\x12Y\n" +
+	"\bresource\x18\x06 \x01(\v2 .confirmate.ontology.v1.ResourceB\x1b\x9a\x84\x9e\x03\x16gorm:\"serializer:json\"R\bresource\"b\n" +
+	"\x15UpdateResourceRequest\x12I\n" +
+	"\bresource\x18\x01 \x01(\v2(.confirmate.evidence.v1.ResourceSnapshotB\x03\xe0A\x02R\bresource\"\x80\x01\n" +
 	"\x15ListGraphEdgesRequest\x12\x1b\n" +
 	"\tpage_size\x18\n" +
 	" \x01(\x05R\bpageSize\x12\x1d\n" +
@@ -499,9 +497,9 @@ const file_api_evidence_evidence_proto_rawDesc = "" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06source\x12\"\n" +
 	"\x06target\x18\x03 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06target\x12\x17\n" +
-	"\x04type\x18\x04 \x01(\tB\x03\xe0A\x02R\x04type2\xba\x02\n" +
-	"\tResources\x12\x98\x01\n" +
-	"\x0eUpdateResource\x12-.confirmate.evidence.v1.UpdateResourceRequest\x1a .confirmate.evidence.v1.Resource\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/evidence_store/resources/{resource.id}\x12\x91\x01\n" +
+	"\x04type\x18\x04 \x01(\tB\x03\xe0A\x02R\x04type2\xc2\x02\n" +
+	"\tResources\x12\xa0\x01\n" +
+	"\x0eUpdateResource\x12-.confirmate.evidence.v1.UpdateResourceRequest\x1a(.confirmate.evidence.v1.ResourceSnapshot\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/evidence_store/resources/{resource.id}\x12\x91\x01\n" +
 	"\x0eListGraphEdges\x12-.confirmate.evidence.v1.ListGraphEdgesRequest\x1a..confirmate.evidence.v1.ListGraphEdgesResponse\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/evidence/graph/edgesB!Z\x1fconfirmate.io/core/api/evidenceb\x06proto3"
 
 var (
@@ -519,24 +517,23 @@ func file_api_evidence_evidence_proto_rawDescGZIP() []byte {
 var file_api_evidence_evidence_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_api_evidence_evidence_proto_goTypes = []any{
 	(*Evidence)(nil),               // 0: confirmate.evidence.v1.Evidence
-	(*Resource)(nil),               // 1: confirmate.evidence.v1.Resource
+	(*ResourceSnapshot)(nil),       // 1: confirmate.evidence.v1.ResourceSnapshot
 	(*UpdateResourceRequest)(nil),  // 2: confirmate.evidence.v1.UpdateResourceRequest
 	(*ListGraphEdgesRequest)(nil),  // 3: confirmate.evidence.v1.ListGraphEdgesRequest
 	(*ListGraphEdgesResponse)(nil), // 4: confirmate.evidence.v1.ListGraphEdgesResponse
 	(*GraphEdge)(nil),              // 5: confirmate.evidence.v1.GraphEdge
 	(*timestamppb.Timestamp)(nil),  // 6: google.protobuf.Timestamp
 	(*ontology.Resource)(nil),      // 7: confirmate.ontology.v1.Resource
-	(*anypb.Any)(nil),              // 8: google.protobuf.Any
 }
 var file_api_evidence_evidence_proto_depIdxs = []int32{
 	6, // 0: confirmate.evidence.v1.Evidence.timestamp:type_name -> google.protobuf.Timestamp
 	7, // 1: confirmate.evidence.v1.Evidence.resource:type_name -> confirmate.ontology.v1.Resource
-	8, // 2: confirmate.evidence.v1.Resource.properties:type_name -> google.protobuf.Any
-	1, // 3: confirmate.evidence.v1.UpdateResourceRequest.resource:type_name -> confirmate.evidence.v1.Resource
+	7, // 2: confirmate.evidence.v1.ResourceSnapshot.resource:type_name -> confirmate.ontology.v1.Resource
+	1, // 3: confirmate.evidence.v1.UpdateResourceRequest.resource:type_name -> confirmate.evidence.v1.ResourceSnapshot
 	5, // 4: confirmate.evidence.v1.ListGraphEdgesResponse.edges:type_name -> confirmate.evidence.v1.GraphEdge
 	2, // 5: confirmate.evidence.v1.Resources.UpdateResource:input_type -> confirmate.evidence.v1.UpdateResourceRequest
 	3, // 6: confirmate.evidence.v1.Resources.ListGraphEdges:input_type -> confirmate.evidence.v1.ListGraphEdgesRequest
-	1, // 7: confirmate.evidence.v1.Resources.UpdateResource:output_type -> confirmate.evidence.v1.Resource
+	1, // 7: confirmate.evidence.v1.Resources.UpdateResource:output_type -> confirmate.evidence.v1.ResourceSnapshot
 	4, // 8: confirmate.evidence.v1.Resources.ListGraphEdges:output_type -> confirmate.evidence.v1.ListGraphEdgesResponse
 	7, // [7:9] is the sub-list for method output_type
 	5, // [5:7] is the sub-list for method input_type

--- a/core/api/evidence/evidence.proto
+++ b/core/api/evidence/evidence.proto
@@ -20,7 +20,6 @@ import "policies/security-metrics/ontology/v1/ontology.proto";
 import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "google/api/annotations.proto";
-import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "tagger/tagger.proto";
 
@@ -54,9 +53,12 @@ message Evidence {
   repeated string experimental_related_resource_ids = 999 [(tagger.tags) = "gorm:\"serializer:json\""];
 }
 
-// Resource is a wrapper around google.protobuf.Value that is needed for
-// persistence reasons.
-message Resource {
+// ResourceSnapshot is the persisted representation of a cloud resource.
+// It is distinct from confirmate.ontology.v1.Resource, which is the semantic
+// discriminated union of all concrete ontology types. ResourceSnapshot carries
+// metadata (id, resourceType, targetOfEvaluationId, toolId) plus the
+// serialised ontology properties.
+message ResourceSnapshot {
   // Id contains a unique ID for each resource. This is specific for the cloud
   // provider this resource was gathered for and can for example be a resource
   // URL.
@@ -82,13 +84,8 @@ message Resource {
     (google.api.field_behavior) = REQUIRED
   ];
 
-  // Properties contains a protobuf message that describe the resource in the
-  // terms of our ontology.
-  google.protobuf.Any properties = 10 [
-    (tagger.tags) = "gorm:\"serializer:anypb;type:json\"",
-    (buf.validate.field).required = true,
-    (google.api.field_behavior) = REQUIRED
-  ];
+  // Semantic representation of the Cloud resource according to our defined ontology
+  confirmate.ontology.v1.Resource resource = 6 [(tagger.tags) = "gorm:\"serializer:json\""];
 }
 
 // Maps cloud resources and its properties to the format of the
@@ -97,7 +94,7 @@ service Resources {
   // UpdateResource updates a resource (or creates it, if it does not exist).
   // This is used to give third-party tools the possibility to add something to
   // the resource graph.
-  rpc UpdateResource(UpdateResourceRequest) returns (confirmate.evidence.v1.Resource) {
+  rpc UpdateResource(UpdateResourceRequest) returns (confirmate.evidence.v1.ResourceSnapshot) {
     option (google.api.http) = {
       post: "/v1/evidence_store/resources/{resource.id}"
       body: "*"
@@ -112,7 +109,7 @@ service Resources {
 }
 
 message UpdateResourceRequest {
-  confirmate.evidence.v1.Resource resource = 1 [(google.api.field_behavior) = REQUIRED];
+  confirmate.evidence.v1.ResourceSnapshot resource = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListGraphEdgesRequest {

--- a/core/api/evidence/evidence_store.pb.go
+++ b/core/api/evidence/evidence_store.pb.go
@@ -604,7 +604,7 @@ func (x *ListResourcesRequest) GetAsc() bool {
 
 type ListResourcesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Results       []*Resource            `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	Results       []*ResourceSnapshot    `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -640,7 +640,7 @@ func (*ListResourcesResponse) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *ListResourcesResponse) GetResults() []*Resource {
+func (x *ListResourcesResponse) GetResults() []*ResourceSnapshot {
 	if x != nil {
 		return x.Results
 	}
@@ -845,9 +845,9 @@ const file_api_evidence_evidence_store_proto_rawDesc = "" +
 	"\x18_target_of_evaluation_idB\n" +
 	"\n" +
 	"\b_tool_idB\t\n" +
-	"\a_filter\"\x80\x01\n" +
-	"\x15ListResourcesResponse\x12?\n" +
-	"\aresults\x18\x01 \x03(\v2 .confirmate.evidence.v1.ResourceB\x03\xe0A\x02R\aresults\x12&\n" +
+	"\a_filter\"\x88\x01\n" +
+	"\x15ListResourcesResponse\x12G\n" +
+	"\aresults\x18\x01 \x03(\v2(.confirmate.evidence.v1.ResourceSnapshotB\x03\xe0A\x02R\aresults\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x12\n" +
 	"\x10ListToolsRequest\".\n" +
 	"\x11ListToolsResponse\x12\x19\n" +
@@ -896,7 +896,7 @@ var file_api_evidence_evidence_store_proto_goTypes = []any{
 	(*ListToolsResponse)(nil),                  // 13: confirmate.evidence.v1.ListToolsResponse
 	(*ListResourcesRequest_Filter)(nil),        // 14: confirmate.evidence.v1.ListResourcesRequest.Filter
 	(*Evidence)(nil),                           // 15: confirmate.evidence.v1.Evidence
-	(*Resource)(nil),                           // 16: confirmate.evidence.v1.Resource
+	(*ResourceSnapshot)(nil),                   // 16: confirmate.evidence.v1.ResourceSnapshot
 }
 var file_api_evidence_evidence_store_proto_depIdxs = []int32{
 	15, // 0: confirmate.evidence.v1.StoreEvidenceRequest.evidence:type_name -> confirmate.evidence.v1.Evidence
@@ -904,7 +904,7 @@ var file_api_evidence_evidence_store_proto_depIdxs = []int32{
 	5,  // 2: confirmate.evidence.v1.ListEvidencesRequest.filter:type_name -> confirmate.evidence.v1.Filter
 	15, // 3: confirmate.evidence.v1.ListEvidencesResponse.evidences:type_name -> confirmate.evidence.v1.Evidence
 	14, // 4: confirmate.evidence.v1.ListResourcesRequest.filter:type_name -> confirmate.evidence.v1.ListResourcesRequest.Filter
-	16, // 5: confirmate.evidence.v1.ListResourcesResponse.results:type_name -> confirmate.evidence.v1.Resource
+	16, // 5: confirmate.evidence.v1.ListResourcesResponse.results:type_name -> confirmate.evidence.v1.ResourceSnapshot
 	1,  // 6: confirmate.evidence.v1.EvidenceStore.StoreEvidence:input_type -> confirmate.evidence.v1.StoreEvidenceRequest
 	1,  // 7: confirmate.evidence.v1.EvidenceStore.StoreEvidences:input_type -> confirmate.evidence.v1.StoreEvidenceRequest
 	4,  // 8: confirmate.evidence.v1.EvidenceStore.ListEvidences:input_type -> confirmate.evidence.v1.ListEvidencesRequest

--- a/core/api/evidence/evidence_store.proto
+++ b/core/api/evidence/evidence_store.proto
@@ -132,7 +132,7 @@ message ListResourcesRequest {
 }
 
 message ListResourcesResponse {
-  repeated Resource results = 1 [(google.api.field_behavior) = REQUIRED];
+  repeated ResourceSnapshot results = 1 [(google.api.field_behavior) = REQUIRED];
   string next_page_token = 2;
 }
 

--- a/core/api/evidence/evidence_test.go
+++ b/core/api/evidence/evidence_test.go
@@ -18,13 +18,10 @@ package evidence
 import (
 	"testing"
 
-	anypb "google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"confirmate.io/core/api/ontology"
 	"confirmate.io/core/util/assert"
-	"confirmate.io/core/util/prototest"
 )
 
 func TestEvidence_GetOntologyResource(t *testing.T) {
@@ -88,77 +85,16 @@ func TestEvidence_GetOntologyResource(t *testing.T) {
 	}
 }
 
-func TestResource_ToOntologyResource(t *testing.T) {
-	type fields struct {
-		Id                   string
-		TargetOfEvaluationId string
-		ResourceType         string
-		Properties           *anypb.Any
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    ontology.IsResource
-		wantErr assert.WantErr
-	}{
-		{
-			name: "happy path VM",
-			fields: fields{
-				Id:                   "vm1",
-				TargetOfEvaluationId: "target1",
-				ResourceType:         "VirtualMachine",
-				Properties: prototest.NewAny(t, &ontology.VirtualMachine{
-					Id:              "vm1",
-					BlockStorageIds: []string{"bs1"},
-				}),
-			},
-			want: &ontology.VirtualMachine{
-				Id:              "vm1",
-				BlockStorageIds: []string{"bs1"},
-			},
-			wantErr: assert.Nil[error],
-		},
-		{
-			name: "not an ontology resource",
-			fields: fields{
-				Id:                   "vm1",
-				TargetOfEvaluationId: "target1",
-				ResourceType:         "Something",
-				Properties:           prototest.NewAny(t, &emptypb.Empty{}),
-			},
-			want: nil,
-			wantErr: func(t *testing.T, err error, args ...any) bool {
-				return assert.ErrorContains(t, err, ontology.ErrNotOntologyResource.Error())
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &Resource{
-				Id:                   tt.fields.Id,
-				TargetOfEvaluationId: tt.fields.TargetOfEvaluationId,
-				ResourceType:         tt.fields.ResourceType,
-				Properties:           tt.fields.Properties,
-			}
-			got, err := r.ToOntologyResource()
-
-			tt.wantErr(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestToEvidenceResource(t *testing.T) {
+func TestToResourceSnapshot(t *testing.T) {
 	type args struct {
-		resource    ontology.IsResource
-		ctID        string
-		collectorID string
+		resource ontology.IsResource
+		toeId    string
+		toolId   string
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *Resource
+		want    *ResourceSnapshot
 		wantErr assert.WantErr
 	}{
 		{
@@ -174,15 +110,15 @@ func TestToEvidenceResource(t *testing.T) {
 						},
 					},
 				},
-				ctID:        "test-toe-id",
-				collectorID: "test-collector-id",
+				toeId:  "test-toe-id",
+				toolId: "test-collector-id",
 			},
-			want: &Resource{
+			want: &ResourceSnapshot{
 				Id:                   "my-block-storage",
 				TargetOfEvaluationId: "test-toe-id",
 				ToolId:               "test-collector-id",
 				ResourceType:         "BlockStorage,Storage,Infrastructure,Resource",
-				Properties: prototest.NewAny(t, &ontology.BlockStorage{
+				Resource: ontology.ProtoResource(&ontology.BlockStorage{
 					Id:   "my-block-storage",
 					Name: "My Block Storage",
 					Backups: []*ontology.Backup{
@@ -199,7 +135,7 @@ func TestToEvidenceResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotR, err := ToEvidenceResource(tt.args.resource, tt.args.ctID, tt.args.collectorID)
+			gotR, err := ToResourceSnapshot(tt.args.resource, tt.args.toeId, tt.args.toolId)
 
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, gotR)

--- a/core/api/evidence/evidenceconnect/evidence.connect.go
+++ b/core/api/evidence/evidenceconnect/evidence.connect.go
@@ -60,7 +60,7 @@ type ResourcesClient interface {
 	// UpdateResource updates a resource (or creates it, if it does not exist).
 	// This is used to give third-party tools the possibility to add something to
 	// the resource graph.
-	UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.Resource], error)
+	UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.ResourceSnapshot], error)
 	// ListGraphEdges returns the edges (relationship) between resources in our
 	// resource graph.
 	ListGraphEdges(context.Context, *connect.Request[evidence.ListGraphEdgesRequest]) (*connect.Response[evidence.ListGraphEdgesResponse], error)
@@ -77,7 +77,7 @@ func NewResourcesClient(httpClient connect.HTTPClient, baseURL string, opts ...c
 	baseURL = strings.TrimRight(baseURL, "/")
 	resourcesMethods := evidence.File_api_evidence_evidence_proto.Services().ByName("Resources").Methods()
 	return &resourcesClient{
-		updateResource: connect.NewClient[evidence.UpdateResourceRequest, evidence.Resource](
+		updateResource: connect.NewClient[evidence.UpdateResourceRequest, evidence.ResourceSnapshot](
 			httpClient,
 			baseURL+ResourcesUpdateResourceProcedure,
 			connect.WithSchema(resourcesMethods.ByName("UpdateResource")),
@@ -94,12 +94,12 @@ func NewResourcesClient(httpClient connect.HTTPClient, baseURL string, opts ...c
 
 // resourcesClient implements ResourcesClient.
 type resourcesClient struct {
-	updateResource *connect.Client[evidence.UpdateResourceRequest, evidence.Resource]
+	updateResource *connect.Client[evidence.UpdateResourceRequest, evidence.ResourceSnapshot]
 	listGraphEdges *connect.Client[evidence.ListGraphEdgesRequest, evidence.ListGraphEdgesResponse]
 }
 
 // UpdateResource calls confirmate.evidence.v1.Resources.UpdateResource.
-func (c *resourcesClient) UpdateResource(ctx context.Context, req *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.Resource], error) {
+func (c *resourcesClient) UpdateResource(ctx context.Context, req *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.ResourceSnapshot], error) {
 	return c.updateResource.CallUnary(ctx, req)
 }
 
@@ -113,7 +113,7 @@ type ResourcesHandler interface {
 	// UpdateResource updates a resource (or creates it, if it does not exist).
 	// This is used to give third-party tools the possibility to add something to
 	// the resource graph.
-	UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.Resource], error)
+	UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.ResourceSnapshot], error)
 	// ListGraphEdges returns the edges (relationship) between resources in our
 	// resource graph.
 	ListGraphEdges(context.Context, *connect.Request[evidence.ListGraphEdgesRequest]) (*connect.Response[evidence.ListGraphEdgesResponse], error)
@@ -153,7 +153,7 @@ func NewResourcesHandler(svc ResourcesHandler, opts ...connect.HandlerOption) (s
 // UnimplementedResourcesHandler returns CodeUnimplemented from all methods.
 type UnimplementedResourcesHandler struct{}
 
-func (UnimplementedResourcesHandler) UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.Resource], error) {
+func (UnimplementedResourcesHandler) UpdateResource(context.Context, *connect.Request[evidence.UpdateResourceRequest]) (*connect.Response[evidence.ResourceSnapshot], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("confirmate.evidence.v1.Resources.UpdateResource is not implemented"))
 }
 

--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -221,7 +221,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/Resource'
+                                $ref: '#/components/schemas/ResourceSnapshot'
                 default:
                     description: Default error response
                     content:
@@ -880,8 +880,6 @@ components:
         CodeRepository:
             type: object
             properties:
-                approvedCommitAuthorEnforced:
-                    type: boolean
                 creationTime:
                     type: string
                     format: date-time
@@ -897,18 +895,9 @@ components:
                         type: string
                 name:
                     type: string
-                numberOfRequiredReviewers:
-                    type: integer
-                    format: int32
                 raw:
                     type: string
                     description: The raw field contains the raw information that is used to fill in the fields of the ontology.
-                reviewPercentage:
-                    type: number
-                    format: float
-                reviewPercentageLastMonth:
-                    type: number
-                    format: float
                 changeAndConfigurationManagement:
                     $ref: '#/components/schemas/ChangeAndConfigurationManagement'
                 codeSignoff:
@@ -927,29 +916,17 @@ components:
                         $ref: '#/components/schemas/Redundancy'
                 parentId:
                     type: string
-                signedCommits:
-                    $ref: '#/components/schemas/SignedCommits'
                 usageStatistics:
                     $ref: '#/components/schemas/UsageStatistics'
-                verifiedCommits:
-                    $ref: '#/components/schemas/VerifiedCommits'
-            description: |-
-                CodeRepository is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-                 ApprovedCommitAuthorEnforced verifies that code modifications are made by authorized developers whose changes have been validated, enhancing accountability and traceability.
-                 ReviewPercentage is the percentage of merged pull requests with code reviews.
-                 ReviewPercentageLastMonth is the percentage of merged pull requests with code reviews in the last 30 days.
+            description: CodeRepository is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         CodeSignoff:
             type: object
             properties:
                 enforced:
                     type: boolean
-                percentage:
-                    type: number
-                    format: float
-                percentageLastMonth:
-                    type: number
-                    format: float
-            description: "CodeSignoff is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n Percentage: Percentage of commits with \"Signed-off-by\" lines. \n PercentageLastMonth: Percentage of commits with \"Signed-off-by\" lines in the last 30 days. \n Signoffs enable users to affirm that a commit complies with the rules and licensing governing a repository"
+            description: |-
+                CodeSignoff is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 Signoffs enable users to affirm that a commit complies with the rules and licensing governing a repository
         Configuration:
             type: object
             properties:
@@ -3629,7 +3606,7 @@ components:
                 results:
                     type: array
                     items:
-                        $ref: '#/components/schemas/Resource'
+                        $ref: '#/components/schemas/ResourceSnapshot'
                 nextPageToken:
                     type: string
         ListSupportedResourceTypesResponse:
@@ -5485,6 +5462,43 @@ components:
                     items:
                         type: string
             description: ResourceLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        ResourceSnapshot:
+            required:
+                - id
+                - targetOfEvaluationId
+                - resourceType
+                - toolId
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: |-
+                        Id contains a unique ID for each resource. This is specific for the cloud
+                         provider this resource was gathered for and can for example be a resource
+                         URL.
+                targetOfEvaluationId:
+                    type: string
+                    description: |-
+                        TargetOfEvaluationId is the UUID for the target of evaluation to which this resource
+                         belongs to.
+                resourceType:
+                    type: string
+                    description: |-
+                        ResourceType contains a comma separated string of resource types according
+                         to our ontology.
+                toolId:
+                    type: string
+                    description: Reference to the tool which provided the resource
+                resource:
+                    allOf:
+                        - $ref: '#/components/schemas/Resource'
+                    description: Semantic representation of the Cloud resource according to our defined ontology
+            description: |-
+                ResourceSnapshot is the persisted representation of a cloud resource.
+                 It is distinct from confirmate.ontology.v1.Resource, which is the semantic
+                 discriminated union of all concrete ontology types. ResourceSnapshot carries
+                 metadata (id, resourceType, targetOfEvaluationId, toolId) plus the
+                 serialised ontology properties.
         RobustnessScore:
             type: object
             properties: {}
@@ -5877,10 +5891,6 @@ components:
                     $ref: '#/components/schemas/Immutability'
                 documentSignature:
                     $ref: '#/components/schemas/DocumentSignature'
-                signedCommits:
-                    $ref: '#/components/schemas/SignedCommits'
-                verifiedCommits:
-                    $ref: '#/components/schemas/VerifiedCommits'
                 explainableResults:
                     $ref: '#/components/schemas/ExplainableResults'
                 robustnessScore:
@@ -5968,18 +5978,6 @@ components:
                     items:
                         $ref: '#/components/schemas/SecurityFeature'
             description: ServiceMetadataDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-        SignedCommits:
-            type: object
-            properties:
-                enforced:
-                    type: boolean
-                percentage:
-                    type: number
-                    format: float
-                percentageLastMonth:
-                    type: number
-                    format: float
-            description: "SignedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  SignedCommits cryptographically verify the identity of the commit author.\n Percentage: Percentage of signed commits. \n PercentageLastMonth: Percentage of signed commits in the last 30 days."
         SingleSignOn:
             type: object
             properties:
@@ -6145,7 +6143,7 @@ components:
             type: object
             properties:
                 resource:
-                    $ref: '#/components/schemas/Resource'
+                    $ref: '#/components/schemas/ResourceSnapshot'
         UsageStatistics:
             type: object
             properties:
@@ -6271,16 +6269,6 @@ components:
             description: |-
                 Value is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  The node that represents the "value" of this option. For example, in an INI file, this would be the [FieldDeclaration.initializer] node that represents the value.
-        VerifiedCommits:
-            type: object
-            properties:
-                percentage:
-                    type: number
-                    format: float
-                percentageLastMonth:
-                    type: number
-                    format: float
-            description: "VerifiedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  VerifiedCommits ensure that cryptographic signatures on commits are successfully validated against trusted keys, confirming author authenticity and code integrity.\n Percentage: Percentage of verified commits. \n PercentageLastMonth: Percentage of verified commits in the last 30 days."
         VirtualMachine:
             type: object
             properties:

--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -880,6 +880,8 @@ components:
         CodeRepository:
             type: object
             properties:
+                approvedCommitAuthorEnforced:
+                    type: boolean
                 creationTime:
                     type: string
                     format: date-time
@@ -895,9 +897,18 @@ components:
                         type: string
                 name:
                     type: string
+                numberOfRequiredReviewers:
+                    type: integer
+                    format: int32
                 raw:
                     type: string
                     description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                reviewPercentage:
+                    type: number
+                    format: float
+                reviewPercentageLastMonth:
+                    type: number
+                    format: float
                 changeAndConfigurationManagement:
                     $ref: '#/components/schemas/ChangeAndConfigurationManagement'
                 codeSignoff:
@@ -916,17 +927,29 @@ components:
                         $ref: '#/components/schemas/Redundancy'
                 parentId:
                     type: string
+                signedCommits:
+                    $ref: '#/components/schemas/SignedCommits'
                 usageStatistics:
                     $ref: '#/components/schemas/UsageStatistics'
-            description: CodeRepository is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                verifiedCommits:
+                    $ref: '#/components/schemas/VerifiedCommits'
+            description: |-
+                CodeRepository is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+                 ApprovedCommitAuthorEnforced verifies that code modifications are made by authorized developers whose changes have been validated, enhancing accountability and traceability.
+                 ReviewPercentage is the percentage of merged pull requests with code reviews.
+                 ReviewPercentageLastMonth is the percentage of merged pull requests with code reviews in the last 30 days.
         CodeSignoff:
             type: object
             properties:
                 enforced:
                     type: boolean
-            description: |-
-                CodeSignoff is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-                 Signoffs enable users to affirm that a commit complies with the rules and licensing governing a repository
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "CodeSignoff is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n Percentage: Percentage of commits with \"Signed-off-by\" lines. \n PercentageLastMonth: Percentage of commits with \"Signed-off-by\" lines in the last 30 days. \n Signoffs enable users to affirm that a commit complies with the rules and licensing governing a repository"
         Configuration:
             type: object
             properties:
@@ -5891,6 +5914,10 @@ components:
                     $ref: '#/components/schemas/Immutability'
                 documentSignature:
                     $ref: '#/components/schemas/DocumentSignature'
+                signedCommits:
+                    $ref: '#/components/schemas/SignedCommits'
+                verifiedCommits:
+                    $ref: '#/components/schemas/VerifiedCommits'
                 explainableResults:
                     $ref: '#/components/schemas/ExplainableResults'
                 robustnessScore:
@@ -5978,6 +6005,18 @@ components:
                     items:
                         $ref: '#/components/schemas/SecurityFeature'
             description: ServiceMetadataDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SignedCommits:
+            type: object
+            properties:
+                enforced:
+                    type: boolean
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "SignedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  SignedCommits cryptographically verify the identity of the commit author.\n Percentage: Percentage of signed commits. \n PercentageLastMonth: Percentage of signed commits in the last 30 days."
         SingleSignOn:
             type: object
             properties:
@@ -6269,6 +6308,16 @@ components:
             description: |-
                 Value is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  The node that represents the "value" of this option. For example, in an INI file, this would be the [FieldDeclaration.initializer] node that represents the value.
+        VerifiedCommits:
+            type: object
+            properties:
+                percentage:
+                    type: number
+                    format: float
+                percentageLastMonth:
+                    type: number
+                    format: float
+            description: "VerifiedCommits is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.\n  VerifiedCommits ensure that cryptographic signatures on commits are successfully validated against trusted keys, confirming author authenticity and code integrity.\n Percentage: Percentage of verified commits. \n PercentageLastMonth: Percentage of verified commits in the last 30 days."
         VirtualMachine:
             type: object
             properties:

--- a/core/api/evidence/request_extensions_test.go
+++ b/core/api/evidence/request_extensions_test.go
@@ -76,7 +76,7 @@ func TestStoreEvidenceRequest_GetPayload(t *testing.T) {
 
 func TestUpdateResourceRequest_TargetOfEvaluationId(t *testing.T) {
 	req := &UpdateResourceRequest{
-		Resource: &Resource{
+		Resource: &ResourceSnapshot{
 			TargetOfEvaluationId: "toe-2",
 		},
 	}

--- a/core/service/evidence/db.go
+++ b/core/service/evidence/db.go
@@ -21,5 +21,5 @@ import (
 
 var types = []any{
 	&evidence.Evidence{},
-	&evidence.Resource{},
+	&evidence.ResourceSnapshot{},
 }

--- a/core/service/evidence/evidencetest/mock.go
+++ b/core/service/evidence/evidencetest/mock.go
@@ -107,30 +107,30 @@ var (
 	}
 	// MockResourceListA is a deterministic resource fixture for list/filter tests.
 	// It corresponds to a VM resource for tool "tool-a" and the same ToE as [MockEvidenceListA].
-	MockResourceListA = &evidence.Resource{
+	MockResourceListA = &evidence.ResourceSnapshot{
 		Id:                   "vm-1",
 		ResourceType:         "virtual_machine",
 		TargetOfEvaluationId: "11111111-1111-1111-1111-111111111111",
 		ToolId:               "tool-a",
-		Properties:           nil,
+		Resource:             nil,
 	}
 	// MockResourceListB is a deterministic resource fixture for list/filter tests.
 	// Compared to [MockResourceListA] represents a different resource type ("application") for tool "tool-a" and a
 	// different ToE.
-	MockResourceListB = &evidence.Resource{
+	MockResourceListB = &evidence.ResourceSnapshot{
 		Id:                   "app-1",
 		ResourceType:         "application",
 		TargetOfEvaluationId: "22222222-2222-2222-2222-222222222222",
 		ToolId:               "tool-a",
-		Properties:           nil,
+		Resource:             nil,
 	}
 	// MockResourceListC is a deterministic resource fixture for list/filter tests.
 	// It represents a VM resource for tool "tool-b" and the same ToE as [MockEvidenceListA]/[MockEvidenceListC].
-	MockResourceListC = &evidence.Resource{
+	MockResourceListC = &evidence.ResourceSnapshot{
 		Id:                   "vm-2",
 		ResourceType:         "virtual_machine",
 		TargetOfEvaluationId: "11111111-1111-1111-1111-111111111111",
 		ToolId:               "tool-b",
-		Properties:           nil,
+		Resource:             nil,
 	}
 )

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -241,7 +241,7 @@ func (svc *Service) initEvidenceChannel() {
 // This implements the [evidenceconnect.EvidenceStoreHandler.StoreEvidence] RPC method.
 func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evidence.StoreEvidenceRequest]) (res *connect.Response[evidence.StoreEvidenceResponse], err error) {
 	var (
-		r *evidence.Resource
+		r *evidence.ResourceSnapshot
 	)
 
 	// Validate request
@@ -265,13 +265,20 @@ func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evid
 	svc.toolIds[req.Msg.Evidence.GetToolId()] = struct{}{}
 	svc.toolIdsMu.Unlock()
 
-	// Store Resource:
-	// Build a resource struct. This will hold the latest sync state of the
-	// resource for our storage layer. This is needed to store the resource in our DBs
-	r, err = evidence.ToEvidenceResource(req.Msg.Evidence.GetOntologyResource(), req.Msg.GetTargetOfEvaluationId(), req.Msg.Evidence.GetToolId())
+	// Store resource snapshot. This will hold the latest sync state of the resource and its
+	// association to ToE for our storage layer.
+	ontologyResource := req.Msg.Evidence.GetOntologyResource()
+	if ontologyResource == nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("could not convert resource (proto to DB): nil ontology resource"))
+	}
+	r, err = evidence.ToResourceSnapshot(
+		ontologyResource,
+		req.Msg.GetTargetOfEvaluationId(),
+		req.Msg.Evidence.GetToolId(),
+	)
 	if err != nil {
 		// Only reveal limited information about the error to the client
-		return nil, connect.NewError(connect.CodeInternal, errors.New("could not convert resource (proto to DB)"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not convert resource (proto to DB): %w", err))
 	}
 	// Persist the latest state of the resource; Save already uses the primary key.
 	err = svc.db.Save(r)
@@ -520,7 +527,7 @@ func (svc *Service) ListResources(_ context.Context, req *connect.Request[eviden
 	// Join query with AND and prepend the query
 	args = append([]any{strings.Join(query, " AND ")}, args...)
 
-	res.Msg.Results, res.Msg.NextPageToken, err = service.PaginateStorage[*evidence.Resource](req.Msg, svc.db, service.DefaultPaginationOpts, args...)
+	res.Msg.Results, res.Msg.NextPageToken, err = service.PaginateStorage[*evidence.ResourceSnapshot](req.Msg, svc.db, service.DefaultPaginationOpts, args...)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}

--- a/core/service/evidence/service_test.go
+++ b/core/service/evidence/service_test.go
@@ -361,7 +361,7 @@ func TestService_StoreEvidence(t *testing.T) {
 			},
 			fields: fields{db: persistencetest.NewInMemoryDB(t, types, nil, func(db persistence.DB) {
 				// Create a resource already such that `save` will update it instead of creating a new entry
-				r, err := evidence.ToEvidenceResource(evidencetest.MockEvidenceWithVMResource.GetOntologyResource(), evidencetest.MockEvidenceWithVMResource.GetTargetOfEvaluationId(), evidencetest.MockEvidenceWithVMResource.GetToolId())
+				r, err := evidence.ToResourceSnapshot(evidencetest.MockEvidenceWithVMResource.GetOntologyResource(), evidencetest.MockEvidenceWithVMResource.GetTargetOfEvaluationId(), evidencetest.MockEvidenceWithVMResource.GetToolId())
 				assert.NoError(t, err)
 				err = db.Create(r)
 				assert.NoError(t, err)


### PR DESCRIPTION
The OpenAPI generator maps schemas by short message name, so confirmate.evidence.v1.Resource and confirmate.ontology.v1.Resource collapsed into a single #/components/schemas/Resource — and the ontology oneof won, leaving UpdateResource and ListResources documented with the wrong shape.

Rename the evidence wrapper to ResourceSnapshot and replace its google.protobuf.Any properties field with a typed
confirmate.ontology.v1.Resource so the snapshot is self-describing instead of needing Any-unwrap on read.

Fixes #298