### PR TITLE
workflow: Update workflow for `go generate`

### DIFF
--- a/.github/workflows/go-generate-check.yml
+++ b/.github/workflows/go-generate-check.yml
@@ -56,20 +56,7 @@ jobs:
               exit 1
             fi
 
-            # Apply exceptions for Connect and OpenAPI files
-            if [[ "$dir" != "core/api/common" && "$proto" != "core/api/assessment/metric.proto" ]]; then
-              connect_go="$dir/${base}connect/$base.connect.go"
-              openapi="$dir/openapi.yaml"
-              
-              if [ -f "$connect_go" ]; then
-                CONNECT_COMMIT_TIME=$(git log -1 --format=%ct HEAD -- "$connect_go" || echo 0)
-                if [ "$PROTO_COMMIT_TIME" -gt "$CONNECT_COMMIT_TIME" ]; then
-                  echo "❌ $proto was modified after the last generation of $connect_go!"
-                  echo "   Please run your generation tool locally and commit the updated connect files."
-                  exit 1
-                fi
-              fi
-              
+            # Apply exceptions for OpenAPI files
               if [ -f "$openapi" ]; then
                 OPENAPI_COMMIT_TIME=$(git log -1 --format=%ct HEAD -- "$openapi" || echo 0)
                 if [ "$PROTO_COMMIT_TIME" -gt "$OPENAPI_COMMIT_TIME" ]; then


### PR DESCRIPTION
This PR deletes the  check for the `*connect` folder. It is possible that the connect folder doesn't change after a change in the proto file. 