### PR TITLE
catalogs: Populate metrics field in `GetControl()` response

### DIFF
--- a/core/service/orchestrator/catalogs.go
+++ b/core/service/orchestrator/catalogs.go
@@ -301,7 +301,7 @@ func (svc *Service) GetControl(
 		return nil, err
 	}
 
-	err = svc.db.Get(&control, persistence.WithPreload("Controls"), "id = ?", req.Msg.ControlId)
+	err = svc.db.Get(&control, persistence.WithPreload("Controls.Metrics"), "id = ?", req.Msg.ControlId)
 	if err = service.HandleDatabaseError(err, service.ErrNotFound("control")); err != nil {
 		return nil, err
 	}

--- a/core/service/orchestrator/catalogs_test.go
+++ b/core/service/orchestrator/catalogs_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"confirmate.io/core/api/assessment"
 	"confirmate.io/core/api/orchestrator"
 	"confirmate.io/core/auth"
 	"confirmate.io/core/persistence"
@@ -927,12 +928,14 @@ func TestService_GetControl(t *testing.T) {
 							Name:            orchestratortest.MockSubControlName1,
 							ShortName:       orchestratortest.MockSubControlShortName1,
 							ParentControlId: new(orchestratortest.MockControlId1),
+							Metrics:         []*assessment.Metric{orchestratortest.MockMetric1},
 						},
 						{
 							Id:              orchestratortest.MockSubControlId2,
 							Name:            orchestratortest.MockSubControlName2,
 							ShortName:       orchestratortest.MockSubControlShortName2,
 							ParentControlId: new(orchestratortest.MockControlId1),
+							Metrics:         []*assessment.Metric{orchestratortest.MockMetric2},
 						},
 					},
 				}


### PR DESCRIPTION
This PR populates the metrics field of a control in the GetControl() response.