### PR TITLE
service/orchestrator: preload Metrics in ListControls

### DIFF
--- a/core/service/orchestrator/catalogs.go
+++ b/core/service/orchestrator/catalogs.go
@@ -273,7 +273,14 @@ func (svc *Service) ListControls(
 		req.Msg.Asc = true
 	}
 
-	controls, npt, err = service.PaginateStorage[*orchestrator.Control](req.Msg, svc.db, service.DefaultPaginationOpts, persistence.WithoutPreload())
+	// Preload Metrics and sub-Controls (with their own Metrics) so callers —
+	// notably the evaluation service — can walk a control's full subtree and
+	// resolve every metric ID without making per-control round trips.
+	controls, npt, err = service.PaginateStorage[*orchestrator.Control](
+		req.Msg, svc.db, service.DefaultPaginationOpts,
+		persistence.WithPreload("Metrics"),
+		persistence.WithPreload("Controls.Metrics"),
+	)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`Orchestrator.ListControls` was passing `WithoutPreload()`, so the `Control` records in the API response carried no `Metrics` and the nested sub-`Controls` (and their `Metrics`) were absent too. The evaluation service builds its metric→assessment lookup off those associations — if `Metrics` is empty, `getAllMetricsFromControl` returns nothing, the metric-id filter on `ListAssessmentResults` matches no rows, and every evaluation result stays `EVALUATION_STATUS_PENDING`.

Switch to two explicit preloads:

  * `Metrics` — the control's own metric references.
  * `Controls.Metrics` — sub-controls and their metric references, so the eval walk over a parent control's subtree resolves without per-control round trips.

Other associations (`Categories`, sub-Controls of sub-Controls) remain unloaded — they're not needed on this endpoint and would just balloon the payload.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./service/orchestrator/... ./server/...` green
- [x] Manually verified that after this change, a freshly-started orchestrator with the demo CRA catalog returns each control's `metrics: [...]` over REST instead of an empty / missing field, and a subsequent `StartEvaluation` flips evaluation results from all-PENDING to a mix of COMPLIANT / NOT_COMPLIANT / PENDING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)