### PR TITLE
server: grant ROLE_ADMIN to service client OAuth tokens

### DIFF
--- a/core/server/commands/confirmate.go
+++ b/core/server/commands/confirmate.go
@@ -190,6 +190,11 @@ func runConfirmate(ctx context.Context, cmd *cli.Command) (err error) {
 	}
 
 	// EvidenceStore service configuration
+	assessmentClient := service.NewHTTPClient()
+	assessmentClient.Timeout = cmd.Duration("evidence-assessment-http-timeout")
+	if authorizer != nil {
+		assessmentClient = api.NewOAuthHTTPClient(assessmentClient, authorizer)
+	}
 	evidenceOpts = append([]service.Option[evidence.Service]{
 		evidence.WithConfig(evidence.Config{
 			AssessmentAddress: cmd.String("evidence-assessment-address"),
@@ -204,11 +209,7 @@ func runConfirmate(ctx context.Context, cmd *cli.Command) (err error) {
 				InMemoryDB: cmd.Bool("db-in-memory"),
 				MaxConn:    cmd.Int("db-max-connections"),
 			},
-			AssessmentHTTPClient: func() *http.Client {
-				c := service.NewHTTPClient()
-				c.Timeout = cmd.Duration("evidence-assessment-http-timeout")
-				return c
-			}(),
+			AssessmentHTTPClient: assessmentClient,
 		}),
 	}, evidenceOptions...)
 

--- a/core/server/oauth_server.go
+++ b/core/server/oauth_server.go
@@ -76,10 +76,11 @@ func WithEmbeddedOAuth2Server(keyPath string, keyPassword string, saveOnCreate b
 			}),
 			oauth2.WithPublicURL(oauthPublicURL),
 			oauth2.WithTokenClaimsFunc(func(clientID string, userID string) map[string]any {
-				if clientID == DefaultOAuth2CLIClientID || userID == DefaultOAuth2LoginUser {
+				if clientID == DefaultOAuth2CLIClientID || clientID == DefaultOAuth2ServiceClientID || userID == DefaultOAuth2LoginUser {
 					// For now we assign the "admin" role to any user authenticated via the CLI
-					// client or the default login user. In a real implementation, you would want to
-					// have a more robust way of assigning roles and permissions.
+					// client, the service client (used for service-to-service calls), or the
+					// default login user. In a real implementation, you would want to have a more
+					// robust way of assigning roles and permissions.
 					return map[string]any{
 						"roles": []string{"ROLE_ADMIN"},
 					}


### PR DESCRIPTION
## Summary

Two coupled bugs prevented `AssessmentResult`s from being created when `--auth-enabled` was set on the combined `confirmate` binary:

1. **Service token had no admin role.** The embedded OAuth2 server's `WithTokenClaimsFunc` only added `ROLE_ADMIN` to tokens for the CLI client and the default login user; the service client (`confirmate`) got no roles. Combined with the token having no `iss` claim, this made `provisionCurrentUser` return an empty userId, and `AuthorizationStrategyPermissionStore.CheckAccess` then denied every service write before reaching the create-allow branch. (Effect: the assessment service's `StoreAssessmentResults` bidi stream to the orchestrator got `permission_denied`.)
2. **Evidence -> assessment hop had no Bearer token at all.** In `runConfirmate`, the EvidenceStore's `AssessmentHTTPClient` was a plain HTTP client, so the bidi stream from evidence to assessment carried no token. The assessment service's `AuthInterceptor` rejected every chunk, the stream was torn down, and assessment never ran. (Effect: even with #1 fixed, `ListAssessmentResults` was still empty.)

Both fixes are tiny:
- `server/oauth_server.go`: add `DefaultOAuth2ServiceClientID` to the same admin branch as the CLI client.
- `server/commands/confirmate.go`: reuse the existing `authorizer` to wrap the evidence service's assessment HTTP client when auth is enabled.

This matches the design intent already documented in `core/docs/authentication-and-authorization.md` ("the orchestrator treats it as an admin request").

Closes #310.

## Test plan
- [x] `./bin/confirmate --auth-enabled --db-in-memory ...`, obtain a token via `POST /v1/auth/token` with `confirmate:confirmate` client_credentials -> token now includes `"roles":["ROLE_ADMIN"]`.
- [x] Direct `StoreAssessmentResult` with that token returns `200`/`{}` (was `403 permission_denied`).
- [x] End-to-end via grpcurl: `StoreEvidence` succeeds and `ListAssessmentResults` returns the produced results (was empty `{}` before the second fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)