### PR TITLE
service/orchestrator: Change `user_id` concatenation

### DIFF
--- a/core/auth/claims.go
+++ b/core/auth/claims.go
@@ -16,6 +16,9 @@
 package auth
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+
 	"confirmate.io/core/api/orchestrator"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -74,10 +77,16 @@ func (claims *OAuthClaims) HasRole(role orchestrator.Role) bool {
 	return false
 }
 
-// GetConfirmateUserIDFromClaims constructs a unique user ID from the claims. It combines the issuer and subject
+// GetConfirmateUserIDFromClaims constructs a unique user ID from the claims.
+// It combines a hashed version of the issuer URL and the subject claim to create a unique identifier for the user.
 func GetConfirmateUserIDFromClaims(claims *OAuthClaims) string {
 	if claims == nil || claims.RegisteredClaims.Issuer == "" || claims.RegisteredClaims.Subject == "" {
 		return ""
 	}
-	return claims.RegisteredClaims.Issuer + "|" + claims.RegisteredClaims.Subject
+
+	// Hash the issuer URL so the URL itself is not stored directly.
+	h := md5.Sum([]byte(claims.RegisteredClaims.Issuer))
+	hashedIssuer := hex.EncodeToString(h[:])
+
+	return hashedIssuer + "-" + claims.RegisteredClaims.Subject
 }

--- a/core/auth/claims_test.go
+++ b/core/auth/claims_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"confirmate.io/core/api/orchestrator"
+	"confirmate.io/core/service/orchestrator/orchestratortest"
 	"confirmate.io/core/util/assert"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -45,7 +46,7 @@ func TestGetConfirmateUserIDFromClaims(t *testing.T) {
 				},
 			},
 			want: func(t *testing.T, got string, _ ...any) bool {
-				expected := "testIssuer|testSubject"
+				expected := orchestratortest.GetConfirmateUserID("testIssuer", "testSubject")
 
 				return assert.Equal(t, expected, got)
 			},

--- a/core/service/orchestrator/audit_scope_test.go
+++ b/core/service/orchestrator/audit_scope_test.go
@@ -183,7 +183,7 @@ func TestService_CreateAuditScope(t *testing.T) {
 				got := assert.InDB[orchestrator.AuditScope](t, db, res.Msg.Id)
 				count, err = db.Count(&orchestrator.UserPermission{},
 					"user_id = ? AND object_id = ? AND object_type = ? AND permission = ?",
-					orchestratortest.MockUserIssuer1+"|"+orchestratortest.MockUserId1,
+					orchestratortest.GetConfirmateUserID(orchestratortest.MockUserIssuer1, orchestratortest.MockUserId1),
 					res.Msg.Id,
 					orchestrator.ObjectType_OBJECT_TYPE_AUDIT_SCOPE,
 					orchestrator.UserPermission_PERMISSION_ADMIN,

--- a/core/service/orchestrator/orchestratortest/mock.go
+++ b/core/service/orchestrator/orchestratortest/mock.go
@@ -16,6 +16,8 @@
 package orchestratortest
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"strconv"
 
 	"confirmate.io/core/api/assessment"
@@ -588,7 +590,7 @@ var (
 		},
 	}
 	MockUser1 = &orchestrator.User{
-		Id:        MockUserIssuer1 + "|" + MockUserId1,
+		Id:        GetConfirmateUserID(MockUserIssuer1, MockUserId1),
 		Username:  new("testuser"),
 		Email:     new("email-1"),
 		FirstName: new("Test"),
@@ -596,7 +598,7 @@ var (
 	}
 
 	MockUser2 = &orchestrator.User{
-		Id:        MockUserIssuer1 + "|" + MockUserId2,
+		Id:        GetConfirmateUserID(MockUserIssuer1, MockUserId2),
 		Username:  new("testuser 2"),
 		Email:     new("email-2"),
 		FirstName: new("Test"),
@@ -604,21 +606,21 @@ var (
 	}
 
 	MockUserPermissionsToEAdmin = &orchestrator.UserPermission{
-		UserId:     MockUserIssuer1 + "|" + MockUserId1,
+		UserId:     GetConfirmateUserID(MockUserIssuer1, MockUserId1),
 		ObjectId:   MockToeId1,
 		ObjectType: orchestrator.ObjectType_OBJECT_TYPE_TARGET_OF_EVALUATION,
 		Permission: orchestrator.UserPermission_PERMISSION_ADMIN,
 	}
 
 	MockUserPermissionsToEContributor = &orchestrator.UserPermission{
-		UserId:     MockUserIssuer1 + "|" + MockUserId1,
+		UserId:     GetConfirmateUserID(MockUserIssuer1, MockUserId1),
 		ObjectId:   MockToeId1,
 		ObjectType: orchestrator.ObjectType_OBJECT_TYPE_TARGET_OF_EVALUATION,
 		Permission: orchestrator.UserPermission_PERMISSION_CONTRIBUTOR,
 	}
 
 	MockUserPermissionsAuditScopeAdmin = &orchestrator.UserPermission{
-		UserId:     MockUserIssuer1 + "|" + MockUserId1,
+		UserId:     GetConfirmateUserID(MockUserIssuer1, MockUserId1),
 		ObjectId:   MockScopeId1,
 		ObjectType: orchestrator.ObjectType_OBJECT_TYPE_AUDIT_SCOPE,
 		Permission: orchestrator.UserPermission_PERMISSION_ADMIN,
@@ -672,4 +674,13 @@ func NewMockAssessmentResultForConcurrentStream(streamID int) *assessment.Assess
 			},
 		},
 	}
+}
+
+// GetConfirmateUserID generates a Confirmate user ID based on the issuer and subject. This function is only for the mocking of users in tests and should not be used in production code, where the user ID should be generated based on the actual claims of the authenticated user.
+func GetConfirmateUserID(issuer, subject string) string {
+	// Hash the issuer URL so the URL itself is not stored directly.
+	h := md5.Sum([]byte(issuer))
+	hashedIssuer := hex.EncodeToString(h[:])
+
+	return hashedIssuer + "-" + subject
 }

--- a/core/service/orchestrator/toe_test.go
+++ b/core/service/orchestrator/toe_test.go
@@ -113,7 +113,7 @@ func TestService_CreateTargetOfEvaluation(t *testing.T) {
 				toe := assert.InDB[orchestrator.TargetOfEvaluation](t, db, res.Msg.Id)
 				count, err = db.Count(&orchestrator.UserPermission{},
 					"user_id = ? AND object_id = ? AND object_type = ? AND permission = ?",
-					orchestratortest.MockUserIssuer1+"|"+orchestratortest.MockUserId1,
+					orchestratortest.GetConfirmateUserID(orchestratortest.MockUserIssuer1, orchestratortest.MockUserId1),
 					res.Msg.Id,
 					orchestrator.ObjectType_OBJECT_TYPE_TARGET_OF_EVALUATION,
 					orchestrator.UserPermission_PERMISSION_ADMIN,

--- a/core/service/orchestrator/user.go
+++ b/core/service/orchestrator/user.go
@@ -119,7 +119,7 @@ func (svc *Service) GetCurrentUser(
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no authentication context"))
 	}
 
-	userId := claims.Issuer + "|" + claims.Subject
+	userId := auth.GetConfirmateUserIDFromClaims(claims)
 	err = svc.db.Get(&user, "id = ?", userId)
 	if err = service.HandleDatabaseError(err, service.ErrNotFound("user")); err != nil {
 		return nil, err
@@ -339,7 +339,7 @@ func provisionCurrentUser(ctx context.Context, svc *Service) (string, error) {
 	// JIT-provision the user using a read-then-update approach to avoid overwriting existing
 	// fields (e.g. enabled status) on every request. The user ID is "iss|sub" as recommended
 	// by the OIDC specification, ensuring uniqueness across identity providers.
-	userId = claims.Issuer + "|" + claims.Subject
+	userId = auth.GetConfirmateUserIDFromClaims(claims)
 	user = &orchestrator.User{}
 	err = svc.db.Get(user, "id = ?", userId)
 

--- a/core/service/orchestrator/user_roles_test.go
+++ b/core/service/orchestrator/user_roles_test.go
@@ -14,6 +14,7 @@ import (
 	"confirmate.io/core/auth"
 	"confirmate.io/core/persistence"
 	"confirmate.io/core/persistence/persistencetest"
+	"confirmate.io/core/service/orchestrator/orchestratortest"
 	"confirmate.io/core/util/assert"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -39,7 +40,7 @@ func TestProvisionCurrentUser_PopulatesRoles(t *testing.T) {
 
 	userId, err := provisionCurrentUser(ctx, svc)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://idp.example|alice", userId)
+	assert.Equal(t, orchestratortest.GetConfirmateUserID("https://idp.example", "alice"), userId)
 
 	var got orchestrator.User
 	assert.NoError(t, db.Get(&got, "id = ?", userId))
@@ -55,7 +56,7 @@ func TestProvisionCurrentUser_PopulatesRoles(t *testing.T) {
 func TestProvisionCurrentUser_UpdatesRolesOnReprovisioning(t *testing.T) {
 	db := persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
 		assert.NoError(t, d.Create(&orchestrator.User{
-			Id:      "https://idp.example|bob",
+			Id:      orchestratortest.GetConfirmateUserID("https://idp.example", "bob"),
 			Enabled: true,
 			Roles:   []orchestrator.Role{orchestrator.Role_ROLE_ADMIN},
 		}))
@@ -74,6 +75,6 @@ func TestProvisionCurrentUser_UpdatesRolesOnReprovisioning(t *testing.T) {
 	assert.NoError(t, err)
 
 	var got orchestrator.User
-	assert.NoError(t, db.Get(&got, "id = ?", "https://idp.example|bob"))
+	assert.NoError(t, db.Get(&got, "id = ?", orchestratortest.GetConfirmateUserID("https://idp.example", "bob")))
 	assert.Equal(t, []orchestrator.Role{orchestrator.Role_ROLE_AUDITOR}, got.Roles)
 }

--- a/core/service/orchestrator/user_test.go
+++ b/core/service/orchestrator/user_test.go
@@ -75,11 +75,11 @@ func TestService_GetCurrentUser(t *testing.T) {
 			}),
 			fields: fields{
 				db: persistencetest.NewInMemoryDB(t, types, joinTables, func(d persistence.DB) {
-					assert.NoError(t, d.Create(&orchestrator.User{Id: "test|user-1", Enabled: true}))
+					assert.NoError(t, d.Create(&orchestrator.User{Id: orchestratortest.GetConfirmateUserID("test", "user-1"), Enabled: true}))
 				}),
 			},
 			want: func(t *testing.T, got *connect.Response[orchestrator.User], _ ...any) bool {
-				return assert.NotNil(t, got) && assert.Equal(t, "test|user-1", got.Msg.Id)
+				return assert.NotNil(t, got) && assert.Equal(t, orchestratortest.GetConfirmateUserID("test", "user-1"), got.Msg.Id)
 			},
 			wantErr: assert.NoError,
 		},
@@ -469,7 +469,7 @@ func TestService_ListUsers(t *testing.T) {
 			want: func(t *testing.T, got *connect.Response[orchestrator.ListUsersResponse], _ ...any) bool {
 				return assert.NotNil(t, got) &&
 					assert.Equal(t, 1, len(got.Msg.Users)) &&
-					assert.Equal(t, orchestratortest.MockUserIssuer1+"|new-caller-id", got.Msg.Users[0].Id)
+					assert.Equal(t, orchestratortest.GetConfirmateUserID(orchestratortest.MockUserIssuer1, "new-caller-id"), got.Msg.Users[0].Id)
 			},
 			wantErr: assert.NoError,
 		},


### PR DESCRIPTION
This PR changes the user_id. 

Before: `userId = <issuer>|<subject>`
After: `userId = md5(<issuer>)-<subject>`