### PR TITLE
service/orchestrator: cascade RemoveControlInScope to descendants

### DIFF
--- a/core/service/orchestrator/workflow.go
+++ b/core/service/orchestrator/workflow.go
@@ -402,18 +402,33 @@ func (svc *Service) RemoveControlInScope(
 		return nil, service.ErrPermissionDenied
 	}
 
+	actor := actorFromContext(ctx)
 	err = svc.db.Transaction(func(tx persistence.DB) error {
-		// control_in_scope_id is intentionally empty: the ControlInScope record is deleted
-		// in this same transaction, so linking to it would create a dangling reference.
-		if err = createAuditTrailEvent(tx, actorFromContext(ctx), cis.AuditScopeId, "", "",
-			&orchestrator.ControlScopingEvent{
-				ControlId:    cis.ControlId,
-				AuditScopeId: cis.AuditScopeId,
-				InScope:      false,
-			}); err != nil {
+		// Cascade: removing a parent control from scope also removes every
+		// descendant ControlInScope record so the subtree state stays consistent
+		// — a sub-control can't be "in scope" while its parent isn't.
+		victims, err := collectControlInScopeSubtree(tx, cis.AuditScopeId, cis.ControlId)
+		if err != nil {
 			return err
 		}
-		return tx.Delete(&cis, "id = ?", cis.Id)
+		victims = append([]*orchestrator.ControlInScope{&cis}, victims...)
+		for _, victim := range victims {
+			// control_in_scope_id is intentionally empty: the ControlInScope record
+			// is deleted in this same transaction, so linking to it would create a
+			// dangling reference.
+			if err := createAuditTrailEvent(tx, actor, victim.AuditScopeId, "", "",
+				&orchestrator.ControlScopingEvent{
+					ControlId:    victim.ControlId,
+					AuditScopeId: victim.AuditScopeId,
+					InScope:      false,
+				}); err != nil {
+				return err
+			}
+			if err := tx.Delete(&orchestrator.ControlInScope{}, "id = ?", victim.Id); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
@@ -421,6 +436,44 @@ func (svc *Service) RemoveControlInScope(
 
 	res = connect.NewResponse(&emptypb.Empty{})
 	return
+}
+
+// collectControlInScopeSubtree returns every ControlInScope record under the
+// given audit scope whose Control is a descendant of rootControlId, by walking
+// the Control.parent_control_id chain breadth-first. The root record itself is
+// not included.
+func collectControlInScopeSubtree(db persistence.DB, auditScopeId, rootControlId string) ([]*orchestrator.ControlInScope, error) {
+	var (
+		queue       = []string{rootControlId}
+		descendants []*orchestrator.ControlInScope
+		visited     = map[string]struct{}{rootControlId: {}}
+	)
+
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+
+		var children []*orchestrator.Control
+		if err := db.List(&children, "id", true, 0, -1, "parent_control_id = ?", parent); err != nil {
+			return nil, fmt.Errorf("list child controls of %q: %w", parent, err)
+		}
+		for _, c := range children {
+			if _, seen := visited[c.Id]; seen {
+				continue
+			}
+			visited[c.Id] = struct{}{}
+			queue = append(queue, c.Id)
+
+			var cis []*orchestrator.ControlInScope
+			if err := db.List(&cis, "id", true, 0, -1,
+				"audit_scope_id = ? AND control_id = ?", auditScopeId, c.Id); err != nil {
+				return nil, fmt.Errorf("list controls in scope for %q: %w", c.Id, err)
+			}
+			descendants = append(descendants, cis...)
+		}
+	}
+
+	return descendants, nil
 }
 
 // ListAuditTrailEvents lists audit trail events, optionally filtered by audit scope.

--- a/core/service/orchestrator/workflow_test.go
+++ b/core/service/orchestrator/workflow_test.go
@@ -875,6 +875,60 @@ func TestService_RemoveControlInScope(t *testing.T) {
 	}
 }
 
+// TestService_RemoveControlInScope_CascadesToDescendants verifies that
+// removing a parent ControlInScope also removes the ControlInScope record of
+// every descendant control in the same audit scope, and that one audit-trail
+// event is recorded per removed record. Without this cascade a sub-control
+// could remain "in scope" after its parent was taken out.
+func TestService_RemoveControlInScope_CascadesToDescendants(t *testing.T) {
+	const subControlInScopeId = "00000000-0000-0000-0004-000000000099"
+
+	db := persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
+		// Seed audit scope, parent control (which auto-cascades the
+		// MockSubControl1 row in via gorm), and a ControlInScope record for
+		// each of them under that audit scope.
+		assert.NoError(t, d.Create(orchestratortest.MockAuditScope1))
+		seedControl(t, d, orchestratortest.MockControl1)
+		assert.NoError(t, d.Create(orchestratortest.MockControlInScope1))
+		assert.NoError(t, d.Create(&orchestrator.ControlInScope{
+			Id:                   subControlInScopeId,
+			AuditScopeId:         orchestratortest.MockScopeId1,
+			TargetOfEvaluationId: orchestratortest.MockToeId1,
+			ControlId:            orchestratortest.MockSubControlId1,
+			State:                orchestrator.ControlInScopeState_CONTROL_IN_SCOPE_STATE_OPEN,
+		}))
+	})
+
+	svc := &Service{db: db, authz: &service.AuthorizationStrategyAllowAll{}}
+	_, err := svc.RemoveControlInScope(context.Background(), connect.NewRequest(
+		&orchestrator.RemoveControlInScopeRequest{Id: orchestratortest.MockControlInScopeId1},
+	))
+	assert.NoError(t, err)
+
+	// Both records should be gone.
+	var parent, child orchestrator.ControlInScope
+	assert.ErrorIs(t, db.Get(&parent, "id = ?", orchestratortest.MockControlInScopeId1), persistence.ErrRecordNotFound)
+	assert.ErrorIs(t, db.Get(&child, "id = ?", subControlInScopeId), persistence.ErrRecordNotFound)
+
+	// One audit-trail event per removed ControlInScope record. We can't filter
+	// here because of a ramsql quirk on the in-memory test backend that drops
+	// rows when WHERE is used on this table; the test seeds no other events, so
+	// listing them all is equivalent.
+	var events []*orchestrator.AuditTrailEvent
+	assert.NoError(t, db.List(&events, "id", true, 0, -1))
+	assert.Equal(t, 2, len(events))
+	scopingControlIds := map[string]struct{}{}
+	for _, e := range events {
+		assert.Equal(t, orchestratortest.MockScopeId1, e.AuditScopeId)
+		var payload orchestrator.ControlScopingEvent
+		assert.NoError(t, e.EventData.UnmarshalTo(&payload))
+		assert.False(t, payload.InScope)
+		scopingControlIds[payload.ControlId] = struct{}{}
+	}
+	assert.Contains(t, scopingControlIds, orchestratortest.MockControlId1)
+	assert.Contains(t, scopingControlIds, orchestratortest.MockSubControlId1)
+}
+
 func TestService_ListAuditTrailEvents(t *testing.T) {
 	type args struct {
 		req     *orchestrator.ListAuditTrailEventsRequest


### PR DESCRIPTION
## Summary
- Removing a parent control from an audit scope now also removes every descendant control's ControlInScope record so the subtree state stays consistent — a sub-control can't be "in scope" while its parent isn't.
- Walks the Control.parent_control_id chain breadth-first within the audit scope, collects every affected ControlInScope, then emits one AuditTrailEvent per removed record inside a single transaction.
- Adds TestService_RemoveControlInScope_CascadesToDescendants covering the parent + sub-control case.

## Test plan
- [x] `go test ./service/orchestrator/ -run TestService_RemoveControlInScope`
- [x] `go test ./service/orchestrator/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)