### PR TITLE
evidenceStore: Change `ListTools()` functionality

### DIFF
--- a/core/api/assessment/openapi.yaml
+++ b/core/api/assessment/openapi.yaml
@@ -7,7 +7,7 @@ info:
     description: |-
         Representing the link between orchestrator and discovery: Assessing evidences
          from discovery and sending results to orchestrator
-    version: core/v0.2.15-25-g8885487
+    version: core/v0.2.15-15-g97e68af
 paths:
     /v1/assessment/evidences:
         post:
@@ -147,6 +147,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Agnostic is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents an agnostic architecture, which is not tied to a specific operating system.
@@ -244,6 +248,10 @@ components:
                         type: string
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Application is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  This encapsulates the whole (source) code of an application.
@@ -1326,6 +1334,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Darwin is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Darwin architecture, commonly found on macOS systems. macOS is a certified. [UNIX](https://www.opengroup.org/openbrand/register/apple.htm) and is (mostly) POSIX compatible.
@@ -2241,6 +2253,8 @@ components:
                     $ref: '#/components/schemas/SchemaValidation'
                 securityAdvisoryFeed:
                     $ref: '#/components/schemas/SecurityAdvisoryFeed'
+                securityIncident:
+                    $ref: '#/components/schemas/SecurityIncident'
                 time:
                     $ref: '#/components/schemas/Time'
                 vulnerability:
@@ -3317,6 +3331,10 @@ components:
                         type: string
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
                 vulnerabilities:
                     type: array
                     items:
@@ -4300,6 +4318,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 POSIX is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a POSIX architecture, commonly found on Linux systems.
@@ -4334,6 +4356,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Package is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a grouping of (source) code into logical unit, for example a package for a namespace.
@@ -5499,6 +5525,8 @@ components:
                     $ref: '#/components/schemas/LocalAttestation'
                 remoteAttestation:
                     $ref: '#/components/schemas/RemoteAttestation'
+                softwareAttestation:
+                    $ref: '#/components/schemas/SoftwareAttestation'
                 automaticUpdates:
                     $ref: '#/components/schemas/AutomaticUpdates'
                 cryptographicHash:
@@ -5518,7 +5546,11 @@ components:
             description: SecurityFeature is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
         SecurityIncident:
             type: object
-            properties: {}
+            properties:
+                team:
+                    type: array
+                    items:
+                        type: string
             description: SecurityIncident is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SecurityTraining:
             type: object
@@ -5603,6 +5635,12 @@ components:
                     description: Maximum password rotation interval in months
                     format: int32
             description: SingleSignOn is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SoftwareAttestation:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: SoftwareAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SourceCodeFile:
             type: object
             properties:
@@ -5634,6 +5672,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: SourceCodeFile is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Status:
             type: object
@@ -6082,6 +6124,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Win32 is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Win32 architecture, commonly found on Windows systems.

--- a/core/api/evaluation/openapi.yaml
+++ b/core/api/evaluation/openapi.yaml
@@ -5,7 +5,7 @@ openapi: 3.0.3
 info:
     title: Evaluation API
     description: Manages the evaluation of Confirmate's assessment results
-    version: core/v0.2.15-25-g8885487
+    version: core/v0.2.15-15-g97e68af
 paths:
     /v1/evaluation/evaluate:
         get:

--- a/core/api/evidence/evidence_store.pb.go
+++ b/core/api/evidence/evidence_store.pb.go
@@ -693,6 +693,7 @@ func (*ListToolsRequest) Descriptor() ([]byte, []int) {
 type ListToolsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ToolIds       []string               `protobuf:"bytes,1,rep,name=tool_ids,json=toolIds,proto3" json:"tool_ids,omitempty"`
+	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -732,6 +733,13 @@ func (x *ListToolsResponse) GetToolIds() []string {
 		return x.ToolIds
 	}
 	return nil
+}
+
+func (x *ListToolsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
 }
 
 type ListResourcesRequest_Filter struct {
@@ -849,9 +857,10 @@ const file_api_evidence_evidence_store_proto_rawDesc = "" +
 	"\x15ListResourcesResponse\x12G\n" +
 	"\aresults\x18\x01 \x03(\v2(.confirmate.evidence.v1.ResourceSnapshotB\x03\xe0A\x02R\aresults\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x12\n" +
-	"\x10ListToolsRequest\".\n" +
+	"\x10ListToolsRequest\"V\n" +
 	"\x11ListToolsResponse\x12\x19\n" +
-	"\btool_ids\x18\x01 \x03(\tR\atoolIds*d\n" +
+	"\btool_ids\x18\x01 \x03(\tR\atoolIds\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*d\n" +
 	"\x0eEvidenceStatus\x12\x1f\n" +
 	"\x1bEVIDENCE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVIDENCE_STATUS_OK\x10\x01\x12\x19\n" +

--- a/core/api/evidence/evidence_store.proto
+++ b/core/api/evidence/evidence_store.proto
@@ -142,4 +142,5 @@ message ListToolsRequest {}
 
 message ListToolsResponse {
   repeated string tool_ids = 1;
+  string next_page_token = 2;
 }

--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -4,7 +4,7 @@
 openapi: 3.0.3
 info:
     title: Evidence Store API
-    version: core/v0.2.15-25-g8885487
+    version: core/v0.2.15-15-g97e68af
 paths:
     /v1/evidence/graph/edges:
         get:
@@ -379,6 +379,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Agnostic is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents an agnostic architecture, which is not tied to a specific operating system.
@@ -476,6 +480,10 @@ components:
                         type: string
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Application is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  This encapsulates the whole (source) code of an application.
@@ -1543,6 +1551,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Darwin is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Darwin architecture, commonly found on macOS systems. macOS is a certified. [UNIX](https://www.opengroup.org/openbrand/register/apple.htm) and is (mostly) POSIX compatible.
@@ -2458,6 +2470,8 @@ components:
                     $ref: '#/components/schemas/SchemaValidation'
                 securityAdvisoryFeed:
                     $ref: '#/components/schemas/SecurityAdvisoryFeed'
+                securityIncident:
+                    $ref: '#/components/schemas/SecurityIncident'
                 time:
                     $ref: '#/components/schemas/Time'
                 vulnerability:
@@ -3550,6 +3564,10 @@ components:
                         type: string
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
                 vulnerabilities:
                     type: array
                     items:
@@ -3608,6 +3626,8 @@ components:
                     type: array
                     items:
                         type: string
+                nextPageToken:
+                    type: string
         LoadBalancer:
             type: object
             properties:
@@ -4578,6 +4598,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 POSIX is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a POSIX architecture, commonly found on Linux systems.
@@ -4612,6 +4636,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Package is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a grouping of (source) code into logical unit, for example a package for a namespace.
@@ -5814,6 +5842,8 @@ components:
                     $ref: '#/components/schemas/LocalAttestation'
                 remoteAttestation:
                     $ref: '#/components/schemas/RemoteAttestation'
+                softwareAttestation:
+                    $ref: '#/components/schemas/SoftwareAttestation'
                 automaticUpdates:
                     $ref: '#/components/schemas/AutomaticUpdates'
                 cryptographicHash:
@@ -5833,7 +5863,11 @@ components:
             description: SecurityFeature is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
         SecurityIncident:
             type: object
-            properties: {}
+            properties:
+                team:
+                    type: array
+                    items:
+                        type: string
             description: SecurityIncident is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SecurityTraining:
             type: object
@@ -5918,6 +5952,12 @@ components:
                     description: Maximum password rotation interval in months
                     format: int32
             description: SingleSignOn is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        SoftwareAttestation:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+            description: SoftwareAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SourceCodeFile:
             type: object
             properties:
@@ -5949,6 +5989,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: SourceCodeFile is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Status:
             type: object
@@ -6408,6 +6452,10 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
+                softwareAttestations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Win32 is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Win32 architecture, commonly found on Windows systems.

--- a/core/api/ontology/ontology.pb.go
+++ b/core/api/ontology/ontology.pb.go
@@ -442,13 +442,14 @@ type Agnostic struct {
 	Labels       map[string]string      `protobuf:"bytes,3423,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,5900,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,10733,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,16288,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,5545,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,4188,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,746,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,10733,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,16288,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,5545,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,4188,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,746,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,12742,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Agnostic) Reset() {
@@ -549,6 +550,13 @@ func (x *Agnostic) GetParentId() string {
 		return *x.ParentId
 	}
 	return ""
+}
+
+func (x *Agnostic) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
 }
 
 // Allocate is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -782,17 +790,18 @@ type Application struct {
 	ProgrammingLanguage string                 `protobuf:"bytes,1665,opt,name=programming_language,json=programmingLanguage,proto3" json:"programming_language,omitempty"`
 	ProgrammingVersion  string                 `protobuf:"bytes,3150,opt,name=programming_version,json=programmingVersion,proto3" json:"programming_version,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string            `protobuf:"bytes,18684,opt,name=raw,proto3" json:"raw,omitempty"`
-	TranslationUnits []string          `protobuf:"bytes,9449,rep,name=translation_units,json=translationUnits,proto3" json:"translation_units,omitempty"`
-	AutomaticUpdates *AutomaticUpdates `protobuf:"bytes,1992,opt,name=automatic_updates,json=automaticUpdates,proto3" json:"automatic_updates,omitempty"`
-	CodeModuleIds    []string          `protobuf:"bytes,18101,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string           `protobuf:"bytes,3551,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	ComputeId        *string           `protobuf:"bytes,13326,opt,name=compute_id,json=computeId,proto3,oneof" json:"compute_id,omitempty"`
-	Functionalities  []*Functionality  `protobuf:"bytes,6572,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	LibraryIds       []string          `protobuf:"bytes,11626,rep,name=library_ids,json=libraryIds,proto3" json:"library_ids,omitempty"`
-	ParentId         *string           `protobuf:"bytes,3984,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,18684,opt,name=raw,proto3" json:"raw,omitempty"`
+	TranslationUnits     []string               `protobuf:"bytes,9449,rep,name=translation_units,json=translationUnits,proto3" json:"translation_units,omitempty"`
+	AutomaticUpdates     *AutomaticUpdates      `protobuf:"bytes,1992,opt,name=automatic_updates,json=automaticUpdates,proto3" json:"automatic_updates,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,18101,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,3551,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	ComputeId            *string                `protobuf:"bytes,13326,opt,name=compute_id,json=computeId,proto3,oneof" json:"compute_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,6572,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	LibraryIds           []string               `protobuf:"bytes,11626,rep,name=library_ids,json=libraryIds,proto3" json:"library_ids,omitempty"`
+	ParentId             *string                `protobuf:"bytes,3984,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,16475,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Application) Reset() {
@@ -935,6 +944,13 @@ func (x *Application) GetParentId() string {
 		return *x.ParentId
 	}
 	return ""
+}
+
+func (x *Application) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
 }
 
 // ApplicationLogging is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -1312,6 +1328,7 @@ type Attestation struct {
 	//
 	//	*Attestation_LocalAttestation
 	//	*Attestation_RemoteAttestation
+	//	*Attestation_SoftwareAttestation
 	Type          isAttestation_Type `protobuf_oneof:"type"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1372,6 +1389,15 @@ func (x *Attestation) GetRemoteAttestation() *RemoteAttestation {
 	return nil
 }
 
+func (x *Attestation) GetSoftwareAttestation() *SoftwareAttestation {
+	if x != nil {
+		if x, ok := x.Type.(*Attestation_SoftwareAttestation); ok {
+			return x.SoftwareAttestation
+		}
+	}
+	return nil
+}
+
 type isAttestation_Type interface {
 	isAttestation_Type()
 }
@@ -1384,9 +1410,15 @@ type Attestation_RemoteAttestation struct {
 	RemoteAttestation *RemoteAttestation `protobuf:"bytes,13640,opt,name=remote_attestation,json=remoteAttestation,proto3,oneof"`
 }
 
+type Attestation_SoftwareAttestation struct {
+	SoftwareAttestation *SoftwareAttestation `protobuf:"bytes,2415,opt,name=software_attestation,json=softwareAttestation,proto3,oneof"`
+}
+
 func (*Attestation_LocalAttestation) isAttestation_Type() {}
 
 func (*Attestation_RemoteAttestation) isAttestation_Type() {}
+
+func (*Attestation_SoftwareAttestation) isAttestation_Type() {}
 
 // Auditing is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 type Auditing struct {
@@ -7679,13 +7711,14 @@ type Darwin struct {
 	Labels       map[string]string      `protobuf:"bytes,4761,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,9393,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,12162,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,3304,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,3877,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,12307,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,1392,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,12162,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,3304,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,3877,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,12307,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,1392,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,14509,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Darwin) Reset() {
@@ -7786,6 +7819,13 @@ func (x *Darwin) GetParentId() string {
 		return *x.ParentId
 	}
 	return ""
+}
+
+func (x *Darwin) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
 }
 
 // Data is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
@@ -12225,6 +12265,7 @@ type Functionality struct {
 	//	*Functionality_RequestForChange
 	//	*Functionality_SchemaValidation
 	//	*Functionality_SecurityAdvisoryFeed
+	//	*Functionality_SecurityIncident
 	//	*Functionality_Time
 	//	*Functionality_Vulnerability
 	Type          isFunctionality_Type `protobuf_oneof:"type"`
@@ -12962,6 +13003,15 @@ func (x *Functionality) GetSecurityAdvisoryFeed() *SecurityAdvisoryFeed {
 	return nil
 }
 
+func (x *Functionality) GetSecurityIncident() *SecurityIncident {
+	if x != nil {
+		if x, ok := x.Type.(*Functionality_SecurityIncident); ok {
+			return x.SecurityIncident
+		}
+	}
+	return nil
+}
+
 func (x *Functionality) GetTime() *Time {
 	if x != nil {
 		if x, ok := x.Type.(*Functionality_Time); ok {
@@ -13292,6 +13342,10 @@ type Functionality_SecurityAdvisoryFeed struct {
 	SecurityAdvisoryFeed *SecurityAdvisoryFeed `protobuf:"bytes,13903,opt,name=security_advisory_feed,json=securityAdvisoryFeed,proto3,oneof"`
 }
 
+type Functionality_SecurityIncident struct {
+	SecurityIncident *SecurityIncident `protobuf:"bytes,5083,opt,name=security_incident,json=securityIncident,proto3,oneof"`
+}
+
 type Functionality_Time struct {
 	Time *Time `protobuf:"bytes,16225,opt,name=time,proto3,oneof"`
 }
@@ -13453,6 +13507,8 @@ func (*Functionality_RequestForChange) isFunctionality_Type() {}
 func (*Functionality_SchemaValidation) isFunctionality_Type() {}
 
 func (*Functionality_SecurityAdvisoryFeed) isFunctionality_Type() {}
+
+func (*Functionality_SecurityIncident) isFunctionality_Type() {}
 
 func (*Functionality_Time) isFunctionality_Type() {}
 
@@ -15620,6 +15676,7 @@ type Integrity struct {
 	//
 	//	*Integrity_LocalAttestation
 	//	*Integrity_RemoteAttestation
+	//	*Integrity_SoftwareAttestation
 	//	*Integrity_AutomaticUpdates
 	//	*Integrity_CryptographicHash
 	//	*Integrity_Immutability
@@ -15681,6 +15738,15 @@ func (x *Integrity) GetRemoteAttestation() *RemoteAttestation {
 	if x != nil {
 		if x, ok := x.Type.(*Integrity_RemoteAttestation); ok {
 			return x.RemoteAttestation
+		}
+	}
+	return nil
+}
+
+func (x *Integrity) GetSoftwareAttestation() *SoftwareAttestation {
+	if x != nil {
+		if x, ok := x.Type.(*Integrity_SoftwareAttestation); ok {
+			return x.SoftwareAttestation
 		}
 	}
 	return nil
@@ -15752,6 +15818,10 @@ type Integrity_RemoteAttestation struct {
 	RemoteAttestation *RemoteAttestation `protobuf:"bytes,13640,opt,name=remote_attestation,json=remoteAttestation,proto3,oneof"`
 }
 
+type Integrity_SoftwareAttestation struct {
+	SoftwareAttestation *SoftwareAttestation `protobuf:"bytes,2415,opt,name=software_attestation,json=softwareAttestation,proto3,oneof"`
+}
+
 type Integrity_AutomaticUpdates struct {
 	AutomaticUpdates *AutomaticUpdates `protobuf:"bytes,9990,opt,name=automatic_updates,json=automaticUpdates,proto3,oneof"`
 }
@@ -15779,6 +15849,8 @@ type Integrity_VerifiedCommits struct {
 func (*Integrity_LocalAttestation) isIntegrity_Type() {}
 
 func (*Integrity_RemoteAttestation) isIntegrity_Type() {}
+
+func (*Integrity_SoftwareAttestation) isIntegrity_Type() {}
 
 func (*Integrity_AutomaticUpdates) isIntegrity_Type() {}
 
@@ -16992,15 +17064,16 @@ type Library struct {
 	Labels       map[string]string      `protobuf:"bytes,7546,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,18601,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,9988,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,7635,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,17722,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,16350,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	LibraryIds       []string         `protobuf:"bytes,7387,rep,name=library_ids,json=libraryIds,proto3" json:"library_ids,omitempty"`
-	ParentId         *string          `protobuf:"bytes,18076,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	Vulnerabilities  []*Vulnerability `protobuf:"bytes,17577,rep,name=vulnerabilities,proto3" json:"vulnerabilities,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,9988,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,7635,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,17722,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,16350,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	LibraryIds           []string               `protobuf:"bytes,7387,rep,name=library_ids,json=libraryIds,proto3" json:"library_ids,omitempty"`
+	ParentId             *string                `protobuf:"bytes,18076,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,17085,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	Vulnerabilities      []*Vulnerability       `protobuf:"bytes,17577,rep,name=vulnerabilities,proto3" json:"vulnerabilities,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Library) Reset() {
@@ -17108,6 +17181,13 @@ func (x *Library) GetParentId() string {
 		return *x.ParentId
 	}
 	return ""
+}
+
+func (x *Library) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
 }
 
 func (x *Library) GetVulnerabilities() []*Vulnerability {
@@ -22682,13 +22762,14 @@ type POSIX struct {
 	Labels       map[string]string      `protobuf:"bytes,8873,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,18076,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,6560,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,5732,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,13099,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,2402,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,15543,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,6560,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,5732,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,13099,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,2402,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,15543,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,4834,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *POSIX) Reset() {
@@ -22791,6 +22872,13 @@ func (x *POSIX) GetParentId() string {
 	return ""
 }
 
+func (x *POSIX) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
+}
+
 // Package is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 // Represents a grouping of (source) code into logical unit, for example a package for a namespace.
 type Package struct {
@@ -22801,13 +22889,14 @@ type Package struct {
 	Labels       map[string]string      `protobuf:"bytes,3230,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,11479,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,603,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,16160,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,17202,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,8054,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,18906,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,603,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,16160,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,17202,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,8054,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,18906,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,10448,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Package) Reset() {
@@ -22908,6 +22997,13 @@ func (x *Package) GetParentId() string {
 		return *x.ParentId
 	}
 	return ""
+}
+
+func (x *Package) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
 }
 
 // Padding is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -28649,6 +28745,7 @@ type SecurityFeature struct {
 	//	*SecurityFeature_EncryptionInUse
 	//	*SecurityFeature_LocalAttestation
 	//	*SecurityFeature_RemoteAttestation
+	//	*SecurityFeature_SoftwareAttestation
 	//	*SecurityFeature_AutomaticUpdates
 	//	*SecurityFeature_CryptographicHash
 	//	*SecurityFeature_Immutability
@@ -29014,6 +29111,15 @@ func (x *SecurityFeature) GetRemoteAttestation() *RemoteAttestation {
 	return nil
 }
 
+func (x *SecurityFeature) GetSoftwareAttestation() *SoftwareAttestation {
+	if x != nil {
+		if x, ok := x.Type.(*SecurityFeature_SoftwareAttestation); ok {
+			return x.SoftwareAttestation
+		}
+	}
+	return nil
+}
+
 func (x *SecurityFeature) GetAutomaticUpdates() *AutomaticUpdates {
 	if x != nil {
 		if x, ok := x.Type.(*SecurityFeature_AutomaticUpdates); ok {
@@ -29230,6 +29336,10 @@ type SecurityFeature_RemoteAttestation struct {
 	RemoteAttestation *RemoteAttestation `protobuf:"bytes,13640,opt,name=remote_attestation,json=remoteAttestation,proto3,oneof"`
 }
 
+type SecurityFeature_SoftwareAttestation struct {
+	SoftwareAttestation *SoftwareAttestation `protobuf:"bytes,2415,opt,name=software_attestation,json=softwareAttestation,proto3,oneof"`
+}
+
 type SecurityFeature_AutomaticUpdates struct {
 	AutomaticUpdates *AutomaticUpdates `protobuf:"bytes,9990,opt,name=automatic_updates,json=automaticUpdates,proto3,oneof"`
 }
@@ -29332,6 +29442,8 @@ func (*SecurityFeature_LocalAttestation) isSecurityFeature_Type() {}
 
 func (*SecurityFeature_RemoteAttestation) isSecurityFeature_Type() {}
 
+func (*SecurityFeature_SoftwareAttestation) isSecurityFeature_Type() {}
+
 func (*SecurityFeature_AutomaticUpdates) isSecurityFeature_Type() {}
 
 func (*SecurityFeature_CryptographicHash) isSecurityFeature_Type() {}
@@ -29351,6 +29463,7 @@ func (*SecurityFeature_RobustnessScore) isSecurityFeature_Type() {}
 // SecurityIncident is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 type SecurityIncident struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Team          []string               `protobuf:"bytes,3344,rep,name=team,proto3" json:"team,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -29383,6 +29496,13 @@ func (x *SecurityIncident) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SecurityIncident.ProtoReflect.Descriptor instead.
 func (*SecurityIncident) Descriptor() ([]byte, []int) {
 	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{245}
+}
+
+func (x *SecurityIncident) GetTeam() []string {
+	if x != nil {
+		return x.Team
+	}
+	return nil
 }
 
 // SecurityTraining is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -29815,6 +29935,51 @@ func (x *SingleSignOn) GetRotationInterval() int32 {
 	return 0
 }
 
+// SoftwareAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+type SoftwareAttestation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,5129,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SoftwareAttestation) Reset() {
+	*x = SoftwareAttestation{}
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[252]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SoftwareAttestation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SoftwareAttestation) ProtoMessage() {}
+
+func (x *SoftwareAttestation) ProtoReflect() protoreflect.Message {
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[252]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SoftwareAttestation.ProtoReflect.Descriptor instead.
+func (*SoftwareAttestation) Descriptor() ([]byte, []int) {
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{252}
+}
+
+func (x *SoftwareAttestation) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
 // Code is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 type Code struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -29835,7 +30000,7 @@ type Code struct {
 
 func (x *Code) Reset() {
 	*x = Code{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[252]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -29847,7 +30012,7 @@ func (x *Code) String() string {
 func (*Code) ProtoMessage() {}
 
 func (x *Code) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[252]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -29860,7 +30025,7 @@ func (x *Code) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Code.ProtoReflect.Descriptor instead.
 func (*Code) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{252}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{253}
 }
 
 func (x *Code) GetType() isCode_Type {
@@ -30003,18 +30168,19 @@ type SourceCodeFile struct {
 	Labels       map[string]string      `protobuf:"bytes,7345,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,14615,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,16625,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,14101,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,8294,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,3267,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,12296,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,16625,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,14101,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,8294,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,3267,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,12296,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,11190,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *SourceCodeFile) Reset() {
 	*x = SourceCodeFile{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30026,7 +30192,7 @@ func (x *SourceCodeFile) String() string {
 func (*SourceCodeFile) ProtoMessage() {}
 
 func (x *SourceCodeFile) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30039,7 +30205,7 @@ func (x *SourceCodeFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceCodeFile.ProtoReflect.Descriptor instead.
 func (*SourceCodeFile) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{253}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{254}
 }
 
 func (x *SourceCodeFile) GetCreationTime() *timestamppb.Timestamp {
@@ -30112,6 +30278,13 @@ func (x *SourceCodeFile) GetParentId() string {
 	return ""
 }
 
+func (x *SourceCodeFile) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
+}
+
 // Storage is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 type Storage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -30128,7 +30301,7 @@ type Storage struct {
 
 func (x *Storage) Reset() {
 	*x = Storage{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30140,7 +30313,7 @@ func (x *Storage) String() string {
 func (*Storage) ProtoMessage() {}
 
 func (x *Storage) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30153,7 +30326,7 @@ func (x *Storage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Storage.ProtoReflect.Descriptor instead.
 func (*Storage) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{254}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{255}
 }
 
 func (x *Storage) GetType() isStorage_Type {
@@ -30246,7 +30419,7 @@ type StorageService struct {
 
 func (x *StorageService) Reset() {
 	*x = StorageService{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[256]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30258,7 +30431,7 @@ func (x *StorageService) String() string {
 func (*StorageService) ProtoMessage() {}
 
 func (x *StorageService) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[256]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30271,7 +30444,7 @@ func (x *StorageService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageService.ProtoReflect.Descriptor instead.
 func (*StorageService) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{255}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{256}
 }
 
 func (x *StorageService) GetType() isStorageService_Type {
@@ -30397,7 +30570,7 @@ type SymmetricCipher struct {
 
 func (x *SymmetricCipher) Reset() {
 	*x = SymmetricCipher{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[256]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[257]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30409,7 +30582,7 @@ func (x *SymmetricCipher) String() string {
 func (*SymmetricCipher) ProtoMessage() {}
 
 func (x *SymmetricCipher) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[256]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[257]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30422,7 +30595,7 @@ func (x *SymmetricCipher) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SymmetricCipher.ProtoReflect.Descriptor instead.
 func (*SymmetricCipher) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{256}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{257}
 }
 
 func (x *SymmetricCipher) GetAuthTagSize() int32 {
@@ -30483,7 +30656,7 @@ type Time struct {
 
 func (x *Time) Reset() {
 	*x = Time{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[257]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[258]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30495,7 +30668,7 @@ func (x *Time) String() string {
 func (*Time) ProtoMessage() {}
 
 func (x *Time) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[257]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[258]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30508,7 +30681,7 @@ func (x *Time) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Time.ProtoReflect.Descriptor instead.
 func (*Time) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{257}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{258}
 }
 
 // Token is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -30530,7 +30703,7 @@ type Token struct {
 
 func (x *Token) Reset() {
 	*x = Token{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[258]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30542,7 +30715,7 @@ func (x *Token) String() string {
 func (*Token) ProtoMessage() {}
 
 func (x *Token) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[258]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30555,7 +30728,7 @@ func (x *Token) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Token.ProtoReflect.Descriptor instead.
 func (*Token) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{258}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{259}
 }
 
 func (x *Token) GetCreationTime() *timestamppb.Timestamp {
@@ -30628,7 +30801,7 @@ type Training struct {
 
 func (x *Training) Reset() {
 	*x = Training{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30640,7 +30813,7 @@ func (x *Training) String() string {
 func (*Training) ProtoMessage() {}
 
 func (x *Training) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30653,7 +30826,7 @@ func (x *Training) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Training.ProtoReflect.Descriptor instead.
 func (*Training) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{259}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{260}
 }
 
 func (x *Training) GetType() isTraining_Type {
@@ -30716,7 +30889,7 @@ type TransportEncryption struct {
 
 func (x *TransportEncryption) Reset() {
 	*x = TransportEncryption{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[261]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30728,7 +30901,7 @@ func (x *TransportEncryption) String() string {
 func (*TransportEncryption) ProtoMessage() {}
 
 func (x *TransportEncryption) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[261]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30741,7 +30914,7 @@ func (x *TransportEncryption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransportEncryption.ProtoReflect.Descriptor instead.
 func (*TransportEncryption) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{260}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{261}
 }
 
 func (x *TransportEncryption) GetEnabled() bool {
@@ -30811,7 +30984,7 @@ type UnlockEncryptedDisk struct {
 
 func (x *UnlockEncryptedDisk) Reset() {
 	*x = UnlockEncryptedDisk{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[261]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[262]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30823,7 +30996,7 @@ func (x *UnlockEncryptedDisk) String() string {
 func (*UnlockEncryptedDisk) ProtoMessage() {}
 
 func (x *UnlockEncryptedDisk) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[261]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[262]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30836,7 +31009,7 @@ func (x *UnlockEncryptedDisk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockEncryptedDisk.ProtoReflect.Descriptor instead.
 func (*UnlockEncryptedDisk) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{261}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{262}
 }
 
 func (x *UnlockEncryptedDisk) GetCodeRegion() *CodeRegion {
@@ -30863,7 +31036,7 @@ type UsageStatistics struct {
 
 func (x *UsageStatistics) Reset() {
 	*x = UsageStatistics{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[262]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[263]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30875,7 +31048,7 @@ func (x *UsageStatistics) String() string {
 func (*UsageStatistics) ProtoMessage() {}
 
 func (x *UsageStatistics) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[262]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[263]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30888,7 +31061,7 @@ func (x *UsageStatistics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UsageStatistics.ProtoReflect.Descriptor instead.
 func (*UsageStatistics) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{262}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{263}
 }
 
 func (x *UsageStatistics) GetApiHitsPerMonth() int32 {
@@ -30921,7 +31094,7 @@ type UserInformationAndIntructionDocument struct {
 
 func (x *UserInformationAndIntructionDocument) Reset() {
 	*x = UserInformationAndIntructionDocument{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[263]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[264]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -30933,7 +31106,7 @@ func (x *UserInformationAndIntructionDocument) String() string {
 func (*UserInformationAndIntructionDocument) ProtoMessage() {}
 
 func (x *UserInformationAndIntructionDocument) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[263]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[264]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -30946,7 +31119,7 @@ func (x *UserInformationAndIntructionDocument) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UserInformationAndIntructionDocument.ProtoReflect.Descriptor instead.
 func (*UserInformationAndIntructionDocument) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{263}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{264}
 }
 
 func (x *UserInformationAndIntructionDocument) GetCreationTime() *timestamppb.Timestamp {
@@ -31065,7 +31238,7 @@ type VMImage struct {
 
 func (x *VMImage) Reset() {
 	*x = VMImage{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[264]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[265]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31077,7 +31250,7 @@ func (x *VMImage) String() string {
 func (*VMImage) ProtoMessage() {}
 
 func (x *VMImage) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[264]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[265]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31090,7 +31263,7 @@ func (x *VMImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VMImage.ProtoReflect.Descriptor instead.
 func (*VMImage) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{264}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{265}
 }
 
 func (x *VMImage) GetCreationTime() *timestamppb.Timestamp {
@@ -31210,7 +31383,7 @@ type ValidateJwt struct {
 
 func (x *ValidateJwt) Reset() {
 	*x = ValidateJwt{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[265]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[266]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31222,7 +31395,7 @@ func (x *ValidateJwt) String() string {
 func (*ValidateJwt) ProtoMessage() {}
 
 func (x *ValidateJwt) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[265]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[266]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31235,7 +31408,7 @@ func (x *ValidateJwt) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateJwt.ProtoReflect.Descriptor instead.
 func (*ValidateJwt) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{265}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{266}
 }
 
 func (x *ValidateJwt) GetAuthenticity() *Authenticity {
@@ -31271,7 +31444,7 @@ type Value struct {
 
 func (x *Value) Reset() {
 	*x = Value{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[266]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[267]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31283,7 +31456,7 @@ func (x *Value) String() string {
 func (*Value) ProtoMessage() {}
 
 func (x *Value) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[266]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[267]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31296,7 +31469,7 @@ func (x *Value) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Value.ProtoReflect.Descriptor instead.
 func (*Value) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{266}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{267}
 }
 
 func (x *Value) GetCreationTime() *timestamppb.Timestamp {
@@ -31371,7 +31544,7 @@ type VerifiedCommits struct {
 
 func (x *VerifiedCommits) Reset() {
 	*x = VerifiedCommits{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[267]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[268]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31383,7 +31556,7 @@ func (x *VerifiedCommits) String() string {
 func (*VerifiedCommits) ProtoMessage() {}
 
 func (x *VerifiedCommits) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[267]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[268]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31396,7 +31569,7 @@ func (x *VerifiedCommits) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifiedCommits.ProtoReflect.Descriptor instead.
 func (*VerifiedCommits) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{267}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{268}
 }
 
 func (x *VerifiedCommits) GetPercentage() float32 {
@@ -31446,7 +31619,7 @@ type VirtualMachine struct {
 
 func (x *VirtualMachine) Reset() {
 	*x = VirtualMachine{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[268]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[269]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31458,7 +31631,7 @@ func (x *VirtualMachine) String() string {
 func (*VirtualMachine) ProtoMessage() {}
 
 func (x *VirtualMachine) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[268]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[269]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31471,7 +31644,7 @@ func (x *VirtualMachine) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VirtualMachine.ProtoReflect.Descriptor instead.
 func (*VirtualMachine) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{268}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{269}
 }
 
 func (x *VirtualMachine) GetCreationTime() *timestamppb.Timestamp {
@@ -31659,7 +31832,7 @@ type VirtualNetwork struct {
 
 func (x *VirtualNetwork) Reset() {
 	*x = VirtualNetwork{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[269]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[270]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31671,7 +31844,7 @@ func (x *VirtualNetwork) String() string {
 func (*VirtualNetwork) ProtoMessage() {}
 
 func (x *VirtualNetwork) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[269]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[270]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31684,7 +31857,7 @@ func (x *VirtualNetwork) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VirtualNetwork.ProtoReflect.Descriptor instead.
 func (*VirtualNetwork) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{269}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{270}
 }
 
 func (x *VirtualNetwork) GetCreationTime() *timestamppb.Timestamp {
@@ -31809,7 +31982,7 @@ type VirtualSubNetwork struct {
 
 func (x *VirtualSubNetwork) Reset() {
 	*x = VirtualSubNetwork{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[270]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[271]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31821,7 +31994,7 @@ func (x *VirtualSubNetwork) String() string {
 func (*VirtualSubNetwork) ProtoMessage() {}
 
 func (x *VirtualSubNetwork) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[270]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[271]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31834,7 +32007,7 @@ func (x *VirtualSubNetwork) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VirtualSubNetwork.ProtoReflect.Descriptor instead.
 func (*VirtualSubNetwork) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{270}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{271}
 }
 
 func (x *VirtualSubNetwork) GetCreationTime() *timestamppb.Timestamp {
@@ -31954,7 +32127,7 @@ type Vulnerability struct {
 
 func (x *Vulnerability) Reset() {
 	*x = Vulnerability{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[271]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[272]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -31966,7 +32139,7 @@ func (x *Vulnerability) String() string {
 func (*Vulnerability) ProtoMessage() {}
 
 func (x *Vulnerability) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[271]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[272]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -31979,7 +32152,7 @@ func (x *Vulnerability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Vulnerability.ProtoReflect.Descriptor instead.
 func (*Vulnerability) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{271}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{272}
 }
 
 func (x *Vulnerability) GetCriticality() string {
@@ -32035,7 +32208,7 @@ type WebApplicationFirewall struct {
 
 func (x *WebApplicationFirewall) Reset() {
 	*x = WebApplicationFirewall{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[272]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[273]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -32047,7 +32220,7 @@ func (x *WebApplicationFirewall) String() string {
 func (*WebApplicationFirewall) ProtoMessage() {}
 
 func (x *WebApplicationFirewall) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[272]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[273]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -32060,7 +32233,7 @@ func (x *WebApplicationFirewall) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebApplicationFirewall.ProtoReflect.Descriptor instead.
 func (*WebApplicationFirewall) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{272}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{273}
 }
 
 func (x *WebApplicationFirewall) GetEnabled() bool {
@@ -32080,18 +32253,19 @@ type Win32 struct {
 	Labels       map[string]string      `protobuf:"bytes,12211,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Name         string                 `protobuf:"bytes,8220,opt,name=name,proto3" json:"name,omitempty"`
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	Raw              string           `protobuf:"bytes,17302,opt,name=raw,proto3" json:"raw,omitempty"`
-	CodeModuleIds    []string         `protobuf:"bytes,822,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
-	CodeRepositoryId *string          `protobuf:"bytes,16090,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
-	Functionalities  []*Functionality `protobuf:"bytes,18689,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
-	ParentId         *string          `protobuf:"bytes,10020,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Raw                  string                 `protobuf:"bytes,17302,opt,name=raw,proto3" json:"raw,omitempty"`
+	CodeModuleIds        []string               `protobuf:"bytes,822,rep,name=code_module_ids,json=codeModuleIds,proto3" json:"code_module_ids,omitempty"`
+	CodeRepositoryId     *string                `protobuf:"bytes,16090,opt,name=code_repository_id,json=codeRepositoryId,proto3,oneof" json:"code_repository_id,omitempty"`
+	Functionalities      []*Functionality       `protobuf:"bytes,18689,rep,name=functionalities,proto3" json:"functionalities,omitempty"`
+	ParentId             *string                `protobuf:"bytes,10020,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	SoftwareAttestations []*SoftwareAttestation `protobuf:"bytes,10723,rep,name=software_attestations,json=softwareAttestations,proto3" json:"software_attestations,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Win32) Reset() {
 	*x = Win32{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[273]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[274]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -32103,7 +32277,7 @@ func (x *Win32) String() string {
 func (*Win32) ProtoMessage() {}
 
 func (x *Win32) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[273]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[274]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -32116,7 +32290,7 @@ func (x *Win32) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Win32.ProtoReflect.Descriptor instead.
 func (*Win32) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{273}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{274}
 }
 
 func (x *Win32) GetCreationTime() *timestamppb.Timestamp {
@@ -32189,6 +32363,13 @@ func (x *Win32) GetParentId() string {
 	return ""
 }
 
+func (x *Win32) GetSoftwareAttestations() []*SoftwareAttestation {
+	if x != nil {
+		return x.SoftwareAttestations
+	}
+	return nil
+}
+
 // Workflow is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 type Workflow struct {
 	state                      protoimpl.MessageState `protogen:"open.v1"`
@@ -32213,7 +32394,7 @@ type Workflow struct {
 
 func (x *Workflow) Reset() {
 	*x = Workflow{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[274]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[275]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -32225,7 +32406,7 @@ func (x *Workflow) String() string {
 func (*Workflow) ProtoMessage() {}
 
 func (x *Workflow) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[274]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[275]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -32238,7 +32419,7 @@ func (x *Workflow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Workflow.ProtoReflect.Descriptor instead.
 func (*Workflow) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{274}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{275}
 }
 
 func (x *Workflow) GetCreationTime() *timestamppb.Timestamp {
@@ -32349,7 +32530,7 @@ type ZoneRedundancy struct {
 
 func (x *ZoneRedundancy) Reset() {
 	*x = ZoneRedundancy{}
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[275]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[276]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -32361,7 +32542,7 @@ func (x *ZoneRedundancy) String() string {
 func (*ZoneRedundancy) ProtoMessage() {}
 
 func (x *ZoneRedundancy) ProtoReflect() protoreflect.Message {
-	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[275]
+	mi := &file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[276]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -32374,7 +32555,7 @@ func (x *ZoneRedundancy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ZoneRedundancy.ProtoReflect.Descriptor instead.
 func (*ZoneRedundancy) Descriptor() ([]byte, []int) {
-	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{275}
+	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP(), []int{276}
 }
 
 func (x *ZoneRedundancy) GetGeoLocations() []*GeoLocation {
@@ -32442,7 +32623,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x1bmonitoring_log_data_enabled\x18\xbaj \x01(\bR\x18monitoringLogDataEnabled\x12E\n" +
 	"\x10retention_period\x18\xa4T \x01(\v2\x19.google.protobuf.DurationR\x0fretentionPeriod\x128\n" +
 	"\x17security_alerts_enabled\x18\x90\x8a\x01 \x01(\bR\x15securityAlertsEnabled\x120\n" +
-	"\x13logging_service_ids\x18\xf8\x82\x01 \x03(\tR\x11loggingServiceIds:=\x82\xa6\x1d\x0fActivityLogging\x82\xa6\x1d\aLogging\x82\xa6\x1d\bAuditing\x82\xa6\x1d\x0fSecurityFeature\"\xf2\x04\n" +
+	"\x13logging_service_ids\x18\xf8\x82\x01 \x03(\tR\x11loggingServiceIds:=\x82\xa6\x1d\x0fActivityLogging\x82\xa6\x1d\aLogging\x82\xa6\x1d\bAuditing\x82\xa6\x1d\x0fSecurityFeature\"\xd5\x05\n" +
 	"\bAgnostic\x12@\n" +
 	"\rcreation_time\x18\xb6\x13 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\x9aA \x01(\tR\vdescription\x12\x17\n" +
@@ -32453,7 +32634,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fcode_module_ids\x18\xa0\x7f \x03(\tR\rcodeModuleIds\x122\n" +
 	"\x12code_repository_id\x18\xa9+ \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12P\n" +
 	"\x0ffunctionalities\x18\xdc  \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12!\n" +
-	"\tparent_id\x18\xea\x05 \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18\xea\x05 \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xc6c \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:?\x82\xa6\x1d\bAgnostic\x82\xa6\x1d\x1bOperatingSystemArchitecture\x82\xa6\x1d\x04Code\x82\xa6\x1d\bResourceB\x15\n" +
@@ -32484,7 +32666,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x10AnomalyDetection\x12\x19\n" +
 	"\aenabled\x18\x94E \x01(\bR\aenabled\x12\x15\n" +
 	"\x05scope\x18\xa2B \x01(\tR\x05scope\x12\\\n" +
-	"\x13application_logging\x18\x81} \x01(\v2*.confirmate.ontology.v1.ApplicationLoggingR\x12applicationLogging:3\x82\xa6\x1d\x10AnomalyDetection\x82\xa6\x1d\bAuditing\x82\xa6\x1d\x0fSecurityFeature\"\xad\a\n" +
+	"\x13application_logging\x18\x81} \x01(\v2*.confirmate.ontology.v1.ApplicationLoggingR\x12applicationLogging:3\x82\xa6\x1d\x10AnomalyDetection\x82\xa6\x1d\bAuditing\x82\xa6\x1d\x0fSecurityFeature\"\x91\b\n" +
 	"\vApplication\x12@\n" +
 	"\rcreation_time\x18\xd1u \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\xeb\x11 \x01(\tR\vdescription\x12\x17\n" +
@@ -32503,7 +32685,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0ffunctionalities\x18\xac3 \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12 \n" +
 	"\vlibrary_ids\x18\xeaZ \x03(\tR\n" +
 	"libraryIds\x12!\n" +
-	"\tparent_id\x18\x90\x1f \x01(\tH\x02R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18\x90\x1f \x01(\tH\x02R\bparentId\x88\x01\x01\x12b\n" +
+	"\x15software_attestations\x18ۀ\x01 \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:0\x82\xa6\x1d\vApplication\x82\xa6\x1d\tComponent\x82\xa6\x1d\x04Code\x82\xa6\x1d\bResourceB\x15\n" +
@@ -32538,10 +32721,11 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x17customer_key_encryption\x18\x9a\\ \x01(\v2-.confirmate.ontology.v1.CustomerKeyEncryptionH\x00R\x15customerKeyEncryption\x12R\n" +
 	"\x0fdisk_encryption\x18\x8cF \x01(\v2&.confirmate.ontology.v1.DiskEncryptionH\x00R\x0ediskEncryption\x12e\n" +
 	"\x16managed_key_encryption\x18\x80Z \x01(\v2,.confirmate.ontology.v1.ManagedKeyEncryptionH\x00R\x14managedKeyEncryptionB\x06\n" +
-	"\x04type\"\xcc\x01\n" +
+	"\x04type\"\xaf\x02\n" +
 	"\vAttestation\x12X\n" +
 	"\x11local_attestation\x18\xc8! \x01(\v2(.confirmate.ontology.v1.LocalAttestationH\x00R\x10localAttestation\x12[\n" +
-	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestationB\x06\n" +
+	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestation\x12a\n" +
+	"\x14software_attestation\x18\xef\x12 \x01(\v2+.confirmate.ontology.v1.SoftwareAttestationH\x00R\x13softwareAttestationB\x06\n" +
 	"\x04type\"\xe0\x06\n" +
 	"\bAuditing\x12X\n" +
 	"\x11anomaly_detection\x18\xf8$ \x01(\v2(.confirmate.ontology.v1.AnomalyDetectionH\x00R\x10anomalyDetection\x12R\n" +
@@ -33131,7 +33315,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:G\x82\xa6\x1d#CyberSecurityRiskAssessmentDocument\x82\xa6\x1d\bDocument\x82\xa6\x1d\x04Data\x82\xa6\x1d\bResourceB\f\n" +
 	"\n" +
 	"_parent_id\"G\n" +
-	"\x0eDDoSProtection:5\x82\xa6\x1d\x0eDDoSProtection\x82\xa6\x1d\fAvailability\x82\xa6\x1d\x0fSecurityFeature\"\xed\x04\n" +
+	"\x0eDDoSProtection:5\x82\xa6\x1d\x0eDDoSProtection\x82\xa6\x1d\fAvailability\x82\xa6\x1d\x0fSecurityFeature\"\xd0\x05\n" +
 	"\x06Darwin\x12@\n" +
 	"\rcreation_time\x18\x9b\\ \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\xb32 \x01(\tR\vdescription\x12\x18\n" +
@@ -33143,7 +33327,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x12code_repository_id\x18\xa5\x1e \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12P\n" +
 	"\x0ffunctionalities\x18\x93` \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12!\n" +
 	"\tparent_id\x18\xf0\n" +
-	" \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	" \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xadq \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:=\x82\xa6\x1d\x06Darwin\x82\xa6\x1d\x1bOperatingSystemArchitecture\x82\xa6\x1d\x04Code\x82\xa6\x1d\bResourceB\x15\n" +
@@ -33590,7 +33775,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"Networking\x82\xa6\x1d\x0eInfrastructure\x82\xa6\x1d\bResourceB\f\n" +
 	"\n" +
 	"_parent_idB\x1f\n" +
-	"\x1d_service_metadata_document_id\"\xa07\n" +
+	"\x1d_service_metadata_document_id\"\xfa7\n" +
 	"\rFunctionality\x12?\n" +
 	"\bboundary\x18\x8cS \x01(\v2 .confirmate.ontology.v1.BoundaryH\x00R\bboundary\x12\x8a\x01\n" +
 	"#change_and_configuration_management\x18\xc7_ \x01(\v28.confirmate.ontology.v1.ChangeAndConfigurationManagementH\x00R changeAndConfigurationManagement\x12X\n" +
@@ -33676,7 +33861,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fprotected_asset\x18\xc9S \x01(\v2&.confirmate.ontology.v1.ProtectedAssetH\x00R\x0eprotectedAsset\x12Y\n" +
 	"\x12request_for_change\x18\xdc) \x01(\v2(.confirmate.ontology.v1.RequestForChangeH\x00R\x10requestForChange\x12X\n" +
 	"\x11schema_validation\x18\xcb\x7f \x01(\v2(.confirmate.ontology.v1.SchemaValidationH\x00R\x10schemaValidation\x12e\n" +
-	"\x16security_advisory_feed\x18\xcfl \x01(\v2,.confirmate.ontology.v1.SecurityAdvisoryFeedH\x00R\x14securityAdvisoryFeed\x123\n" +
+	"\x16security_advisory_feed\x18\xcfl \x01(\v2,.confirmate.ontology.v1.SecurityAdvisoryFeedH\x00R\x14securityAdvisoryFeed\x12X\n" +
+	"\x11security_incident\x18\xdb' \x01(\v2(.confirmate.ontology.v1.SecurityIncidentH\x00R\x10securityIncident\x123\n" +
 	"\x04time\x18\xe1~ \x01(\v2\x1c.confirmate.ontology.v1.TimeH\x00R\x04time\x12N\n" +
 	"\rvulnerability\x18\xe7' \x01(\v2%.confirmate.ontology.v1.VulnerabilityH\x00R\rvulnerabilityB\x06\n" +
 	"\x04type\"m\n" +
@@ -33862,10 +34048,11 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x16InstallUpdateOperation\x12V\n" +
 	"\x11automatic_updates\x18\xf18 \x01(\v2(.confirmate.ontology.v1.AutomaticUpdatesR\x10automaticUpdates\x12D\n" +
 	"\vcode_region\x18\xefj \x01(\v2\".confirmate.ontology.v1.CodeRegionR\n" +
-	"codeRegion:8\x82\xa6\x1d\x16InstallUpdateOperation\x82\xa6\x1d\tOperation\x82\xa6\x1d\rFunctionality\"\xd4\x05\n" +
+	"codeRegion:8\x82\xa6\x1d\x16InstallUpdateOperation\x82\xa6\x1d\tOperation\x82\xa6\x1d\rFunctionality\"\xb7\x06\n" +
 	"\tIntegrity\x12X\n" +
 	"\x11local_attestation\x18\xc8! \x01(\v2(.confirmate.ontology.v1.LocalAttestationH\x00R\x10localAttestation\x12[\n" +
-	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestation\x12X\n" +
+	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestation\x12a\n" +
+	"\x14software_attestation\x18\xef\x12 \x01(\v2+.confirmate.ontology.v1.SoftwareAttestationH\x00R\x13softwareAttestation\x12X\n" +
 	"\x11automatic_updates\x18\x86N \x01(\v2(.confirmate.ontology.v1.AutomaticUpdatesH\x00R\x10automaticUpdates\x12\\\n" +
 	"\x12cryptographic_hash\x18\xf7\x8d\x01 \x01(\v2).confirmate.ontology.v1.CryptographicHashH\x00R\x11cryptographicHash\x12K\n" +
 	"\fimmutability\x18\xd8\x0f \x01(\v2$.confirmate.ontology.v1.ImmutabilityH\x00R\fimmutability\x12[\n" +
@@ -34007,7 +34194,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"L3Firewall\x82\xa6\x1d\bFirewall\x82\xa6\x1d\x11AccessRestriction\x82\xa6\x1d\rAuthorization\x82\xa6\x1d\x0fSecurityFeature\"n\n" +
 	"\x14LeastPrivilegePolicy\x12\x1f\n" +
 	"\n" +
-	"is_defined\x18\x90\x8d\x01 \x01(\bR\tisDefined:5\x82\xa6\x1d\x14LeastPrivilegePolicy\x82\xa6\x1d\bPolicies\x82\xa6\x1d\rFunctionality\"\xd5\x05\n" +
+	"is_defined\x18\x90\x8d\x01 \x01(\bR\tisDefined:5\x82\xa6\x1d\x14LeastPrivilegePolicy\x82\xa6\x1d\bPolicies\x82\xa6\x1d\rFunctionality\"\xb9\x06\n" +
 	"\aLibrary\x12@\n" +
 	"\rcreation_time\x18\xd3] \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\xc3\x13 \x01(\tR\vdescription\x12\x17\n" +
@@ -34020,7 +34207,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0ffunctionalities\x18\xde\x7f \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12 \n" +
 	"\vlibrary_ids\x18\xdb9 \x03(\tR\n" +
 	"libraryIds\x12\"\n" +
-	"\tparent_id\x18\x9c\x8d\x01 \x01(\tH\x01R\bparentId\x88\x01\x01\x12Q\n" +
+	"\tparent_id\x18\x9c\x8d\x01 \x01(\tH\x01R\bparentId\x88\x01\x01\x12b\n" +
+	"\x15software_attestations\x18\xbd\x85\x01 \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x12Q\n" +
 	"\x0fvulnerabilities\x18\xa9\x89\x01 \x03(\v2%.confirmate.ontology.v1.VulnerabilityR\x0fvulnerabilities\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -34585,7 +34773,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\n" +
 	"get_secret\x18\xf9\x15 \x01(\v2!.confirmate.ontology.v1.GetSecretH\x00R\tgetSecretB\x06\n" +
 	"\x04type\"%\n" +
-	"\x06Output:\x1b\x82\xa6\x1d\x06Output\x82\xa6\x1d\rFunctionality\"\xea\x04\n" +
+	"\x06Output:\x1b\x82\xa6\x1d\x06Output\x82\xa6\x1d\rFunctionality\"\xcd\x05\n" +
 	"\x05POSIX\x12@\n" +
 	"\rcreation_time\x18\xdbi \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\xf0$ \x01(\tR\vdescription\x12\x17\n" +
@@ -34596,13 +34784,14 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fcode_module_ids\x18\xe4, \x03(\tR\rcodeModuleIds\x122\n" +
 	"\x12code_repository_id\x18\xabf \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12P\n" +
 	"\x0ffunctionalities\x18\xe2\x12 \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12!\n" +
-	"\tparent_id\x18\xb7y \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18\xb7y \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xe2% \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:<\x82\xa6\x1d\x05POSIX\x82\xa6\x1d\x1bOperatingSystemArchitecture\x82\xa6\x1d\x04Code\x82\xa6\x1d\bResourceB\x15\n" +
 	"\x13_code_repository_idB\f\n" +
 	"\n" +
-	"_parent_id\"\xe1\x04\n" +
+	"_parent_id\"\xc4\x05\n" +
 	"\aPackage\x12A\n" +
 	"\rcreation_time\x18\xe0\x8a\x01 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\x8fg \x01(\tR\vdescription\x12\x17\n" +
@@ -34613,7 +34802,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fcode_module_ids\x18\xa0~ \x03(\tR\rcodeModuleIds\x123\n" +
 	"\x12code_repository_id\x18\xb2\x86\x01 \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12P\n" +
 	"\x0ffunctionalities\x18\xf6> \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12\"\n" +
-	"\tparent_id\x18ړ\x01 \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18ړ\x01 \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xd0Q \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:-\x82\xa6\x1d\aPackage\x82\xa6\x1d\n" +
@@ -35168,7 +35358,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"Networking\x82\xa6\x1d\x0eInfrastructure\x82\xa6\x1d\bResourceB\f\n" +
 	"\n" +
 	"_parent_idB\x1f\n" +
-	"\x1d_service_metadata_document_id\"\xf2\x1d\n" +
+	"\x1d_service_metadata_document_id\"\xd5\x1e\n" +
 	"\x0fSecurityFeature\x12X\n" +
 	"\x11anomaly_detection\x18\xf8$ \x01(\v2(.confirmate.ontology.v1.AnomalyDetectionH\x00R\x10anomalyDetection\x12R\n" +
 	"\x0fasset_inventory\x18\xa0d \x01(\v2&.confirmate.ontology.v1.AssetInventoryH\x00R\x0eassetInventory\x12J\n" +
@@ -35206,7 +35396,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x14transport_encryption\x18\xb3n \x01(\v2+.confirmate.ontology.v1.TransportEncryptionH\x00R\x13transportEncryption\x12V\n" +
 	"\x11encryption_in_use\x18\x9f{ \x01(\v2'.confirmate.ontology.v1.EncryptionInUseH\x00R\x0fencryptionInUse\x12X\n" +
 	"\x11local_attestation\x18\xc8! \x01(\v2(.confirmate.ontology.v1.LocalAttestationH\x00R\x10localAttestation\x12[\n" +
-	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestation\x12X\n" +
+	"\x12remote_attestation\x18\xc8j \x01(\v2).confirmate.ontology.v1.RemoteAttestationH\x00R\x11remoteAttestation\x12a\n" +
+	"\x14software_attestation\x18\xef\x12 \x01(\v2+.confirmate.ontology.v1.SoftwareAttestationH\x00R\x13softwareAttestation\x12X\n" +
 	"\x11automatic_updates\x18\x86N \x01(\v2(.confirmate.ontology.v1.AutomaticUpdatesH\x00R\x10automaticUpdates\x12\\\n" +
 	"\x12cryptographic_hash\x18\xf7\x8d\x01 \x01(\v2).confirmate.ontology.v1.CryptographicHashH\x00R\x11cryptographicHash\x12K\n" +
 	"\fimmutability\x18\xd8\x0f \x01(\v2$.confirmate.ontology.v1.ImmutabilityH\x00R\fimmutability\x12[\n" +
@@ -35215,8 +35406,9 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x10verified_commits\x18\xd0~ \x01(\v2'.confirmate.ontology.v1.VerifiedCommitsH\x00R\x0fverifiedCommits\x12^\n" +
 	"\x13explainable_results\x18\xc90 \x01(\v2*.confirmate.ontology.v1.ExplainableResultsH\x00R\x12explainableResults\x12U\n" +
 	"\x10robustness_score\x18\xbce \x01(\v2'.confirmate.ontology.v1.RobustnessScoreH\x00R\x0frobustnessScoreB\x06\n" +
-	"\x04type\"(\n" +
-	"\x10SecurityIncident:\x14\x82\xa6\x1d\x10SecurityIncident\"\xda\x01\n" +
+	"\x04type\"N\n" +
+	"\x10SecurityIncident\x12\x13\n" +
+	"\x04team\x18\x90\x1a \x03(\tR\x04team:%\x82\xa6\x1d\x10SecurityIncident\x82\xa6\x1d\rFunctionality\"\xda\x01\n" +
 	"\x10SecurityTraining\x127\n" +
 	"\x17annual_update_completed\x18\x8aU \x01(\bR\x15annualUpdateCompleted\x12L\n" +
 	"!successfully_completed_percentage\x18\xfa\x93\x01 \x01(\bR\x1fsuccessfullyCompletedPercentage:?\x82\xa6\x1d\x10SecurityTraining\x82\xa6\x1d\bTraining\x82\xa6\x1d\n" +
@@ -35256,7 +35448,9 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x12context_is_checked\x18\x98q \x01(\bR\x10contextIsChecked\x12\x19\n" +
 	"\aenabled\x18\xc9R \x01(\bR\aenabled\x12E\n" +
 	"\x1efailed_authentication_attempts\x18\x87O \x01(\x05R\x1cfailedAuthenticationAttempts\x12,\n" +
-	"\x11rotation_interval\x18\xe1G \x01(\x05R\x10rotationInterval:3\x82\xa6\x1d\fSingleSignOn\x82\xa6\x1d\fAuthenticity\x82\xa6\x1d\x0fSecurityFeature\"\x97\x04\n" +
+	"\x11rotation_interval\x18\xe1G \x01(\x05R\x10rotationInterval:3\x82\xa6\x1d\fSingleSignOn\x82\xa6\x1d\fAuthenticity\x82\xa6\x1d\x0fSecurityFeature\"x\n" +
+	"\x13SoftwareAttestation\x12\x19\n" +
+	"\aenabled\x18\x89( \x01(\bR\aenabled:F\x82\xa6\x1d\x13SoftwareAttestation\x82\xa6\x1d\vAttestation\x82\xa6\x1d\tIntegrity\x82\xa6\x1d\x0fSecurityFeature\"\x97\x04\n" +
 	"\x04Code\x12I\n" +
 	"\vapplication\x18\xfa\x90\x01 \x01(\v2#.confirmate.ontology.v1.ApplicationH\x00R\vapplication\x12<\n" +
 	"\alibrary\x18\xb9o \x01(\v2\x1f.confirmate.ontology.v1.LibraryH\x00R\alibrary\x12<\n" +
@@ -35266,7 +35460,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x06darwin\x18֑\x01 \x01(\v2\x1e.confirmate.ontology.v1.DarwinH\x00R\x06darwin\x126\n" +
 	"\x05posix\x18\xa7? \x01(\v2\x1d.confirmate.ontology.v1.POSIXH\x00R\x05posix\x126\n" +
 	"\x05win32\x18\xb62 \x01(\v2\x1d.confirmate.ontology.v1.Win32H\x00R\x05win32B\x06\n" +
-	"\x04type\"\xf4\x04\n" +
+	"\x04type\"\xd7\x05\n" +
 	"\x0eSourceCodeFile\x12@\n" +
 	"\rcreation_time\x18\xdc8 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\xe0t \x01(\tR\vdescription\x12\x17\n" +
@@ -35277,7 +35471,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fcode_module_ids\x18\x95n \x03(\tR\rcodeModuleIds\x122\n" +
 	"\x12code_repository_id\x18\xe6@ \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12P\n" +
 	"\x0ffunctionalities\x18\xc3\x19 \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12!\n" +
-	"\tparent_id\x18\x88` \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18\x88` \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xb6W \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:4\x82\xa6\x1d\x0eSourceCodeFile\x82\xa6\x1d\n" +
@@ -35490,7 +35685,7 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\vexploitable\x18\xde| \x01(\bR\vexploitable\x12\x11\n" +
 	"\x03url\x18\x95] \x01(\tR\x03url:\"\x82\xa6\x1d\rVulnerability\x82\xa6\x1d\rFunctionality\"\x94\x01\n" +
 	"\x16WebApplicationFirewall\x12\x19\n" +
-	"\aenabled\x18\x81F \x01(\bR\aenabled:_\x82\xa6\x1d\x16WebApplicationFirewall\x82\xa6\x1d\bFirewall\x82\xa6\x1d\x11AccessRestriction\x82\xa6\x1d\rAuthorization\x82\xa6\x1d\x0fSecurityFeature\"\xeb\x04\n" +
+	"\aenabled\x18\x81F \x01(\bR\aenabled:_\x82\xa6\x1d\x16WebApplicationFirewall\x82\xa6\x1d\bFirewall\x82\xa6\x1d\x11AccessRestriction\x82\xa6\x1d\rAuthorization\x82\xa6\x1d\x0fSecurityFeature\"\xce\x05\n" +
 	"\x05Win32\x12@\n" +
 	"\rcreation_time\x18\x96G \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\x12!\n" +
 	"\vdescription\x18\x94\x10 \x01(\tR\vdescription\x12\x17\n" +
@@ -35501,7 +35696,8 @@ const file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc = "" +
 	"\x0fcode_module_ids\x18\xb6\x06 \x03(\tR\rcodeModuleIds\x122\n" +
 	"\x12code_repository_id\x18\xda} \x01(\tH\x00R\x10codeRepositoryId\x88\x01\x01\x12Q\n" +
 	"\x0ffunctionalities\x18\x81\x92\x01 \x03(\v2%.confirmate.ontology.v1.FunctionalityR\x0ffunctionalities\x12!\n" +
-	"\tparent_id\x18\xa4N \x01(\tH\x01R\bparentId\x88\x01\x01\x1a9\n" +
+	"\tparent_id\x18\xa4N \x01(\tH\x01R\bparentId\x88\x01\x01\x12a\n" +
+	"\x15software_attestations\x18\xe3S \x03(\v2+.confirmate.ontology.v1.SoftwareAttestationR\x14softwareAttestations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:<\x82\xa6\x1d\x05Win32\x82\xa6\x1d\x1bOperatingSystemArchitecture\x82\xa6\x1d\x04Code\x82\xa6\x1d\bResourceB\x15\n" +
@@ -35545,7 +35741,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_rawDescGZIP() []b
 	return file_policies_security_metrics_ontology_v1_ontology_proto_rawDescData
 }
 
-var file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes = make([]protoimpl.MessageInfo, 355)
+var file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes = make([]protoimpl.MessageInfo, 356)
 var file_policies_security_metrics_ontology_v1_ontology_proto_goTypes = []any{
 	(*ABAC)(nil),                                     // 0: confirmate.ontology.v1.ABAC
 	(*AccessRestriction)(nil),                        // 1: confirmate.ontology.v1.AccessRestriction
@@ -35799,1370 +35995,1383 @@ var file_policies_security_metrics_ontology_v1_ontology_proto_goTypes = []any{
 	(*DocumentSignature)(nil),                        // 249: confirmate.ontology.v1.DocumentSignature
 	(*SignedCommits)(nil),                            // 250: confirmate.ontology.v1.SignedCommits
 	(*SingleSignOn)(nil),                             // 251: confirmate.ontology.v1.SingleSignOn
-	(*Code)(nil),                                     // 252: confirmate.ontology.v1.Code
-	(*SourceCodeFile)(nil),                           // 253: confirmate.ontology.v1.SourceCodeFile
-	(*Storage)(nil),                                  // 254: confirmate.ontology.v1.Storage
-	(*StorageService)(nil),                           // 255: confirmate.ontology.v1.StorageService
-	(*SymmetricCipher)(nil),                          // 256: confirmate.ontology.v1.SymmetricCipher
-	(*Time)(nil),                                     // 257: confirmate.ontology.v1.Time
-	(*Token)(nil),                                    // 258: confirmate.ontology.v1.Token
-	(*Training)(nil),                                 // 259: confirmate.ontology.v1.Training
-	(*TransportEncryption)(nil),                      // 260: confirmate.ontology.v1.TransportEncryption
-	(*UnlockEncryptedDisk)(nil),                      // 261: confirmate.ontology.v1.UnlockEncryptedDisk
-	(*UsageStatistics)(nil),                          // 262: confirmate.ontology.v1.UsageStatistics
-	(*UserInformationAndIntructionDocument)(nil),     // 263: confirmate.ontology.v1.UserInformationAndIntructionDocument
-	(*VMImage)(nil),                                  // 264: confirmate.ontology.v1.VMImage
-	(*ValidateJwt)(nil),                              // 265: confirmate.ontology.v1.ValidateJwt
-	(*Value)(nil),                                    // 266: confirmate.ontology.v1.Value
-	(*VerifiedCommits)(nil),                          // 267: confirmate.ontology.v1.VerifiedCommits
-	(*VirtualMachine)(nil),                           // 268: confirmate.ontology.v1.VirtualMachine
-	(*VirtualNetwork)(nil),                           // 269: confirmate.ontology.v1.VirtualNetwork
-	(*VirtualSubNetwork)(nil),                        // 270: confirmate.ontology.v1.VirtualSubNetwork
-	(*Vulnerability)(nil),                            // 271: confirmate.ontology.v1.Vulnerability
-	(*WebApplicationFirewall)(nil),                   // 272: confirmate.ontology.v1.WebApplicationFirewall
-	(*Win32)(nil),                                    // 273: confirmate.ontology.v1.Win32
-	(*Workflow)(nil),                                 // 274: confirmate.ontology.v1.Workflow
-	(*ZoneRedundancy)(nil),                           // 275: confirmate.ontology.v1.ZoneRedundancy
-	nil,                                              // 276: confirmate.ontology.v1.Account.LabelsEntry
-	nil,                                              // 277: confirmate.ontology.v1.Agnostic.LabelsEntry
-	nil,                                              // 278: confirmate.ontology.v1.AndRule.LabelsEntry
-	nil,                                              // 279: confirmate.ontology.v1.Application.LabelsEntry
-	nil,                                              // 280: confirmate.ontology.v1.BlockStorage.LabelsEntry
-	nil,                                              // 281: confirmate.ontology.v1.Certificate.LabelsEntry
-	nil,                                              // 282: confirmate.ontology.v1.CodeRepository.LabelsEntry
-	nil,                                              // 283: confirmate.ontology.v1.Configuration.LabelsEntry
-	nil,                                              // 284: confirmate.ontology.v1.ConfigurationDocument.LabelsEntry
-	nil,                                              // 285: confirmate.ontology.v1.ConfigurationGroup.LabelsEntry
-	nil,                                              // 286: confirmate.ontology.v1.ConfigurationGroupSource.LabelsEntry
-	nil,                                              // 287: confirmate.ontology.v1.ConfigurationOption.LabelsEntry
-	nil,                                              // 288: confirmate.ontology.v1.ConfigurationOptionSource.LabelsEntry
-	nil,                                              // 289: confirmate.ontology.v1.ConfigurationSource.LabelsEntry
-	nil,                                              // 290: confirmate.ontology.v1.Container.LabelsEntry
-	nil,                                              // 291: confirmate.ontology.v1.ContainerImage.LabelsEntry
-	nil,                                              // 292: confirmate.ontology.v1.ContainerOrchestration.LabelsEntry
-	nil,                                              // 293: confirmate.ontology.v1.ContainerRegistry.LabelsEntry
-	nil,                                              // 294: confirmate.ontology.v1.Context.LabelsEntry
-	nil,                                              // 295: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.LabelsEntry
-	nil,                                              // 296: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.LabelsEntry
-	nil,                                              // 297: confirmate.ontology.v1.Darwin.LabelsEntry
-	nil,                                              // 298: confirmate.ontology.v1.DatabaseStorage.LabelsEntry
-	nil,                                              // 299: confirmate.ontology.v1.DeviceProvisioningService.LabelsEntry
-	nil,                                              // 300: confirmate.ontology.v1.DistributionOfUpdatesDocument.LabelsEntry
-	nil,                                              // 301: confirmate.ontology.v1.DocumentDatabaseService.LabelsEntry
-	nil,                                              // 302: confirmate.ontology.v1.EUDeclarationOfConformity.LabelsEntry
-	nil,                                              // 303: confirmate.ontology.v1.File.LabelsEntry
-	nil,                                              // 304: confirmate.ontology.v1.FileHandle.LabelsEntry
-	nil,                                              // 305: confirmate.ontology.v1.FileStorage.LabelsEntry
-	nil,                                              // 306: confirmate.ontology.v1.FileStorageService.LabelsEntry
-	nil,                                              // 307: confirmate.ontology.v1.Function.LabelsEntry
-	nil,                                              // 308: confirmate.ontology.v1.FunctionService.LabelsEntry
-	nil,                                              // 309: confirmate.ontology.v1.GenericNetworkService.LabelsEntry
-	nil,                                              // 310: confirmate.ontology.v1.Identity.LabelsEntry
-	nil,                                              // 311: confirmate.ontology.v1.Job.LabelsEntry
-	nil,                                              // 312: confirmate.ontology.v1.Key.LabelsEntry
-	nil,                                              // 313: confirmate.ontology.v1.KeyValueDatabaseService.LabelsEntry
-	nil,                                              // 314: confirmate.ontology.v1.KeyVault.LabelsEntry
-	nil,                                              // 315: confirmate.ontology.v1.Library.LabelsEntry
-	nil,                                              // 316: confirmate.ontology.v1.LoadBalancer.LabelsEntry
-	nil,                                              // 317: confirmate.ontology.v1.LogDocument.LabelsEntry
-	nil,                                              // 318: confirmate.ontology.v1.LoggingService.LabelsEntry
-	nil,                                              // 319: confirmate.ontology.v1.MachineLearningDataset.LabelsEntry
-	nil,                                              // 320: confirmate.ontology.v1.MachineLearningModel.LabelsEntry
-	nil,                                              // 321: confirmate.ontology.v1.MachineLearningService.LabelsEntry
-	nil,                                              // 322: confirmate.ontology.v1.Memory.LabelsEntry
-	nil,                                              // 323: confirmate.ontology.v1.MessagingHub.LabelsEntry
-	nil,                                              // 324: confirmate.ontology.v1.MultiModalDatabaseService.LabelsEntry
-	nil,                                              // 325: confirmate.ontology.v1.NetworkInterface.LabelsEntry
-	nil,                                              // 326: confirmate.ontology.v1.NetworkSecurityGroup.LabelsEntry
-	nil,                                              // 327: confirmate.ontology.v1.ObjectStorage.LabelsEntry
-	nil,                                              // 328: confirmate.ontology.v1.ObjectStorageService.LabelsEntry
-	nil,                                              // 329: confirmate.ontology.v1.POSIX.LabelsEntry
-	nil,                                              // 330: confirmate.ontology.v1.Package.LabelsEntry
-	nil,                                              // 331: confirmate.ontology.v1.PasswordPolicy.LabelsEntry
-	nil,                                              // 332: confirmate.ontology.v1.PolicyDocument.LabelsEntry
-	nil,                                              // 333: confirmate.ontology.v1.Product.LabelsEntry
-	nil,                                              // 334: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.LabelsEntry
-	nil,                                              // 335: confirmate.ontology.v1.QPU.LabelsEntry
-	nil,                                              // 336: confirmate.ontology.v1.RelationalDatabaseService.LabelsEntry
-	nil,                                              // 337: confirmate.ontology.v1.ReportDocument.LabelsEntry
-	nil,                                              // 338: confirmate.ontology.v1.ResourceGroup.LabelsEntry
-	nil,                                              // 339: confirmate.ontology.v1.RoleAssignment.LabelsEntry
-	nil,                                              // 340: confirmate.ontology.v1.SBOMDocument.LabelsEntry
-	nil,                                              // 341: confirmate.ontology.v1.Secret.LabelsEntry
-	nil,                                              // 342: confirmate.ontology.v1.SecurityAdvisoryDocument.LabelsEntry
-	nil,                                              // 343: confirmate.ontology.v1.SecurityAdvisoryService.LabelsEntry
-	nil,                                              // 344: confirmate.ontology.v1.ServiceMetadataDocument.LabelsEntry
-	nil,                                              // 345: confirmate.ontology.v1.SourceCodeFile.LabelsEntry
-	nil,                                              // 346: confirmate.ontology.v1.Token.LabelsEntry
-	nil,                                              // 347: confirmate.ontology.v1.UserInformationAndIntructionDocument.LabelsEntry
-	nil,                                              // 348: confirmate.ontology.v1.VMImage.LabelsEntry
-	nil,                                              // 349: confirmate.ontology.v1.Value.LabelsEntry
-	nil,                                              // 350: confirmate.ontology.v1.VirtualMachine.LabelsEntry
-	nil,                                              // 351: confirmate.ontology.v1.VirtualNetwork.LabelsEntry
-	nil,                                              // 352: confirmate.ontology.v1.VirtualSubNetwork.LabelsEntry
-	nil,                                              // 353: confirmate.ontology.v1.Win32.LabelsEntry
-	nil,                                              // 354: confirmate.ontology.v1.Workflow.LabelsEntry
-	(*timestamppb.Timestamp)(nil),                    // 355: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),                      // 356: google.protobuf.Duration
-	(*descriptorpb.MessageOptions)(nil),              // 357: google.protobuf.MessageOptions
+	(*SoftwareAttestation)(nil),                      // 252: confirmate.ontology.v1.SoftwareAttestation
+	(*Code)(nil),                                     // 253: confirmate.ontology.v1.Code
+	(*SourceCodeFile)(nil),                           // 254: confirmate.ontology.v1.SourceCodeFile
+	(*Storage)(nil),                                  // 255: confirmate.ontology.v1.Storage
+	(*StorageService)(nil),                           // 256: confirmate.ontology.v1.StorageService
+	(*SymmetricCipher)(nil),                          // 257: confirmate.ontology.v1.SymmetricCipher
+	(*Time)(nil),                                     // 258: confirmate.ontology.v1.Time
+	(*Token)(nil),                                    // 259: confirmate.ontology.v1.Token
+	(*Training)(nil),                                 // 260: confirmate.ontology.v1.Training
+	(*TransportEncryption)(nil),                      // 261: confirmate.ontology.v1.TransportEncryption
+	(*UnlockEncryptedDisk)(nil),                      // 262: confirmate.ontology.v1.UnlockEncryptedDisk
+	(*UsageStatistics)(nil),                          // 263: confirmate.ontology.v1.UsageStatistics
+	(*UserInformationAndIntructionDocument)(nil),     // 264: confirmate.ontology.v1.UserInformationAndIntructionDocument
+	(*VMImage)(nil),                                  // 265: confirmate.ontology.v1.VMImage
+	(*ValidateJwt)(nil),                              // 266: confirmate.ontology.v1.ValidateJwt
+	(*Value)(nil),                                    // 267: confirmate.ontology.v1.Value
+	(*VerifiedCommits)(nil),                          // 268: confirmate.ontology.v1.VerifiedCommits
+	(*VirtualMachine)(nil),                           // 269: confirmate.ontology.v1.VirtualMachine
+	(*VirtualNetwork)(nil),                           // 270: confirmate.ontology.v1.VirtualNetwork
+	(*VirtualSubNetwork)(nil),                        // 271: confirmate.ontology.v1.VirtualSubNetwork
+	(*Vulnerability)(nil),                            // 272: confirmate.ontology.v1.Vulnerability
+	(*WebApplicationFirewall)(nil),                   // 273: confirmate.ontology.v1.WebApplicationFirewall
+	(*Win32)(nil),                                    // 274: confirmate.ontology.v1.Win32
+	(*Workflow)(nil),                                 // 275: confirmate.ontology.v1.Workflow
+	(*ZoneRedundancy)(nil),                           // 276: confirmate.ontology.v1.ZoneRedundancy
+	nil,                                              // 277: confirmate.ontology.v1.Account.LabelsEntry
+	nil,                                              // 278: confirmate.ontology.v1.Agnostic.LabelsEntry
+	nil,                                              // 279: confirmate.ontology.v1.AndRule.LabelsEntry
+	nil,                                              // 280: confirmate.ontology.v1.Application.LabelsEntry
+	nil,                                              // 281: confirmate.ontology.v1.BlockStorage.LabelsEntry
+	nil,                                              // 282: confirmate.ontology.v1.Certificate.LabelsEntry
+	nil,                                              // 283: confirmate.ontology.v1.CodeRepository.LabelsEntry
+	nil,                                              // 284: confirmate.ontology.v1.Configuration.LabelsEntry
+	nil,                                              // 285: confirmate.ontology.v1.ConfigurationDocument.LabelsEntry
+	nil,                                              // 286: confirmate.ontology.v1.ConfigurationGroup.LabelsEntry
+	nil,                                              // 287: confirmate.ontology.v1.ConfigurationGroupSource.LabelsEntry
+	nil,                                              // 288: confirmate.ontology.v1.ConfigurationOption.LabelsEntry
+	nil,                                              // 289: confirmate.ontology.v1.ConfigurationOptionSource.LabelsEntry
+	nil,                                              // 290: confirmate.ontology.v1.ConfigurationSource.LabelsEntry
+	nil,                                              // 291: confirmate.ontology.v1.Container.LabelsEntry
+	nil,                                              // 292: confirmate.ontology.v1.ContainerImage.LabelsEntry
+	nil,                                              // 293: confirmate.ontology.v1.ContainerOrchestration.LabelsEntry
+	nil,                                              // 294: confirmate.ontology.v1.ContainerRegistry.LabelsEntry
+	nil,                                              // 295: confirmate.ontology.v1.Context.LabelsEntry
+	nil,                                              // 296: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.LabelsEntry
+	nil,                                              // 297: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.LabelsEntry
+	nil,                                              // 298: confirmate.ontology.v1.Darwin.LabelsEntry
+	nil,                                              // 299: confirmate.ontology.v1.DatabaseStorage.LabelsEntry
+	nil,                                              // 300: confirmate.ontology.v1.DeviceProvisioningService.LabelsEntry
+	nil,                                              // 301: confirmate.ontology.v1.DistributionOfUpdatesDocument.LabelsEntry
+	nil,                                              // 302: confirmate.ontology.v1.DocumentDatabaseService.LabelsEntry
+	nil,                                              // 303: confirmate.ontology.v1.EUDeclarationOfConformity.LabelsEntry
+	nil,                                              // 304: confirmate.ontology.v1.File.LabelsEntry
+	nil,                                              // 305: confirmate.ontology.v1.FileHandle.LabelsEntry
+	nil,                                              // 306: confirmate.ontology.v1.FileStorage.LabelsEntry
+	nil,                                              // 307: confirmate.ontology.v1.FileStorageService.LabelsEntry
+	nil,                                              // 308: confirmate.ontology.v1.Function.LabelsEntry
+	nil,                                              // 309: confirmate.ontology.v1.FunctionService.LabelsEntry
+	nil,                                              // 310: confirmate.ontology.v1.GenericNetworkService.LabelsEntry
+	nil,                                              // 311: confirmate.ontology.v1.Identity.LabelsEntry
+	nil,                                              // 312: confirmate.ontology.v1.Job.LabelsEntry
+	nil,                                              // 313: confirmate.ontology.v1.Key.LabelsEntry
+	nil,                                              // 314: confirmate.ontology.v1.KeyValueDatabaseService.LabelsEntry
+	nil,                                              // 315: confirmate.ontology.v1.KeyVault.LabelsEntry
+	nil,                                              // 316: confirmate.ontology.v1.Library.LabelsEntry
+	nil,                                              // 317: confirmate.ontology.v1.LoadBalancer.LabelsEntry
+	nil,                                              // 318: confirmate.ontology.v1.LogDocument.LabelsEntry
+	nil,                                              // 319: confirmate.ontology.v1.LoggingService.LabelsEntry
+	nil,                                              // 320: confirmate.ontology.v1.MachineLearningDataset.LabelsEntry
+	nil,                                              // 321: confirmate.ontology.v1.MachineLearningModel.LabelsEntry
+	nil,                                              // 322: confirmate.ontology.v1.MachineLearningService.LabelsEntry
+	nil,                                              // 323: confirmate.ontology.v1.Memory.LabelsEntry
+	nil,                                              // 324: confirmate.ontology.v1.MessagingHub.LabelsEntry
+	nil,                                              // 325: confirmate.ontology.v1.MultiModalDatabaseService.LabelsEntry
+	nil,                                              // 326: confirmate.ontology.v1.NetworkInterface.LabelsEntry
+	nil,                                              // 327: confirmate.ontology.v1.NetworkSecurityGroup.LabelsEntry
+	nil,                                              // 328: confirmate.ontology.v1.ObjectStorage.LabelsEntry
+	nil,                                              // 329: confirmate.ontology.v1.ObjectStorageService.LabelsEntry
+	nil,                                              // 330: confirmate.ontology.v1.POSIX.LabelsEntry
+	nil,                                              // 331: confirmate.ontology.v1.Package.LabelsEntry
+	nil,                                              // 332: confirmate.ontology.v1.PasswordPolicy.LabelsEntry
+	nil,                                              // 333: confirmate.ontology.v1.PolicyDocument.LabelsEntry
+	nil,                                              // 334: confirmate.ontology.v1.Product.LabelsEntry
+	nil,                                              // 335: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.LabelsEntry
+	nil,                                              // 336: confirmate.ontology.v1.QPU.LabelsEntry
+	nil,                                              // 337: confirmate.ontology.v1.RelationalDatabaseService.LabelsEntry
+	nil,                                              // 338: confirmate.ontology.v1.ReportDocument.LabelsEntry
+	nil,                                              // 339: confirmate.ontology.v1.ResourceGroup.LabelsEntry
+	nil,                                              // 340: confirmate.ontology.v1.RoleAssignment.LabelsEntry
+	nil,                                              // 341: confirmate.ontology.v1.SBOMDocument.LabelsEntry
+	nil,                                              // 342: confirmate.ontology.v1.Secret.LabelsEntry
+	nil,                                              // 343: confirmate.ontology.v1.SecurityAdvisoryDocument.LabelsEntry
+	nil,                                              // 344: confirmate.ontology.v1.SecurityAdvisoryService.LabelsEntry
+	nil,                                              // 345: confirmate.ontology.v1.ServiceMetadataDocument.LabelsEntry
+	nil,                                              // 346: confirmate.ontology.v1.SourceCodeFile.LabelsEntry
+	nil,                                              // 347: confirmate.ontology.v1.Token.LabelsEntry
+	nil,                                              // 348: confirmate.ontology.v1.UserInformationAndIntructionDocument.LabelsEntry
+	nil,                                              // 349: confirmate.ontology.v1.VMImage.LabelsEntry
+	nil,                                              // 350: confirmate.ontology.v1.Value.LabelsEntry
+	nil,                                              // 351: confirmate.ontology.v1.VirtualMachine.LabelsEntry
+	nil,                                              // 352: confirmate.ontology.v1.VirtualNetwork.LabelsEntry
+	nil,                                              // 353: confirmate.ontology.v1.VirtualSubNetwork.LabelsEntry
+	nil,                                              // 354: confirmate.ontology.v1.Win32.LabelsEntry
+	nil,                                              // 355: confirmate.ontology.v1.Workflow.LabelsEntry
+	(*timestamppb.Timestamp)(nil),                    // 356: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),                      // 357: google.protobuf.Duration
+	(*descriptorpb.MessageOptions)(nil),              // 358: google.protobuf.MessageOptions
 }
 var file_policies_security_metrics_ontology_v1_ontology_proto_depIdxs = []int32{
 	147,  // 0: confirmate.ontology.v1.AccessRestriction.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
-	272,  // 1: confirmate.ontology.v1.AccessRestriction.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
+	273,  // 1: confirmate.ontology.v1.AccessRestriction.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
 	216,  // 2: confirmate.ontology.v1.AccessRestriction.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
-	355,  // 3: confirmate.ontology.v1.Account.creation_time:type_name -> google.protobuf.Timestamp
-	276,  // 4: confirmate.ontology.v1.Account.labels:type_name -> confirmate.ontology.v1.Account.LabelsEntry
+	356,  // 3: confirmate.ontology.v1.Account.creation_time:type_name -> google.protobuf.Timestamp
+	277,  // 4: confirmate.ontology.v1.Account.labels:type_name -> confirmate.ontology.v1.Account.LabelsEntry
 	10,   // 5: confirmate.ontology.v1.Account.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
 	31,   // 6: confirmate.ontology.v1.Account.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
 	110,  // 7: confirmate.ontology.v1.Account.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
 	165,  // 8: confirmate.ontology.v1.Account.loggings:type_name -> confirmate.ontology.v1.Logging
 	172,  // 9: confirmate.ontology.v1.Account.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
 	219,  // 10: confirmate.ontology.v1.Account.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 11: confirmate.ontology.v1.Account.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	356,  // 12: confirmate.ontology.v1.ActivityLogging.retention_period:type_name -> google.protobuf.Duration
-	355,  // 13: confirmate.ontology.v1.Agnostic.creation_time:type_name -> google.protobuf.Timestamp
-	277,  // 14: confirmate.ontology.v1.Agnostic.labels:type_name -> confirmate.ontology.v1.Agnostic.LabelsEntry
+	263,  // 11: confirmate.ontology.v1.Account.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	357,  // 12: confirmate.ontology.v1.ActivityLogging.retention_period:type_name -> google.protobuf.Duration
+	356,  // 13: confirmate.ontology.v1.Agnostic.creation_time:type_name -> google.protobuf.Timestamp
+	278,  // 14: confirmate.ontology.v1.Agnostic.labels:type_name -> confirmate.ontology.v1.Agnostic.LabelsEntry
 	107,  // 15: confirmate.ontology.v1.Agnostic.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	39,   // 16: confirmate.ontology.v1.Allocate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 17: confirmate.ontology.v1.AndRule.creation_time:type_name -> google.protobuf.Timestamp
-	278,  // 18: confirmate.ontology.v1.AndRule.labels:type_name -> confirmate.ontology.v1.AndRule.LabelsEntry
-	72,   // 19: confirmate.ontology.v1.AndRule.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	9,    // 20: confirmate.ontology.v1.AnomalyDetection.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
-	355,  // 21: confirmate.ontology.v1.Application.creation_time:type_name -> google.protobuf.Timestamp
-	279,  // 22: confirmate.ontology.v1.Application.labels:type_name -> confirmate.ontology.v1.Application.LabelsEntry
-	20,   // 23: confirmate.ontology.v1.Application.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
-	107,  // 24: confirmate.ontology.v1.Application.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	356,  // 25: confirmate.ontology.v1.ApplicationLogging.retention_period:type_name -> google.protobuf.Duration
-	198,  // 26: confirmate.ontology.v1.AsymmetricCipher.padding:type_name -> confirmate.ontology.v1.Padding
-	66,   // 27: confirmate.ontology.v1.AtRestEncryption.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
-	81,   // 28: confirmate.ontology.v1.AtRestEncryption.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	173,  // 29: confirmate.ontology.v1.AtRestEncryption.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
-	155,  // 30: confirmate.ontology.v1.Attestation.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
-	225,  // 31: confirmate.ontology.v1.Attestation.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	7,    // 32: confirmate.ontology.v1.Auditing.anomaly_detection:type_name -> confirmate.ontology.v1.AnomalyDetection
-	10,   // 33: confirmate.ontology.v1.Auditing.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
-	41,   // 34: confirmate.ontology.v1.Auditing.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
-	3,    // 35: confirmate.ontology.v1.Auditing.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	9,    // 36: confirmate.ontology.v1.Auditing.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
-	26,   // 37: confirmate.ontology.v1.Auditing.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
-	188,  // 38: confirmate.ontology.v1.Auditing.os_logging:type_name -> confirmate.ontology.v1.OSLogging
-	232,  // 39: confirmate.ontology.v1.Auditing.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	172,  // 40: confirmate.ontology.v1.Auditing.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	262,  // 41: confirmate.ontology.v1.Auditing.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	17,   // 42: confirmate.ontology.v1.Authenticate.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	39,   // 43: confirmate.ontology.v1.Authenticate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	15,   // 44: confirmate.ontology.v1.AuthenticationOperation.authenticate:type_name -> confirmate.ontology.v1.Authenticate
-	19,   // 45: confirmate.ontology.v1.AuthenticationOperation.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
-	139,  // 46: confirmate.ontology.v1.AuthenticationOperation.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
-	265,  // 47: confirmate.ontology.v1.AuthenticationOperation.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
-	30,   // 48: confirmate.ontology.v1.Authenticity.certificate_based_authentication:type_name -> confirmate.ontology.v1.CertificateBasedAuthentication
-	141,  // 49: confirmate.ontology.v1.Authenticity.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
-	180,  // 50: confirmate.ontology.v1.Authenticity.multi_factor_authentiation:type_name -> confirmate.ontology.v1.MultiFactorAuthentiation
-	187,  // 51: confirmate.ontology.v1.Authenticity.no_authentication:type_name -> confirmate.ontology.v1.NoAuthentication
-	189,  // 52: confirmate.ontology.v1.Authenticity.otp_based_authentication:type_name -> confirmate.ontology.v1.OTPBasedAuthentication
-	199,  // 53: confirmate.ontology.v1.Authenticity.password_based_authentication:type_name -> confirmate.ontology.v1.PasswordBasedAuthentication
-	251,  // 54: confirmate.ontology.v1.Authenticity.single_sign_on:type_name -> confirmate.ontology.v1.SingleSignOn
-	0,    // 55: confirmate.ontology.v1.Authorization.abac:type_name -> confirmate.ontology.v1.ABAC
-	147,  // 56: confirmate.ontology.v1.Authorization.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
-	272,  // 57: confirmate.ontology.v1.Authorization.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
-	216,  // 58: confirmate.ontology.v1.Authorization.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
-	215,  // 59: confirmate.ontology.v1.Authorization.rbac:type_name -> confirmate.ontology.v1.RBAC
-	17,   // 60: confirmate.ontology.v1.AuthorizeJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	39,   // 61: confirmate.ontology.v1.AuthorizeJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	356,  // 62: confirmate.ontology.v1.AutomaticUpdates.interval:type_name -> google.protobuf.Duration
-	23,   // 63: confirmate.ontology.v1.Availability.backup:type_name -> confirmate.ontology.v1.Backup
-	68,   // 64: confirmate.ontology.v1.Availability.d_do_s_protection:type_name -> confirmate.ontology.v1.DDoSProtection
-	110,  // 65: confirmate.ontology.v1.Availability.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	111,  // 66: confirmate.ontology.v1.Availability.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
-	158,  // 67: confirmate.ontology.v1.Availability.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
-	275,  // 68: confirmate.ontology.v1.Availability.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
-	356,  // 69: confirmate.ontology.v1.Backup.interval:type_name -> google.protobuf.Duration
-	356,  // 70: confirmate.ontology.v1.Backup.retention_period:type_name -> google.protobuf.Duration
-	260,  // 71: confirmate.ontology.v1.Backup.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	355,  // 72: confirmate.ontology.v1.BlockStorage.creation_time:type_name -> google.protobuf.Timestamp
-	280,  // 73: confirmate.ontology.v1.BlockStorage.labels:type_name -> confirmate.ontology.v1.BlockStorage.LabelsEntry
-	3,    // 74: confirmate.ontology.v1.BlockStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	12,   // 75: confirmate.ontology.v1.BlockStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
-	23,   // 76: confirmate.ontology.v1.BlockStorage.backups:type_name -> confirmate.ontology.v1.Backup
-	31,   // 77: confirmate.ontology.v1.BlockStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 78: confirmate.ontology.v1.BlockStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	132,  // 79: confirmate.ontology.v1.BlockStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
-	165,  // 80: confirmate.ontology.v1.BlockStorage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 81: confirmate.ontology.v1.BlockStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 82: confirmate.ontology.v1.BlockStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	232,  // 83: confirmate.ontology.v1.BlockStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 84: confirmate.ontology.v1.BlockStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	39,   // 85: confirmate.ontology.v1.BlockStorageOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	356,  // 86: confirmate.ontology.v1.BootLogging.retention_period:type_name -> google.protobuf.Duration
-	140,  // 87: confirmate.ontology.v1.CICDService.job:type_name -> confirmate.ontology.v1.Job
-	274,  // 88: confirmate.ontology.v1.CICDService.workflow:type_name -> confirmate.ontology.v1.Workflow
-	355,  // 89: confirmate.ontology.v1.Certificate.creation_time:type_name -> google.protobuf.Timestamp
-	355,  // 90: confirmate.ontology.v1.Certificate.expiration_date:type_name -> google.protobuf.Timestamp
-	281,  // 91: confirmate.ontology.v1.Certificate.labels:type_name -> confirmate.ontology.v1.Certificate.LabelsEntry
-	355,  // 92: confirmate.ontology.v1.Certificate.not_before_date:type_name -> google.protobuf.Timestamp
-	31,   // 93: confirmate.ontology.v1.Certificate.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 94: confirmate.ontology.v1.Certificate.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	37,   // 95: confirmate.ontology.v1.Certificate.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
-	165,  // 96: confirmate.ontology.v1.Certificate.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 97: confirmate.ontology.v1.Certificate.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 98: confirmate.ontology.v1.Certificate.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 99: confirmate.ontology.v1.Certificate.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	229,  // 100: confirmate.ontology.v1.ChangeAndConfigurationManagement.request_for_change:type_name -> confirmate.ontology.v1.RequestForChange
-	39,   // 101: confirmate.ontology.v1.CheckAccess.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	207,  // 102: confirmate.ontology.v1.CheckAccess.protected_asset:type_name -> confirmate.ontology.v1.ProtectedAsset
-	11,   // 103: confirmate.ontology.v1.Cipher.asymmetric_cipher:type_name -> confirmate.ontology.v1.AsymmetricCipher
-	128,  // 104: confirmate.ontology.v1.Cipher.hybrid_cipher:type_name -> confirmate.ontology.v1.HybridCipher
-	256,  // 105: confirmate.ontology.v1.Cipher.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
-	79,   // 106: confirmate.ontology.v1.CipherOperation.decryption:type_name -> confirmate.ontology.v1.Decryption
-	33,   // 107: confirmate.ontology.v1.CipherSuite.ciphers:type_name -> confirmate.ontology.v1.Cipher
-	2,    // 108: confirmate.ontology.v1.Infrastructure.account:type_name -> confirmate.ontology.v1.Account
-	140,  // 109: confirmate.ontology.v1.Infrastructure.job:type_name -> confirmate.ontology.v1.Job
-	274,  // 110: confirmate.ontology.v1.Infrastructure.workflow:type_name -> confirmate.ontology.v1.Workflow
-	40,   // 111: confirmate.ontology.v1.Infrastructure.code_repository:type_name -> confirmate.ontology.v1.CodeRepository
-	54,   // 112: confirmate.ontology.v1.Infrastructure.container:type_name -> confirmate.ontology.v1.Container
-	105,  // 113: confirmate.ontology.v1.Infrastructure.function:type_name -> confirmate.ontology.v1.Function
-	214,  // 114: confirmate.ontology.v1.Infrastructure.qpu:type_name -> confirmate.ontology.v1.QPU
-	268,  // 115: confirmate.ontology.v1.Infrastructure.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
-	56,   // 116: confirmate.ontology.v1.Infrastructure.container_orchestration:type_name -> confirmate.ontology.v1.ContainerOrchestration
-	57,   // 117: confirmate.ontology.v1.Infrastructure.container_registry:type_name -> confirmate.ontology.v1.ContainerRegistry
-	29,   // 118: confirmate.ontology.v1.Infrastructure.certificate:type_name -> confirmate.ontology.v1.Certificate
-	143,  // 119: confirmate.ontology.v1.Infrastructure.key:type_name -> confirmate.ontology.v1.Key
-	239,  // 120: confirmate.ontology.v1.Infrastructure.secret:type_name -> confirmate.ontology.v1.Secret
-	130,  // 121: confirmate.ontology.v1.Infrastructure.identity:type_name -> confirmate.ontology.v1.Identity
-	235,  // 122: confirmate.ontology.v1.Infrastructure.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
-	55,   // 123: confirmate.ontology.v1.Infrastructure.container_image:type_name -> confirmate.ontology.v1.ContainerImage
-	264,  // 124: confirmate.ontology.v1.Infrastructure.vm_image:type_name -> confirmate.ontology.v1.VMImage
-	80,   // 125: confirmate.ontology.v1.Infrastructure.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
-	177,  // 126: confirmate.ontology.v1.Infrastructure.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
-	146,  // 127: confirmate.ontology.v1.Infrastructure.key_vault:type_name -> confirmate.ontology.v1.KeyVault
-	183,  // 128: confirmate.ontology.v1.Infrastructure.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
-	184,  // 129: confirmate.ontology.v1.Infrastructure.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
-	106,  // 130: confirmate.ontology.v1.Infrastructure.function_service:type_name -> confirmate.ontology.v1.FunctionService
-	109,  // 131: confirmate.ontology.v1.Infrastructure.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
-	151,  // 132: confirmate.ontology.v1.Infrastructure.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
-	166,  // 133: confirmate.ontology.v1.Infrastructure.logging_service:type_name -> confirmate.ontology.v1.LoggingService
-	170,  // 134: confirmate.ontology.v1.Infrastructure.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
-	243,  // 135: confirmate.ontology.v1.Infrastructure.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
-	85,   // 136: confirmate.ontology.v1.Infrastructure.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 137: confirmate.ontology.v1.Infrastructure.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 138: confirmate.ontology.v1.Infrastructure.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 139: confirmate.ontology.v1.Infrastructure.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	102,  // 140: confirmate.ontology.v1.Infrastructure.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
-	192,  // 141: confirmate.ontology.v1.Infrastructure.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
-	269,  // 142: confirmate.ontology.v1.Infrastructure.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
-	270,  // 143: confirmate.ontology.v1.Infrastructure.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
-	200,  // 144: confirmate.ontology.v1.Infrastructure.password_policy:type_name -> confirmate.ontology.v1.PasswordPolicy
-	231,  // 145: confirmate.ontology.v1.Infrastructure.resource_group:type_name -> confirmate.ontology.v1.ResourceGroup
-	24,   // 146: confirmate.ontology.v1.Infrastructure.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
-	77,   // 147: confirmate.ontology.v1.Infrastructure.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
-	101,  // 148: confirmate.ontology.v1.Infrastructure.file_storage:type_name -> confirmate.ontology.v1.FileStorage
-	190,  // 149: confirmate.ontology.v1.Infrastructure.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
-	355,  // 150: confirmate.ontology.v1.CodeRepository.creation_time:type_name -> google.protobuf.Timestamp
-	282,  // 151: confirmate.ontology.v1.CodeRepository.labels:type_name -> confirmate.ontology.v1.CodeRepository.LabelsEntry
-	31,   // 152: confirmate.ontology.v1.CodeRepository.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	41,   // 153: confirmate.ontology.v1.CodeRepository.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
-	110,  // 154: confirmate.ontology.v1.CodeRepository.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 155: confirmate.ontology.v1.CodeRepository.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 156: confirmate.ontology.v1.CodeRepository.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 157: confirmate.ontology.v1.CodeRepository.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	250,  // 158: confirmate.ontology.v1.CodeRepository.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
-	262,  // 159: confirmate.ontology.v1.CodeRepository.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	267,  // 160: confirmate.ontology.v1.CodeRepository.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
-	8,    // 161: confirmate.ontology.v1.Component.application:type_name -> confirmate.ontology.v1.Application
-	149,  // 162: confirmate.ontology.v1.Component.library:type_name -> confirmate.ontology.v1.Library
-	54,   // 163: confirmate.ontology.v1.Compute.container:type_name -> confirmate.ontology.v1.Container
-	105,  // 164: confirmate.ontology.v1.Compute.function:type_name -> confirmate.ontology.v1.Function
-	214,  // 165: confirmate.ontology.v1.Compute.qpu:type_name -> confirmate.ontology.v1.QPU
-	268,  // 166: confirmate.ontology.v1.Compute.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
-	66,   // 167: confirmate.ontology.v1.Confidentiality.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
-	81,   // 168: confirmate.ontology.v1.Confidentiality.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	173,  // 169: confirmate.ontology.v1.Confidentiality.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
-	260,  // 170: confirmate.ontology.v1.Confidentiality.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	90,   // 171: confirmate.ontology.v1.Confidentiality.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	355,  // 172: confirmate.ontology.v1.Configuration.creation_time:type_name -> google.protobuf.Timestamp
-	283,  // 173: confirmate.ontology.v1.Configuration.labels:type_name -> confirmate.ontology.v1.Configuration.LabelsEntry
-	72,   // 174: confirmate.ontology.v1.Configuration.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 175: confirmate.ontology.v1.ConfigurationDocument.creation_time:type_name -> google.protobuf.Timestamp
-	284,  // 176: confirmate.ontology.v1.ConfigurationDocument.labels:type_name -> confirmate.ontology.v1.ConfigurationDocument.LabelsEntry
-	64,   // 177: confirmate.ontology.v1.ConfigurationDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 178: confirmate.ontology.v1.ConfigurationDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 179: confirmate.ontology.v1.ConfigurationDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 180: confirmate.ontology.v1.ConfigurationDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 181: confirmate.ontology.v1.ConfigurationDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	355,  // 182: confirmate.ontology.v1.ConfigurationGroup.creation_time:type_name -> google.protobuf.Timestamp
-	285,  // 183: confirmate.ontology.v1.ConfigurationGroup.labels:type_name -> confirmate.ontology.v1.ConfigurationGroup.LabelsEntry
-	72,   // 184: confirmate.ontology.v1.ConfigurationGroup.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 185: confirmate.ontology.v1.ConfigurationGroupSource.creation_time:type_name -> google.protobuf.Timestamp
-	286,  // 186: confirmate.ontology.v1.ConfigurationGroupSource.labels:type_name -> confirmate.ontology.v1.ConfigurationGroupSource.LabelsEntry
-	72,   // 187: confirmate.ontology.v1.ConfigurationGroupSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	152,  // 188: confirmate.ontology.v1.ConfigurationOperation.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
-	211,  // 189: confirmate.ontology.v1.ConfigurationOperation.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
-	212,  // 190: confirmate.ontology.v1.ConfigurationOperation.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
-	213,  // 191: confirmate.ontology.v1.ConfigurationOperation.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
-	217,  // 192: confirmate.ontology.v1.ConfigurationOperation.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
-	218,  // 193: confirmate.ontology.v1.ConfigurationOperation.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
-	220,  // 194: confirmate.ontology.v1.ConfigurationOperation.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
-	221,  // 195: confirmate.ontology.v1.ConfigurationOperation.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
-	355,  // 196: confirmate.ontology.v1.ConfigurationOption.creation_time:type_name -> google.protobuf.Timestamp
-	287,  // 197: confirmate.ontology.v1.ConfigurationOption.labels:type_name -> confirmate.ontology.v1.ConfigurationOption.LabelsEntry
-	72,   // 198: confirmate.ontology.v1.ConfigurationOption.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 199: confirmate.ontology.v1.ConfigurationOptionSource.creation_time:type_name -> google.protobuf.Timestamp
-	288,  // 200: confirmate.ontology.v1.ConfigurationOptionSource.labels:type_name -> confirmate.ontology.v1.ConfigurationOptionSource.LabelsEntry
-	72,   // 201: confirmate.ontology.v1.ConfigurationOptionSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 202: confirmate.ontology.v1.ConfigurationSource.creation_time:type_name -> google.protobuf.Timestamp
-	289,  // 203: confirmate.ontology.v1.ConfigurationSource.labels:type_name -> confirmate.ontology.v1.ConfigurationSource.LabelsEntry
-	72,   // 204: confirmate.ontology.v1.ConfigurationSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 205: confirmate.ontology.v1.Container.creation_time:type_name -> google.protobuf.Timestamp
-	290,  // 206: confirmate.ontology.v1.Container.labels:type_name -> confirmate.ontology.v1.Container.LabelsEntry
-	31,   // 207: confirmate.ontology.v1.Container.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	90,   // 208: confirmate.ontology.v1.Container.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	110,  // 209: confirmate.ontology.v1.Container.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 210: confirmate.ontology.v1.Container.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 211: confirmate.ontology.v1.Container.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 212: confirmate.ontology.v1.Container.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	225,  // 213: confirmate.ontology.v1.Container.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	232,  // 214: confirmate.ontology.v1.Container.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 215: confirmate.ontology.v1.Container.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 216: confirmate.ontology.v1.ContainerImage.creation_time:type_name -> google.protobuf.Timestamp
-	291,  // 217: confirmate.ontology.v1.ContainerImage.labels:type_name -> confirmate.ontology.v1.ContainerImage.LabelsEntry
-	31,   // 218: confirmate.ontology.v1.ContainerImage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 219: confirmate.ontology.v1.ContainerImage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 220: confirmate.ontology.v1.ContainerImage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 221: confirmate.ontology.v1.ContainerImage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 222: confirmate.ontology.v1.ContainerImage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 223: confirmate.ontology.v1.ContainerImage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 224: confirmate.ontology.v1.ContainerOrchestration.creation_time:type_name -> google.protobuf.Timestamp
-	292,  // 225: confirmate.ontology.v1.ContainerOrchestration.labels:type_name -> confirmate.ontology.v1.ContainerOrchestration.LabelsEntry
-	31,   // 226: confirmate.ontology.v1.ContainerOrchestration.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 227: confirmate.ontology.v1.ContainerOrchestration.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 228: confirmate.ontology.v1.ContainerOrchestration.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 229: confirmate.ontology.v1.ContainerOrchestration.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 230: confirmate.ontology.v1.ContainerOrchestration.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	232,  // 231: confirmate.ontology.v1.ContainerOrchestration.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 232: confirmate.ontology.v1.ContainerOrchestration.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 233: confirmate.ontology.v1.ContainerRegistry.creation_time:type_name -> google.protobuf.Timestamp
-	293,  // 234: confirmate.ontology.v1.ContainerRegistry.labels:type_name -> confirmate.ontology.v1.ContainerRegistry.LabelsEntry
-	31,   // 235: confirmate.ontology.v1.ContainerRegistry.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 236: confirmate.ontology.v1.ContainerRegistry.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 237: confirmate.ontology.v1.ContainerRegistry.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 238: confirmate.ontology.v1.ContainerRegistry.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 239: confirmate.ontology.v1.ContainerRegistry.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 240: confirmate.ontology.v1.ContainerRegistry.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 241: confirmate.ontology.v1.Context.creation_time:type_name -> google.protobuf.Timestamp
-	294,  // 242: confirmate.ontology.v1.Context.labels:type_name -> confirmate.ontology.v1.Context.LabelsEntry
-	72,   // 243: confirmate.ontology.v1.Context.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 244: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.creation_time:type_name -> google.protobuf.Timestamp
-	295,  // 245: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.labels:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.LabelsEntry
-	72,   // 246: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	38,   // 247: confirmate.ontology.v1.Core.cloud_sdk:type_name -> confirmate.ontology.v1.CloudSDK
-	119,  // 248: confirmate.ontology.v1.Core.http_client_library:type_name -> confirmate.ontology.v1.HttpClientLibrary
-	127,  // 249: confirmate.ontology.v1.Core.http_server:type_name -> confirmate.ontology.v1.HttpServer
-	164,  // 250: confirmate.ontology.v1.Core.logger:type_name -> confirmate.ontology.v1.Logger
-	233,  // 251: confirmate.ontology.v1.Core.resource_type:type_name -> confirmate.ontology.v1.ResourceType
-	39,   // 252: confirmate.ontology.v1.CreateEncryptedDisk.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	81,   // 253: confirmate.ontology.v1.CreateEncryptedDisk.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	39,   // 254: confirmate.ontology.v1.CreateSecret.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	29,   // 255: confirmate.ontology.v1.Credential.certificate:type_name -> confirmate.ontology.v1.Certificate
-	143,  // 256: confirmate.ontology.v1.Credential.key:type_name -> confirmate.ontology.v1.Key
-	239,  // 257: confirmate.ontology.v1.Credential.secret:type_name -> confirmate.ontology.v1.Secret
-	94,   // 258: confirmate.ontology.v1.CryptographicHash.errors:type_name -> confirmate.ontology.v1.Error
-	116,  // 259: confirmate.ontology.v1.CryptographicOperation.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
-	33,   // 260: confirmate.ontology.v1.CustomerKeyEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
-	355,  // 261: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.creation_time:type_name -> google.protobuf.Timestamp
-	296,  // 262: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.labels:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.LabelsEntry
-	64,   // 263: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 264: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 265: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 266: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 267: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	355,  // 268: confirmate.ontology.v1.Darwin.creation_time:type_name -> google.protobuf.Timestamp
-	297,  // 269: confirmate.ontology.v1.Darwin.labels:type_name -> confirmate.ontology.v1.Darwin.LabelsEntry
-	107,  // 270: confirmate.ontology.v1.Darwin.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	45,   // 271: confirmate.ontology.v1.Data.configuration:type_name -> confirmate.ontology.v1.Configuration
-	47,   // 272: confirmate.ontology.v1.Data.configuration_group:type_name -> confirmate.ontology.v1.ConfigurationGroup
-	48,   // 273: confirmate.ontology.v1.Data.configuration_group_source:type_name -> confirmate.ontology.v1.ConfigurationGroupSource
-	50,   // 274: confirmate.ontology.v1.Data.configuration_option:type_name -> confirmate.ontology.v1.ConfigurationOption
-	51,   // 275: confirmate.ontology.v1.Data.configuration_option_source:type_name -> confirmate.ontology.v1.ConfigurationOptionSource
-	52,   // 276: confirmate.ontology.v1.Data.configuration_source:type_name -> confirmate.ontology.v1.ConfigurationSource
-	58,   // 277: confirmate.ontology.v1.Data.context:type_name -> confirmate.ontology.v1.Context
-	46,   // 278: confirmate.ontology.v1.Data.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
-	67,   // 279: confirmate.ontology.v1.Data.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
-	83,   // 280: confirmate.ontology.v1.Data.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
-	88,   // 281: confirmate.ontology.v1.Data.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
-	228,  // 282: confirmate.ontology.v1.Data.report_document:type_name -> confirmate.ontology.v1.ReportDocument
-	159,  // 283: confirmate.ontology.v1.Data.log_document:type_name -> confirmate.ontology.v1.LogDocument
-	203,  // 284: confirmate.ontology.v1.Data.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
-	209,  // 285: confirmate.ontology.v1.Data.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
-	236,  // 286: confirmate.ontology.v1.Data.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
-	241,  // 287: confirmate.ontology.v1.Data.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
-	248,  // 288: confirmate.ontology.v1.Data.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
-	263,  // 289: confirmate.ontology.v1.Data.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
-	97,   // 290: confirmate.ontology.v1.Data.file:type_name -> confirmate.ontology.v1.File
-	98,   // 291: confirmate.ontology.v1.Data.file_handle:type_name -> confirmate.ontology.v1.FileHandle
-	168,  // 292: confirmate.ontology.v1.Data.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
-	169,  // 293: confirmate.ontology.v1.Data.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
-	59,   // 294: confirmate.ontology.v1.Data.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
-	6,    // 295: confirmate.ontology.v1.Data.and_rule:type_name -> confirmate.ontology.v1.AndRule
-	258,  // 296: confirmate.ontology.v1.Data.token:type_name -> confirmate.ontology.v1.Token
-	266,  // 297: confirmate.ontology.v1.Data.value:type_name -> confirmate.ontology.v1.Value
-	156,  // 298: confirmate.ontology.v1.DataLocation.local_data_location:type_name -> confirmate.ontology.v1.LocalDataLocation
-	226,  // 299: confirmate.ontology.v1.DataLocation.remote_data_location:type_name -> confirmate.ontology.v1.RemoteDataLocation
-	39,   // 300: confirmate.ontology.v1.DatabaseConnect.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	73,   // 301: confirmate.ontology.v1.DatabaseOperation.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
-	75,   // 302: confirmate.ontology.v1.DatabaseOperation.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
-	39,   // 303: confirmate.ontology.v1.DatabaseQuery.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	85,   // 304: confirmate.ontology.v1.DatabaseService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 305: confirmate.ontology.v1.DatabaseService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 306: confirmate.ontology.v1.DatabaseService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 307: confirmate.ontology.v1.DatabaseService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	355,  // 308: confirmate.ontology.v1.DatabaseStorage.creation_time:type_name -> google.protobuf.Timestamp
-	298,  // 309: confirmate.ontology.v1.DatabaseStorage.labels:type_name -> confirmate.ontology.v1.DatabaseStorage.LabelsEntry
-	3,    // 310: confirmate.ontology.v1.DatabaseStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	12,   // 311: confirmate.ontology.v1.DatabaseStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
-	23,   // 312: confirmate.ontology.v1.DatabaseStorage.backups:type_name -> confirmate.ontology.v1.Backup
-	31,   // 313: confirmate.ontology.v1.DatabaseStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 314: confirmate.ontology.v1.DatabaseStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	132,  // 315: confirmate.ontology.v1.DatabaseStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
-	165,  // 316: confirmate.ontology.v1.DatabaseStorage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 317: confirmate.ontology.v1.DatabaseStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 318: confirmate.ontology.v1.DatabaseStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	232,  // 319: confirmate.ontology.v1.DatabaseStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 320: confirmate.ontology.v1.DatabaseStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	39,   // 321: confirmate.ontology.v1.DeAllocate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	33,   // 322: confirmate.ontology.v1.Decryption.cipher:type_name -> confirmate.ontology.v1.Cipher
-	39,   // 323: confirmate.ontology.v1.Decryption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 324: confirmate.ontology.v1.DeviceProvisioningService.creation_time:type_name -> google.protobuf.Timestamp
-	299,  // 325: confirmate.ontology.v1.DeviceProvisioningService.labels:type_name -> confirmate.ontology.v1.DeviceProvisioningService.LabelsEntry
-	31,   // 326: confirmate.ontology.v1.DeviceProvisioningService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 327: confirmate.ontology.v1.DeviceProvisioningService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 328: confirmate.ontology.v1.DeviceProvisioningService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 329: confirmate.ontology.v1.DeviceProvisioningService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 330: confirmate.ontology.v1.DeviceProvisioningService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 331: confirmate.ontology.v1.DeviceProvisioningService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	24,   // 332: confirmate.ontology.v1.DiskEncryption.used_by:type_name -> confirmate.ontology.v1.BlockStorage
-	33,   // 333: confirmate.ontology.v1.DiskEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
-	61,   // 334: confirmate.ontology.v1.DiskEncryptionOperation.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
-	261,  // 335: confirmate.ontology.v1.DiskEncryptionOperation.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
-	355,  // 336: confirmate.ontology.v1.DistributionOfUpdatesDocument.creation_time:type_name -> google.protobuf.Timestamp
-	300,  // 337: confirmate.ontology.v1.DistributionOfUpdatesDocument.labels:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument.LabelsEntry
-	64,   // 338: confirmate.ontology.v1.DistributionOfUpdatesDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 339: confirmate.ontology.v1.DistributionOfUpdatesDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 340: confirmate.ontology.v1.DistributionOfUpdatesDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 341: confirmate.ontology.v1.DistributionOfUpdatesDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 342: confirmate.ontology.v1.DistributionOfUpdatesDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	46,   // 343: confirmate.ontology.v1.Document.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
-	67,   // 344: confirmate.ontology.v1.Document.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
-	83,   // 345: confirmate.ontology.v1.Document.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
-	88,   // 346: confirmate.ontology.v1.Document.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
-	228,  // 347: confirmate.ontology.v1.Document.report_document:type_name -> confirmate.ontology.v1.ReportDocument
-	159,  // 348: confirmate.ontology.v1.Document.log_document:type_name -> confirmate.ontology.v1.LogDocument
-	203,  // 349: confirmate.ontology.v1.Document.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
-	209,  // 350: confirmate.ontology.v1.Document.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
-	236,  // 351: confirmate.ontology.v1.Document.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
-	241,  // 352: confirmate.ontology.v1.Document.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
-	248,  // 353: confirmate.ontology.v1.Document.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
-	263,  // 354: confirmate.ontology.v1.Document.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
-	355,  // 355: confirmate.ontology.v1.DocumentDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
-	301,  // 356: confirmate.ontology.v1.DocumentDatabaseService.labels:type_name -> confirmate.ontology.v1.DocumentDatabaseService.LabelsEntry
-	3,    // 357: confirmate.ontology.v1.DocumentDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	7,    // 358: confirmate.ontology.v1.DocumentDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
-	31,   // 359: confirmate.ontology.v1.DocumentDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 360: confirmate.ontology.v1.DocumentDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 361: confirmate.ontology.v1.DocumentDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 362: confirmate.ontology.v1.DocumentDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 363: confirmate.ontology.v1.DocumentDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 364: confirmate.ontology.v1.DocumentDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 365: confirmate.ontology.v1.DocumentDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 366: confirmate.ontology.v1.DocumentDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	153,  // 367: confirmate.ontology.v1.DynamicLoadingOperation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
-	154,  // 368: confirmate.ontology.v1.DynamicLoadingOperation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
-	355,  // 369: confirmate.ontology.v1.EUDeclarationOfConformity.creation_time:type_name -> google.protobuf.Timestamp
-	302,  // 370: confirmate.ontology.v1.EUDeclarationOfConformity.labels:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity.LabelsEntry
-	64,   // 371: confirmate.ontology.v1.EUDeclarationOfConformity.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 372: confirmate.ontology.v1.EUDeclarationOfConformity.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 373: confirmate.ontology.v1.EUDeclarationOfConformity.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 374: confirmate.ontology.v1.EUDeclarationOfConformity.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 375: confirmate.ontology.v1.EUDeclarationOfConformity.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	66,   // 376: confirmate.ontology.v1.Encryption.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
-	81,   // 377: confirmate.ontology.v1.Encryption.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	173,  // 378: confirmate.ontology.v1.Encryption.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
-	260,  // 379: confirmate.ontology.v1.Encryption.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	39,   // 380: confirmate.ontology.v1.EncryptionOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	89,   // 381: confirmate.ontology.v1.EncryptionOperation.encryption:type_name -> confirmate.ontology.v1.Encryption
-	150,  // 382: confirmate.ontology.v1.EntryPoint.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
-	171,  // 383: confirmate.ontology.v1.EntryPoint.main:type_name -> confirmate.ontology.v1.Main
-	121,  // 384: confirmate.ontology.v1.EntryPoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	39,   // 385: confirmate.ontology.v1.EqualityCheck.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	206,  // 386: confirmate.ontology.v1.EqualityCheck.left_principal:type_name -> confirmate.ontology.v1.Principal
-	206,  // 387: confirmate.ontology.v1.EqualityCheck.right_principal:type_name -> confirmate.ontology.v1.Principal
-	27,   // 388: confirmate.ontology.v1.ExitBoundaryOperation.boundary:type_name -> confirmate.ontology.v1.Boundary
-	39,   // 389: confirmate.ontology.v1.ExitBoundaryOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 390: confirmate.ontology.v1.File.creation_time:type_name -> google.protobuf.Timestamp
-	303,  // 391: confirmate.ontology.v1.File.labels:type_name -> confirmate.ontology.v1.File.LabelsEntry
-	72,   // 392: confirmate.ontology.v1.File.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 393: confirmate.ontology.v1.FileHandle.creation_time:type_name -> google.protobuf.Timestamp
-	304,  // 394: confirmate.ontology.v1.FileHandle.labels:type_name -> confirmate.ontology.v1.FileHandle.LabelsEntry
-	72,   // 395: confirmate.ontology.v1.FileHandle.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	97,   // 396: confirmate.ontology.v1.FileLikeObject.file:type_name -> confirmate.ontology.v1.File
-	98,   // 397: confirmate.ontology.v1.FileLikeObject.file_handle:type_name -> confirmate.ontology.v1.FileHandle
-	39,   // 398: confirmate.ontology.v1.FileOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 399: confirmate.ontology.v1.FileStorage.creation_time:type_name -> google.protobuf.Timestamp
-	305,  // 400: confirmate.ontology.v1.FileStorage.labels:type_name -> confirmate.ontology.v1.FileStorage.LabelsEntry
-	3,    // 401: confirmate.ontology.v1.FileStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	12,   // 402: confirmate.ontology.v1.FileStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
-	23,   // 403: confirmate.ontology.v1.FileStorage.backups:type_name -> confirmate.ontology.v1.Backup
-	31,   // 404: confirmate.ontology.v1.FileStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 405: confirmate.ontology.v1.FileStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	132,  // 406: confirmate.ontology.v1.FileStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
-	165,  // 407: confirmate.ontology.v1.FileStorage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 408: confirmate.ontology.v1.FileStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 409: confirmate.ontology.v1.FileStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	232,  // 410: confirmate.ontology.v1.FileStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 411: confirmate.ontology.v1.FileStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 412: confirmate.ontology.v1.FileStorageService.creation_time:type_name -> google.protobuf.Timestamp
-	306,  // 413: confirmate.ontology.v1.FileStorageService.labels:type_name -> confirmate.ontology.v1.FileStorageService.LabelsEntry
-	3,    // 414: confirmate.ontology.v1.FileStorageService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	31,   // 415: confirmate.ontology.v1.FileStorageService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 416: confirmate.ontology.v1.FileStorageService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 417: confirmate.ontology.v1.FileStorageService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 418: confirmate.ontology.v1.FileStorageService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 419: confirmate.ontology.v1.FileStorageService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 420: confirmate.ontology.v1.FileStorageService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 421: confirmate.ontology.v1.FileStorageService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 422: confirmate.ontology.v1.FileStorageService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	147,  // 423: confirmate.ontology.v1.Firewall.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
-	272,  // 424: confirmate.ontology.v1.Firewall.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
-	38,   // 425: confirmate.ontology.v1.Framework.cloud_sdk:type_name -> confirmate.ontology.v1.CloudSDK
-	119,  // 426: confirmate.ontology.v1.Framework.http_client_library:type_name -> confirmate.ontology.v1.HttpClientLibrary
-	127,  // 427: confirmate.ontology.v1.Framework.http_server:type_name -> confirmate.ontology.v1.HttpServer
-	164,  // 428: confirmate.ontology.v1.Framework.logger:type_name -> confirmate.ontology.v1.Logger
-	355,  // 429: confirmate.ontology.v1.Function.creation_time:type_name -> google.protobuf.Timestamp
-	307,  // 430: confirmate.ontology.v1.Function.labels:type_name -> confirmate.ontology.v1.Function.LabelsEntry
-	31,   // 431: confirmate.ontology.v1.Function.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	90,   // 432: confirmate.ontology.v1.Function.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	110,  // 433: confirmate.ontology.v1.Function.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 434: confirmate.ontology.v1.Function.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 435: confirmate.ontology.v1.Function.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 436: confirmate.ontology.v1.Function.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	225,  // 437: confirmate.ontology.v1.Function.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	232,  // 438: confirmate.ontology.v1.Function.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 439: confirmate.ontology.v1.Function.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 440: confirmate.ontology.v1.FunctionService.creation_time:type_name -> google.protobuf.Timestamp
-	308,  // 441: confirmate.ontology.v1.FunctionService.labels:type_name -> confirmate.ontology.v1.FunctionService.LabelsEntry
-	31,   // 442: confirmate.ontology.v1.FunctionService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 443: confirmate.ontology.v1.FunctionService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 444: confirmate.ontology.v1.FunctionService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 445: confirmate.ontology.v1.FunctionService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 446: confirmate.ontology.v1.FunctionService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 447: confirmate.ontology.v1.FunctionService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 448: confirmate.ontology.v1.FunctionService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	27,   // 449: confirmate.ontology.v1.Functionality.boundary:type_name -> confirmate.ontology.v1.Boundary
-	31,   // 450: confirmate.ontology.v1.Functionality.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	11,   // 451: confirmate.ontology.v1.Functionality.asymmetric_cipher:type_name -> confirmate.ontology.v1.AsymmetricCipher
-	128,  // 452: confirmate.ontology.v1.Functionality.hybrid_cipher:type_name -> confirmate.ontology.v1.HybridCipher
-	256,  // 453: confirmate.ontology.v1.Functionality.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
-	35,   // 454: confirmate.ontology.v1.Functionality.cipher_suite:type_name -> confirmate.ontology.v1.CipherSuite
-	39,   // 455: confirmate.ontology.v1.Functionality.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	156,  // 456: confirmate.ontology.v1.Functionality.local_data_location:type_name -> confirmate.ontology.v1.LocalDataLocation
-	226,  // 457: confirmate.ontology.v1.Functionality.remote_data_location:type_name -> confirmate.ontology.v1.RemoteDataLocation
-	86,   // 458: confirmate.ontology.v1.Functionality.dynamic_loading:type_name -> confirmate.ontology.v1.DynamicLoading
-	150,  // 459: confirmate.ontology.v1.Functionality.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
-	171,  // 460: confirmate.ontology.v1.Functionality.main:type_name -> confirmate.ontology.v1.Main
-	121,  // 461: confirmate.ontology.v1.Functionality.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	94,   // 462: confirmate.ontology.v1.Functionality.error:type_name -> confirmate.ontology.v1.Error
-	53,   // 463: confirmate.ontology.v1.Functionality.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
-	179,  // 464: confirmate.ontology.v1.Functionality.monitoring_procedure:type_name -> confirmate.ontology.v1.MonitoringProcedure
-	22,   // 465: confirmate.ontology.v1.Functionality.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
-	246,  // 466: confirmate.ontology.v1.Functionality.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
-	118,  // 467: confirmate.ontology.v1.Functionality.http_client:type_name -> confirmate.ontology.v1.HttpClient
-	124,  // 468: confirmate.ontology.v1.Functionality.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
-	125,  // 469: confirmate.ontology.v1.Functionality.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
-	133,  // 470: confirmate.ontology.v1.Functionality.initialization_vector:type_name -> confirmate.ontology.v1.InitializationVector
-	134,  // 471: confirmate.ontology.v1.Functionality.input:type_name -> confirmate.ontology.v1.Input
-	144,  // 472: confirmate.ontology.v1.Functionality.key_derivation_function:type_name -> confirmate.ontology.v1.KeyDerivationFunction
-	176,  // 473: confirmate.ontology.v1.Functionality.message_authentication_code:type_name -> confirmate.ontology.v1.MessageAuthenticationCode
-	15,   // 474: confirmate.ontology.v1.Functionality.authenticate:type_name -> confirmate.ontology.v1.Authenticate
-	19,   // 475: confirmate.ontology.v1.Functionality.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
-	139,  // 476: confirmate.ontology.v1.Functionality.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
-	265,  // 477: confirmate.ontology.v1.Functionality.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
-	25,   // 478: confirmate.ontology.v1.Functionality.block_storage_operation:type_name -> confirmate.ontology.v1.BlockStorageOperation
-	79,   // 479: confirmate.ontology.v1.Functionality.decryption:type_name -> confirmate.ontology.v1.Decryption
-	152,  // 480: confirmate.ontology.v1.Functionality.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
-	211,  // 481: confirmate.ontology.v1.Functionality.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
-	212,  // 482: confirmate.ontology.v1.Functionality.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
-	213,  // 483: confirmate.ontology.v1.Functionality.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
-	217,  // 484: confirmate.ontology.v1.Functionality.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
-	218,  // 485: confirmate.ontology.v1.Functionality.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
-	220,  // 486: confirmate.ontology.v1.Functionality.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
-	221,  // 487: confirmate.ontology.v1.Functionality.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
-	116,  // 488: confirmate.ontology.v1.Functionality.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
-	73,   // 489: confirmate.ontology.v1.Functionality.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
-	75,   // 490: confirmate.ontology.v1.Functionality.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
-	61,   // 491: confirmate.ontology.v1.Functionality.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
-	261,  // 492: confirmate.ontology.v1.Functionality.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
-	91,   // 493: confirmate.ontology.v1.Functionality.encryption_operation:type_name -> confirmate.ontology.v1.EncryptionOperation
-	95,   // 494: confirmate.ontology.v1.Functionality.exit_boundary_operation:type_name -> confirmate.ontology.v1.ExitBoundaryOperation
-	100,  // 495: confirmate.ontology.v1.Functionality.file_operation:type_name -> confirmate.ontology.v1.FileOperation
-	112,  // 496: confirmate.ontology.v1.Functionality.get_current_time_operation:type_name -> confirmate.ontology.v1.GetCurrentTimeOperation
-	123,  // 497: confirmate.ontology.v1.Functionality.http_request:type_name -> confirmate.ontology.v1.HttpRequest
-	122,  // 498: confirmate.ontology.v1.Functionality.http_endpoint_operation:type_name -> confirmate.ontology.v1.HttpEndpointOperation
-	222,  // 499: confirmate.ontology.v1.Functionality.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
-	135,  // 500: confirmate.ontology.v1.Functionality.input_validation_operation:type_name -> confirmate.ontology.v1.InputValidationOperation
-	136,  // 501: confirmate.ontology.v1.Functionality.install_update_operation:type_name -> confirmate.ontology.v1.InstallUpdateOperation
-	160,  // 502: confirmate.ontology.v1.Functionality.log_get:type_name -> confirmate.ontology.v1.LogGet
-	163,  // 503: confirmate.ontology.v1.Functionality.log_write:type_name -> confirmate.ontology.v1.LogWrite
-	162,  // 504: confirmate.ontology.v1.Functionality.log_output:type_name -> confirmate.ontology.v1.LogOutput
-	5,    // 505: confirmate.ontology.v1.Functionality.allocate:type_name -> confirmate.ontology.v1.Allocate
-	78,   // 506: confirmate.ontology.v1.Functionality.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
-	153,  // 507: confirmate.ontology.v1.Functionality.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
-	154,  // 508: confirmate.ontology.v1.Functionality.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
-	191,  // 509: confirmate.ontology.v1.Functionality.object_storage_request:type_name -> confirmate.ontology.v1.ObjectStorageRequest
-	93,   // 510: confirmate.ontology.v1.Functionality.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
-	32,   // 511: confirmate.ontology.v1.Functionality.check_access:type_name -> confirmate.ontology.v1.CheckAccess
-	62,   // 512: confirmate.ontology.v1.Functionality.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
-	113,  // 513: confirmate.ontology.v1.Functionality.get_secret:type_name -> confirmate.ontology.v1.GetSecret
-	195,  // 514: confirmate.ontology.v1.Functionality.output:type_name -> confirmate.ontology.v1.Output
-	198,  // 515: confirmate.ontology.v1.Functionality.padding:type_name -> confirmate.ontology.v1.Padding
-	71,   // 516: confirmate.ontology.v1.Functionality.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
-	148,  // 517: confirmate.ontology.v1.Functionality.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
-	182,  // 518: confirmate.ontology.v1.Functionality.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
-	237,  // 519: confirmate.ontology.v1.Functionality.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
-	247,  // 520: confirmate.ontology.v1.Functionality.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
-	206,  // 521: confirmate.ontology.v1.Functionality.principal:type_name -> confirmate.ontology.v1.Principal
-	207,  // 522: confirmate.ontology.v1.Functionality.protected_asset:type_name -> confirmate.ontology.v1.ProtectedAsset
-	229,  // 523: confirmate.ontology.v1.Functionality.request_for_change:type_name -> confirmate.ontology.v1.RequestForChange
-	238,  // 524: confirmate.ontology.v1.Functionality.schema_validation:type_name -> confirmate.ontology.v1.SchemaValidation
-	242,  // 525: confirmate.ontology.v1.Functionality.security_advisory_feed:type_name -> confirmate.ontology.v1.SecurityAdvisoryFeed
-	257,  // 526: confirmate.ontology.v1.Functionality.time:type_name -> confirmate.ontology.v1.Time
-	271,  // 527: confirmate.ontology.v1.Functionality.vulnerability:type_name -> confirmate.ontology.v1.Vulnerability
-	228,  // 528: confirmate.ontology.v1.GenericDocument.report_document:type_name -> confirmate.ontology.v1.ReportDocument
-	355,  // 529: confirmate.ontology.v1.GenericNetworkService.creation_time:type_name -> google.protobuf.Timestamp
-	309,  // 530: confirmate.ontology.v1.GenericNetworkService.labels:type_name -> confirmate.ontology.v1.GenericNetworkService.LabelsEntry
-	31,   // 531: confirmate.ontology.v1.GenericNetworkService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 532: confirmate.ontology.v1.GenericNetworkService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 533: confirmate.ontology.v1.GenericNetworkService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 534: confirmate.ontology.v1.GenericNetworkService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 535: confirmate.ontology.v1.GenericNetworkService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 536: confirmate.ontology.v1.GenericNetworkService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 537: confirmate.ontology.v1.GenericNetworkService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	110,  // 538: confirmate.ontology.v1.GeoRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
-	39,   // 539: confirmate.ontology.v1.GetCurrentTimeOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	257,  // 540: confirmate.ontology.v1.GetCurrentTimeOperation.time:type_name -> confirmate.ontology.v1.Time
-	39,   // 541: confirmate.ontology.v1.GetSecret.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	53,   // 542: confirmate.ontology.v1.Governance.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
-	179,  // 543: confirmate.ontology.v1.Governance.monitoring_procedure:type_name -> confirmate.ontology.v1.MonitoringProcedure
-	22,   // 544: confirmate.ontology.v1.Governance.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
-	246,  // 545: confirmate.ontology.v1.Governance.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
-	174,  // 546: confirmate.ontology.v1.Hardware.memory:type_name -> confirmate.ontology.v1.Memory
-	39,   // 547: confirmate.ontology.v1.HashOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	244,  // 548: confirmate.ontology.v1.HashOperation.security_feature:type_name -> confirmate.ontology.v1.SecurityFeature
-	118,  // 549: confirmate.ontology.v1.Http.http_client:type_name -> confirmate.ontology.v1.HttpClient
-	124,  // 550: confirmate.ontology.v1.Http.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
-	125,  // 551: confirmate.ontology.v1.Http.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
-	17,   // 552: confirmate.ontology.v1.HttpClient.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	260,  // 553: confirmate.ontology.v1.HttpClient.uses:type_name -> confirmate.ontology.v1.TransportEncryption
-	123,  // 554: confirmate.ontology.v1.HttpClientOperation.http_request:type_name -> confirmate.ontology.v1.HttpRequest
-	17,   // 555: confirmate.ontology.v1.HttpEndpoint.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	18,   // 556: confirmate.ontology.v1.HttpEndpoint.authorization:type_name -> confirmate.ontology.v1.Authorization
-	124,  // 557: confirmate.ontology.v1.HttpEndpoint.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
-	216,  // 558: confirmate.ontology.v1.HttpEndpoint.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
-	260,  // 559: confirmate.ontology.v1.HttpEndpoint.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	39,   // 560: confirmate.ontology.v1.HttpEndpointOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	117,  // 561: confirmate.ontology.v1.HttpEndpointOperation.http:type_name -> confirmate.ontology.v1.Http
-	39,   // 562: confirmate.ontology.v1.HttpRequest.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	118,  // 563: confirmate.ontology.v1.HttpRequest.http_client:type_name -> confirmate.ontology.v1.HttpClient
-	121,  // 564: confirmate.ontology.v1.HttpRequest.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
-	121,  // 565: confirmate.ontology.v1.HttpRequestHandler.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
-	222,  // 566: confirmate.ontology.v1.HttpRequestHandlerOperation.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
-	125,  // 567: confirmate.ontology.v1.HttpServer.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
-	11,   // 568: confirmate.ontology.v1.HybridCipher.uses:type_name -> confirmate.ontology.v1.AsymmetricCipher
-	144,  // 569: confirmate.ontology.v1.HybridCipher.key_derivation_function:type_name -> confirmate.ontology.v1.KeyDerivationFunction
-	176,  // 570: confirmate.ontology.v1.HybridCipher.message_authentication_code:type_name -> confirmate.ontology.v1.MessageAuthenticationCode
-	198,  // 571: confirmate.ontology.v1.HybridCipher.padding:type_name -> confirmate.ontology.v1.Padding
-	256,  // 572: confirmate.ontology.v1.HybridCipher.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
-	130,  // 573: confirmate.ontology.v1.Identifiable.identity:type_name -> confirmate.ontology.v1.Identity
-	235,  // 574: confirmate.ontology.v1.Identifiable.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
-	355,  // 575: confirmate.ontology.v1.Identity.creation_time:type_name -> google.protobuf.Timestamp
-	310,  // 576: confirmate.ontology.v1.Identity.labels:type_name -> confirmate.ontology.v1.Identity.LabelsEntry
-	355,  // 577: confirmate.ontology.v1.Identity.last_activity:type_name -> google.protobuf.Timestamp
-	18,   // 578: confirmate.ontology.v1.Identity.authorization:type_name -> confirmate.ontology.v1.Authorization
-	31,   // 579: confirmate.ontology.v1.Identity.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 580: confirmate.ontology.v1.Identity.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 581: confirmate.ontology.v1.Identity.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 582: confirmate.ontology.v1.Identity.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 583: confirmate.ontology.v1.Identity.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 584: confirmate.ontology.v1.Identity.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	55,   // 585: confirmate.ontology.v1.Image.container_image:type_name -> confirmate.ontology.v1.ContainerImage
-	264,  // 586: confirmate.ontology.v1.Image.vm_image:type_name -> confirmate.ontology.v1.VMImage
-	39,   // 587: confirmate.ontology.v1.InputValidationOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	134,  // 588: confirmate.ontology.v1.InputValidationOperation.input:type_name -> confirmate.ontology.v1.Input
-	195,  // 589: confirmate.ontology.v1.InputValidationOperation.output:type_name -> confirmate.ontology.v1.Output
-	20,   // 590: confirmate.ontology.v1.InstallUpdateOperation.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
-	39,   // 591: confirmate.ontology.v1.InstallUpdateOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	155,  // 592: confirmate.ontology.v1.Integrity.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
-	225,  // 593: confirmate.ontology.v1.Integrity.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	20,   // 594: confirmate.ontology.v1.Integrity.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
-	64,   // 595: confirmate.ontology.v1.Integrity.cryptographic_hash:type_name -> confirmate.ontology.v1.CryptographicHash
-	132,  // 596: confirmate.ontology.v1.Integrity.immutability:type_name -> confirmate.ontology.v1.Immutability
-	249,  // 597: confirmate.ontology.v1.Integrity.document_signature:type_name -> confirmate.ontology.v1.DocumentSignature
-	250,  // 598: confirmate.ontology.v1.Integrity.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
-	267,  // 599: confirmate.ontology.v1.Integrity.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
-	80,   // 600: confirmate.ontology.v1.IoT.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
-	177,  // 601: confirmate.ontology.v1.IoT.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
-	17,   // 602: confirmate.ontology.v1.IssueJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	39,   // 603: confirmate.ontology.v1.IssueJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 604: confirmate.ontology.v1.Job.creation_time:type_name -> google.protobuf.Timestamp
-	311,  // 605: confirmate.ontology.v1.Job.labels:type_name -> confirmate.ontology.v1.Job.LabelsEntry
-	31,   // 606: confirmate.ontology.v1.Job.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 607: confirmate.ontology.v1.Job.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 608: confirmate.ontology.v1.Job.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 609: confirmate.ontology.v1.Job.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 610: confirmate.ontology.v1.Job.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 611: confirmate.ontology.v1.Job.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	141,  // 612: confirmate.ontology.v1.TokenBasedAuthentication.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
-	355,  // 613: confirmate.ontology.v1.Key.creation_time:type_name -> google.protobuf.Timestamp
-	355,  // 614: confirmate.ontology.v1.Key.expiration_date:type_name -> google.protobuf.Timestamp
-	312,  // 615: confirmate.ontology.v1.Key.labels:type_name -> confirmate.ontology.v1.Key.LabelsEntry
-	355,  // 616: confirmate.ontology.v1.Key.not_before_date:type_name -> google.protobuf.Timestamp
-	31,   // 617: confirmate.ontology.v1.Key.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 618: confirmate.ontology.v1.Key.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	37,   // 619: confirmate.ontology.v1.Key.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
-	165,  // 620: confirmate.ontology.v1.Key.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 621: confirmate.ontology.v1.Key.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 622: confirmate.ontology.v1.Key.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 623: confirmate.ontology.v1.Key.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	134,  // 624: confirmate.ontology.v1.KeyDerivationFunction.input:type_name -> confirmate.ontology.v1.Input
-	355,  // 625: confirmate.ontology.v1.KeyValueDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
-	313,  // 626: confirmate.ontology.v1.KeyValueDatabaseService.labels:type_name -> confirmate.ontology.v1.KeyValueDatabaseService.LabelsEntry
-	3,    // 627: confirmate.ontology.v1.KeyValueDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	7,    // 628: confirmate.ontology.v1.KeyValueDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
-	31,   // 629: confirmate.ontology.v1.KeyValueDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 630: confirmate.ontology.v1.KeyValueDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 631: confirmate.ontology.v1.KeyValueDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 632: confirmate.ontology.v1.KeyValueDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 633: confirmate.ontology.v1.KeyValueDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 634: confirmate.ontology.v1.KeyValueDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 635: confirmate.ontology.v1.KeyValueDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 636: confirmate.ontology.v1.KeyValueDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 637: confirmate.ontology.v1.KeyVault.creation_time:type_name -> google.protobuf.Timestamp
-	314,  // 638: confirmate.ontology.v1.KeyVault.labels:type_name -> confirmate.ontology.v1.KeyVault.LabelsEntry
-	31,   // 639: confirmate.ontology.v1.KeyVault.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 640: confirmate.ontology.v1.KeyVault.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 641: confirmate.ontology.v1.KeyVault.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 642: confirmate.ontology.v1.KeyVault.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 643: confirmate.ontology.v1.KeyVault.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 644: confirmate.ontology.v1.KeyVault.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 645: confirmate.ontology.v1.Library.creation_time:type_name -> google.protobuf.Timestamp
-	315,  // 646: confirmate.ontology.v1.Library.labels:type_name -> confirmate.ontology.v1.Library.LabelsEntry
-	107,  // 647: confirmate.ontology.v1.Library.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	271,  // 648: confirmate.ontology.v1.Library.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
-	193,  // 649: confirmate.ontology.v1.LibraryEntryPoint.used_by:type_name -> confirmate.ontology.v1.OperatingSystemArchitecture
-	355,  // 650: confirmate.ontology.v1.LoadBalancer.creation_time:type_name -> google.protobuf.Timestamp
-	316,  // 651: confirmate.ontology.v1.LoadBalancer.labels:type_name -> confirmate.ontology.v1.LoadBalancer.LabelsEntry
-	1,    // 652: confirmate.ontology.v1.LoadBalancer.access_restriction:type_name -> confirmate.ontology.v1.AccessRestriction
-	31,   // 653: confirmate.ontology.v1.LoadBalancer.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 654: confirmate.ontology.v1.LoadBalancer.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 655: confirmate.ontology.v1.LoadBalancer.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 656: confirmate.ontology.v1.LoadBalancer.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 657: confirmate.ontology.v1.LoadBalancer.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 658: confirmate.ontology.v1.LoadBalancer.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 659: confirmate.ontology.v1.LoadBalancer.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 660: confirmate.ontology.v1.LoadBalancer.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	39,   // 661: confirmate.ontology.v1.LoadConfiguration.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 662: confirmate.ontology.v1.LoadLibrary.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	92,   // 663: confirmate.ontology.v1.LoadLibrary.entry_points:type_name -> confirmate.ontology.v1.EntryPoint
-	39,   // 664: confirmate.ontology.v1.LoadSymbol.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	12,   // 665: confirmate.ontology.v1.LocalDataLocation.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
-	150,  // 666: confirmate.ontology.v1.LocalEntryPoint.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
-	171,  // 667: confirmate.ontology.v1.LocalEntryPoint.main:type_name -> confirmate.ontology.v1.Main
-	110,  // 668: confirmate.ontology.v1.LocalRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
-	355,  // 669: confirmate.ontology.v1.LogDocument.creation_time:type_name -> google.protobuf.Timestamp
-	317,  // 670: confirmate.ontology.v1.LogDocument.labels:type_name -> confirmate.ontology.v1.LogDocument.LabelsEntry
-	64,   // 671: confirmate.ontology.v1.LogDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 672: confirmate.ontology.v1.LogDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 673: confirmate.ontology.v1.LogDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 674: confirmate.ontology.v1.LogDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 675: confirmate.ontology.v1.LogDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	39,   // 676: confirmate.ontology.v1.LogGet.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	165,  // 677: confirmate.ontology.v1.LogGet.logging:type_name -> confirmate.ontology.v1.Logging
-	160,  // 678: confirmate.ontology.v1.LogOperation.log_get:type_name -> confirmate.ontology.v1.LogGet
-	163,  // 679: confirmate.ontology.v1.LogOperation.log_write:type_name -> confirmate.ontology.v1.LogWrite
-	39,   // 680: confirmate.ontology.v1.LogOutput.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	165,  // 681: confirmate.ontology.v1.LogOutput.logging:type_name -> confirmate.ontology.v1.Logging
-	39,   // 682: confirmate.ontology.v1.LogWrite.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	165,  // 683: confirmate.ontology.v1.LogWrite.logging:type_name -> confirmate.ontology.v1.Logging
-	3,    // 684: confirmate.ontology.v1.Logging.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	9,    // 685: confirmate.ontology.v1.Logging.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
-	26,   // 686: confirmate.ontology.v1.Logging.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
-	188,  // 687: confirmate.ontology.v1.Logging.os_logging:type_name -> confirmate.ontology.v1.OSLogging
-	232,  // 688: confirmate.ontology.v1.Logging.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	355,  // 689: confirmate.ontology.v1.LoggingService.creation_time:type_name -> google.protobuf.Timestamp
-	318,  // 690: confirmate.ontology.v1.LoggingService.labels:type_name -> confirmate.ontology.v1.LoggingService.LabelsEntry
-	31,   // 691: confirmate.ontology.v1.LoggingService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 692: confirmate.ontology.v1.LoggingService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 693: confirmate.ontology.v1.LoggingService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 694: confirmate.ontology.v1.LoggingService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 695: confirmate.ontology.v1.LoggingService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 696: confirmate.ontology.v1.LoggingService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 697: confirmate.ontology.v1.LoggingService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	168,  // 698: confirmate.ontology.v1.MachineLearning.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
-	169,  // 699: confirmate.ontology.v1.MachineLearning.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
-	355,  // 700: confirmate.ontology.v1.MachineLearningDataset.creation_time:type_name -> google.protobuf.Timestamp
-	319,  // 701: confirmate.ontology.v1.MachineLearningDataset.labels:type_name -> confirmate.ontology.v1.MachineLearningDataset.LabelsEntry
-	72,   // 702: confirmate.ontology.v1.MachineLearningDataset.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 703: confirmate.ontology.v1.MachineLearningModel.creation_time:type_name -> google.protobuf.Timestamp
-	320,  // 704: confirmate.ontology.v1.MachineLearningModel.labels:type_name -> confirmate.ontology.v1.MachineLearningModel.LabelsEntry
-	72,   // 705: confirmate.ontology.v1.MachineLearningModel.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	271,  // 706: confirmate.ontology.v1.MachineLearningModel.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
-	355,  // 707: confirmate.ontology.v1.MachineLearningService.creation_time:type_name -> google.protobuf.Timestamp
-	321,  // 708: confirmate.ontology.v1.MachineLearningService.labels:type_name -> confirmate.ontology.v1.MachineLearningService.LabelsEntry
-	31,   // 709: confirmate.ontology.v1.MachineLearningService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 710: confirmate.ontology.v1.MachineLearningService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 711: confirmate.ontology.v1.MachineLearningService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 712: confirmate.ontology.v1.MachineLearningService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 713: confirmate.ontology.v1.MachineLearningService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 714: confirmate.ontology.v1.MachineLearningService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 715: confirmate.ontology.v1.MachineLearningService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	193,  // 716: confirmate.ontology.v1.Main.used_by:type_name -> confirmate.ontology.v1.OperatingSystemArchitecture
-	356,  // 717: confirmate.ontology.v1.MalwareProtection.duration_since_active:type_name -> google.protobuf.Duration
-	9,    // 718: confirmate.ontology.v1.MalwareProtection.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
-	33,   // 719: confirmate.ontology.v1.ManagedKeyEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
-	355,  // 720: confirmate.ontology.v1.Memory.creation_time:type_name -> google.protobuf.Timestamp
-	322,  // 721: confirmate.ontology.v1.Memory.labels:type_name -> confirmate.ontology.v1.Memory.LabelsEntry
-	5,    // 722: confirmate.ontology.v1.MemoryOperation.allocate:type_name -> confirmate.ontology.v1.Allocate
-	78,   // 723: confirmate.ontology.v1.MemoryOperation.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
-	153,  // 724: confirmate.ontology.v1.MemoryOperation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
-	154,  // 725: confirmate.ontology.v1.MemoryOperation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
-	134,  // 726: confirmate.ontology.v1.MessageAuthenticationCode.input:type_name -> confirmate.ontology.v1.Input
-	355,  // 727: confirmate.ontology.v1.MessagingHub.creation_time:type_name -> google.protobuf.Timestamp
-	323,  // 728: confirmate.ontology.v1.MessagingHub.labels:type_name -> confirmate.ontology.v1.MessagingHub.LabelsEntry
-	31,   // 729: confirmate.ontology.v1.MessagingHub.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 730: confirmate.ontology.v1.MessagingHub.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 731: confirmate.ontology.v1.MessagingHub.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 732: confirmate.ontology.v1.MessagingHub.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 733: confirmate.ontology.v1.MessagingHub.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 734: confirmate.ontology.v1.MessagingHub.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	197,  // 735: confirmate.ontology.v1.CodeModule.package:type_name -> confirmate.ontology.v1.Package
-	253,  // 736: confirmate.ontology.v1.CodeModule.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
-	17,   // 737: confirmate.ontology.v1.MultiFactorAuthentiation.authenticities:type_name -> confirmate.ontology.v1.Authenticity
-	355,  // 738: confirmate.ontology.v1.MultiModalDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
-	324,  // 739: confirmate.ontology.v1.MultiModalDatabaseService.labels:type_name -> confirmate.ontology.v1.MultiModalDatabaseService.LabelsEntry
-	3,    // 740: confirmate.ontology.v1.MultiModalDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	7,    // 741: confirmate.ontology.v1.MultiModalDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
-	31,   // 742: confirmate.ontology.v1.MultiModalDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 743: confirmate.ontology.v1.MultiModalDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 744: confirmate.ontology.v1.MultiModalDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 745: confirmate.ontology.v1.MultiModalDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 746: confirmate.ontology.v1.MultiModalDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 747: confirmate.ontology.v1.MultiModalDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 748: confirmate.ontology.v1.MultiModalDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 749: confirmate.ontology.v1.MultiModalDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 750: confirmate.ontology.v1.NetworkInterface.creation_time:type_name -> google.protobuf.Timestamp
-	325,  // 751: confirmate.ontology.v1.NetworkInterface.labels:type_name -> confirmate.ontology.v1.NetworkInterface.LabelsEntry
-	1,    // 752: confirmate.ontology.v1.NetworkInterface.access_restriction:type_name -> confirmate.ontology.v1.AccessRestriction
-	31,   // 753: confirmate.ontology.v1.NetworkInterface.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 754: confirmate.ontology.v1.NetworkInterface.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 755: confirmate.ontology.v1.NetworkInterface.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 756: confirmate.ontology.v1.NetworkInterface.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 757: confirmate.ontology.v1.NetworkInterface.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 758: confirmate.ontology.v1.NetworkInterface.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 759: confirmate.ontology.v1.NetworkSecurityGroup.creation_time:type_name -> google.protobuf.Timestamp
-	326,  // 760: confirmate.ontology.v1.NetworkSecurityGroup.labels:type_name -> confirmate.ontology.v1.NetworkSecurityGroup.LabelsEntry
-	31,   // 761: confirmate.ontology.v1.NetworkSecurityGroup.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 762: confirmate.ontology.v1.NetworkSecurityGroup.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 763: confirmate.ontology.v1.NetworkSecurityGroup.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 764: confirmate.ontology.v1.NetworkSecurityGroup.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 765: confirmate.ontology.v1.NetworkSecurityGroup.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 766: confirmate.ontology.v1.NetworkSecurityGroup.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	106,  // 767: confirmate.ontology.v1.NetworkService.function_service:type_name -> confirmate.ontology.v1.FunctionService
-	109,  // 768: confirmate.ontology.v1.NetworkService.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
-	151,  // 769: confirmate.ontology.v1.NetworkService.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
-	166,  // 770: confirmate.ontology.v1.NetworkService.logging_service:type_name -> confirmate.ontology.v1.LoggingService
-	170,  // 771: confirmate.ontology.v1.NetworkService.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
-	243,  // 772: confirmate.ontology.v1.NetworkService.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
-	85,   // 773: confirmate.ontology.v1.NetworkService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 774: confirmate.ontology.v1.NetworkService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 775: confirmate.ontology.v1.NetworkService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 776: confirmate.ontology.v1.NetworkService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	102,  // 777: confirmate.ontology.v1.NetworkService.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
-	192,  // 778: confirmate.ontology.v1.NetworkService.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
-	183,  // 779: confirmate.ontology.v1.Networking.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
-	184,  // 780: confirmate.ontology.v1.Networking.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
-	106,  // 781: confirmate.ontology.v1.Networking.function_service:type_name -> confirmate.ontology.v1.FunctionService
-	109,  // 782: confirmate.ontology.v1.Networking.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
-	151,  // 783: confirmate.ontology.v1.Networking.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
-	166,  // 784: confirmate.ontology.v1.Networking.logging_service:type_name -> confirmate.ontology.v1.LoggingService
-	170,  // 785: confirmate.ontology.v1.Networking.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
-	243,  // 786: confirmate.ontology.v1.Networking.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
-	85,   // 787: confirmate.ontology.v1.Networking.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 788: confirmate.ontology.v1.Networking.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 789: confirmate.ontology.v1.Networking.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 790: confirmate.ontology.v1.Networking.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	102,  // 791: confirmate.ontology.v1.Networking.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
-	192,  // 792: confirmate.ontology.v1.Networking.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
-	269,  // 793: confirmate.ontology.v1.Networking.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
-	270,  // 794: confirmate.ontology.v1.Networking.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
-	356,  // 795: confirmate.ontology.v1.OSLogging.retention_period:type_name -> google.protobuf.Duration
-	355,  // 796: confirmate.ontology.v1.ObjectStorage.creation_time:type_name -> google.protobuf.Timestamp
-	327,  // 797: confirmate.ontology.v1.ObjectStorage.labels:type_name -> confirmate.ontology.v1.ObjectStorage.LabelsEntry
-	3,    // 798: confirmate.ontology.v1.ObjectStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	12,   // 799: confirmate.ontology.v1.ObjectStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
-	23,   // 800: confirmate.ontology.v1.ObjectStorage.backups:type_name -> confirmate.ontology.v1.Backup
-	31,   // 801: confirmate.ontology.v1.ObjectStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 802: confirmate.ontology.v1.ObjectStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	132,  // 803: confirmate.ontology.v1.ObjectStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
-	165,  // 804: confirmate.ontology.v1.ObjectStorage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 805: confirmate.ontology.v1.ObjectStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 806: confirmate.ontology.v1.ObjectStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	232,  // 807: confirmate.ontology.v1.ObjectStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 808: confirmate.ontology.v1.ObjectStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	39,   // 809: confirmate.ontology.v1.ObjectStorageRequest.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 810: confirmate.ontology.v1.ObjectStorageService.creation_time:type_name -> google.protobuf.Timestamp
-	328,  // 811: confirmate.ontology.v1.ObjectStorageService.labels:type_name -> confirmate.ontology.v1.ObjectStorageService.LabelsEntry
-	3,    // 812: confirmate.ontology.v1.ObjectStorageService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	31,   // 813: confirmate.ontology.v1.ObjectStorageService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 814: confirmate.ontology.v1.ObjectStorageService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 815: confirmate.ontology.v1.ObjectStorageService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 816: confirmate.ontology.v1.ObjectStorageService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 817: confirmate.ontology.v1.ObjectStorageService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 818: confirmate.ontology.v1.ObjectStorageService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 819: confirmate.ontology.v1.ObjectStorageService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 820: confirmate.ontology.v1.ObjectStorageService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	4,    // 821: confirmate.ontology.v1.OperatingSystemArchitecture.agnostic:type_name -> confirmate.ontology.v1.Agnostic
-	69,   // 822: confirmate.ontology.v1.OperatingSystemArchitecture.darwin:type_name -> confirmate.ontology.v1.Darwin
-	196,  // 823: confirmate.ontology.v1.OperatingSystemArchitecture.posix:type_name -> confirmate.ontology.v1.POSIX
-	273,  // 824: confirmate.ontology.v1.OperatingSystemArchitecture.win32:type_name -> confirmate.ontology.v1.Win32
-	15,   // 825: confirmate.ontology.v1.Operation.authenticate:type_name -> confirmate.ontology.v1.Authenticate
-	19,   // 826: confirmate.ontology.v1.Operation.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
-	139,  // 827: confirmate.ontology.v1.Operation.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
-	265,  // 828: confirmate.ontology.v1.Operation.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
-	25,   // 829: confirmate.ontology.v1.Operation.block_storage_operation:type_name -> confirmate.ontology.v1.BlockStorageOperation
-	79,   // 830: confirmate.ontology.v1.Operation.decryption:type_name -> confirmate.ontology.v1.Decryption
-	152,  // 831: confirmate.ontology.v1.Operation.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
-	211,  // 832: confirmate.ontology.v1.Operation.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
-	212,  // 833: confirmate.ontology.v1.Operation.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
-	213,  // 834: confirmate.ontology.v1.Operation.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
-	217,  // 835: confirmate.ontology.v1.Operation.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
-	218,  // 836: confirmate.ontology.v1.Operation.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
-	220,  // 837: confirmate.ontology.v1.Operation.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
-	221,  // 838: confirmate.ontology.v1.Operation.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
-	116,  // 839: confirmate.ontology.v1.Operation.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
-	73,   // 840: confirmate.ontology.v1.Operation.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
-	75,   // 841: confirmate.ontology.v1.Operation.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
-	61,   // 842: confirmate.ontology.v1.Operation.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
-	261,  // 843: confirmate.ontology.v1.Operation.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
-	91,   // 844: confirmate.ontology.v1.Operation.encryption_operation:type_name -> confirmate.ontology.v1.EncryptionOperation
-	95,   // 845: confirmate.ontology.v1.Operation.exit_boundary_operation:type_name -> confirmate.ontology.v1.ExitBoundaryOperation
-	100,  // 846: confirmate.ontology.v1.Operation.file_operation:type_name -> confirmate.ontology.v1.FileOperation
-	112,  // 847: confirmate.ontology.v1.Operation.get_current_time_operation:type_name -> confirmate.ontology.v1.GetCurrentTimeOperation
-	123,  // 848: confirmate.ontology.v1.Operation.http_request:type_name -> confirmate.ontology.v1.HttpRequest
-	122,  // 849: confirmate.ontology.v1.Operation.http_endpoint_operation:type_name -> confirmate.ontology.v1.HttpEndpointOperation
-	222,  // 850: confirmate.ontology.v1.Operation.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
-	135,  // 851: confirmate.ontology.v1.Operation.input_validation_operation:type_name -> confirmate.ontology.v1.InputValidationOperation
-	136,  // 852: confirmate.ontology.v1.Operation.install_update_operation:type_name -> confirmate.ontology.v1.InstallUpdateOperation
-	160,  // 853: confirmate.ontology.v1.Operation.log_get:type_name -> confirmate.ontology.v1.LogGet
-	163,  // 854: confirmate.ontology.v1.Operation.log_write:type_name -> confirmate.ontology.v1.LogWrite
-	162,  // 855: confirmate.ontology.v1.Operation.log_output:type_name -> confirmate.ontology.v1.LogOutput
-	5,    // 856: confirmate.ontology.v1.Operation.allocate:type_name -> confirmate.ontology.v1.Allocate
-	78,   // 857: confirmate.ontology.v1.Operation.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
-	153,  // 858: confirmate.ontology.v1.Operation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
-	154,  // 859: confirmate.ontology.v1.Operation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
-	191,  // 860: confirmate.ontology.v1.Operation.object_storage_request:type_name -> confirmate.ontology.v1.ObjectStorageRequest
-	93,   // 861: confirmate.ontology.v1.Operation.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
-	32,   // 862: confirmate.ontology.v1.Operation.check_access:type_name -> confirmate.ontology.v1.CheckAccess
-	62,   // 863: confirmate.ontology.v1.Operation.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
-	113,  // 864: confirmate.ontology.v1.Operation.get_secret:type_name -> confirmate.ontology.v1.GetSecret
-	355,  // 865: confirmate.ontology.v1.POSIX.creation_time:type_name -> google.protobuf.Timestamp
-	329,  // 866: confirmate.ontology.v1.POSIX.labels:type_name -> confirmate.ontology.v1.POSIX.LabelsEntry
-	107,  // 867: confirmate.ontology.v1.POSIX.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	355,  // 868: confirmate.ontology.v1.Package.creation_time:type_name -> google.protobuf.Timestamp
-	330,  // 869: confirmate.ontology.v1.Package.labels:type_name -> confirmate.ontology.v1.Package.LabelsEntry
-	107,  // 870: confirmate.ontology.v1.Package.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	355,  // 871: confirmate.ontology.v1.PasswordPolicy.creation_time:type_name -> google.protobuf.Timestamp
-	331,  // 872: confirmate.ontology.v1.PasswordPolicy.labels:type_name -> confirmate.ontology.v1.PasswordPolicy.LabelsEntry
-	31,   // 873: confirmate.ontology.v1.PasswordPolicy.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 874: confirmate.ontology.v1.PasswordPolicy.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 875: confirmate.ontology.v1.PasswordPolicy.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 876: confirmate.ontology.v1.PasswordPolicy.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 877: confirmate.ontology.v1.PasswordPolicy.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 878: confirmate.ontology.v1.PasswordPolicy.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	71,   // 879: confirmate.ontology.v1.Policies.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
-	148,  // 880: confirmate.ontology.v1.Policies.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
-	182,  // 881: confirmate.ontology.v1.Policies.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
-	237,  // 882: confirmate.ontology.v1.Policies.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
-	247,  // 883: confirmate.ontology.v1.Policies.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
-	59,   // 884: confirmate.ontology.v1.Policy.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
-	355,  // 885: confirmate.ontology.v1.PolicyDocument.creation_time:type_name -> google.protobuf.Timestamp
-	332,  // 886: confirmate.ontology.v1.PolicyDocument.labels:type_name -> confirmate.ontology.v1.PolicyDocument.LabelsEntry
-	10,   // 887: confirmate.ontology.v1.PolicyDocument.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
-	23,   // 888: confirmate.ontology.v1.PolicyDocument.backup:type_name -> confirmate.ontology.v1.Backup
-	36,   // 889: confirmate.ontology.v1.PolicyDocument.cloud_feature:type_name -> confirmate.ontology.v1.CloudFeature
-	64,   // 890: confirmate.ontology.v1.PolicyDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	71,   // 891: confirmate.ontology.v1.PolicyDocument.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
-	72,   // 892: confirmate.ontology.v1.PolicyDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 893: confirmate.ontology.v1.PolicyDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	114,  // 894: confirmate.ontology.v1.PolicyDocument.governances:type_name -> confirmate.ontology.v1.Governance
-	148,  // 895: confirmate.ontology.v1.PolicyDocument.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
-	182,  // 896: confirmate.ontology.v1.PolicyDocument.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
-	237,  // 897: confirmate.ontology.v1.PolicyDocument.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
-	238,  // 898: confirmate.ontology.v1.PolicyDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 899: confirmate.ontology.v1.PolicyDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	245,  // 900: confirmate.ontology.v1.PolicyDocument.security_incident:type_name -> confirmate.ontology.v1.SecurityIncident
-	247,  // 901: confirmate.ontology.v1.PolicyDocument.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
-	93,   // 902: confirmate.ontology.v1.PolicyOperation.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
-	6,    // 903: confirmate.ontology.v1.PolicyRule.and_rule:type_name -> confirmate.ontology.v1.AndRule
-	230,  // 904: confirmate.ontology.v1.ProtectedAsset.protects:type_name -> confirmate.ontology.v1.Resource
-	355,  // 905: confirmate.ontology.v1.Product.creation_time:type_name -> google.protobuf.Timestamp
-	333,  // 906: confirmate.ontology.v1.Product.labels:type_name -> confirmate.ontology.v1.Product.LabelsEntry
-	355,  // 907: confirmate.ontology.v1.Product.support_ends:type_name -> google.protobuf.Timestamp
-	53,   // 908: confirmate.ontology.v1.Product.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
-	114,  // 909: confirmate.ontology.v1.Product.governances:type_name -> confirmate.ontology.v1.Governance
-	355,  // 910: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.creation_time:type_name -> google.protobuf.Timestamp
-	334,  // 911: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.labels:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.LabelsEntry
-	64,   // 912: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 913: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 914: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 915: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 916: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	32,   // 917: confirmate.ontology.v1.ProtectedAssetOperation.check_access:type_name -> confirmate.ontology.v1.CheckAccess
-	39,   // 918: confirmate.ontology.v1.ProvideConfiguration.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 919: confirmate.ontology.v1.ProvideConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 920: confirmate.ontology.v1.ProvideConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 921: confirmate.ontology.v1.QPU.creation_time:type_name -> google.protobuf.Timestamp
-	335,  // 922: confirmate.ontology.v1.QPU.labels:type_name -> confirmate.ontology.v1.QPU.LabelsEntry
-	31,   // 923: confirmate.ontology.v1.QPU.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	90,   // 924: confirmate.ontology.v1.QPU.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	110,  // 925: confirmate.ontology.v1.QPU.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 926: confirmate.ontology.v1.QPU.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 927: confirmate.ontology.v1.QPU.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 928: confirmate.ontology.v1.QPU.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	225,  // 929: confirmate.ontology.v1.QPU.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	232,  // 930: confirmate.ontology.v1.QPU.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 931: confirmate.ontology.v1.QPU.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	39,   // 932: confirmate.ontology.v1.ReadConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 933: confirmate.ontology.v1.ReadConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	111,  // 934: confirmate.ontology.v1.Redundancy.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
-	158,  // 935: confirmate.ontology.v1.Redundancy.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
-	275,  // 936: confirmate.ontology.v1.Redundancy.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
-	39,   // 937: confirmate.ontology.v1.RegisterConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 938: confirmate.ontology.v1.RegisterConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	39,   // 939: confirmate.ontology.v1.RegisterHttpEndpoint.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	121,  // 940: confirmate.ontology.v1.RegisterHttpEndpoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	125,  // 941: confirmate.ontology.v1.RegisterHttpEndpoint.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
-	355,  // 942: confirmate.ontology.v1.RelationalDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
-	336,  // 943: confirmate.ontology.v1.RelationalDatabaseService.labels:type_name -> confirmate.ontology.v1.RelationalDatabaseService.LabelsEntry
-	3,    // 944: confirmate.ontology.v1.RelationalDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	7,    // 945: confirmate.ontology.v1.RelationalDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
-	31,   // 946: confirmate.ontology.v1.RelationalDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 947: confirmate.ontology.v1.RelationalDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	121,  // 948: confirmate.ontology.v1.RelationalDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	165,  // 949: confirmate.ontology.v1.RelationalDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 950: confirmate.ontology.v1.RelationalDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 951: confirmate.ontology.v1.RelationalDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	260,  // 952: confirmate.ontology.v1.RelationalDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 953: confirmate.ontology.v1.RelationalDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	96,   // 954: confirmate.ontology.v1.Reliability.explainable_results:type_name -> confirmate.ontology.v1.ExplainableResults
-	234,  // 955: confirmate.ontology.v1.Reliability.robustness_score:type_name -> confirmate.ontology.v1.RobustnessScore
-	355,  // 956: confirmate.ontology.v1.RemoteAttestation.creation_time:type_name -> google.protobuf.Timestamp
-	17,   // 957: confirmate.ontology.v1.RemoteDataLocation.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	260,  // 958: confirmate.ontology.v1.RemoteDataLocation.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	121,  // 959: confirmate.ontology.v1.RemoteEntryPoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
-	355,  // 960: confirmate.ontology.v1.ReportDocument.creation_time:type_name -> google.protobuf.Timestamp
-	337,  // 961: confirmate.ontology.v1.ReportDocument.labels:type_name -> confirmate.ontology.v1.ReportDocument.LabelsEntry
-	64,   // 962: confirmate.ontology.v1.ReportDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 963: confirmate.ontology.v1.ReportDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 964: confirmate.ontology.v1.ReportDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 965: confirmate.ontology.v1.ReportDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 966: confirmate.ontology.v1.ReportDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	2,    // 967: confirmate.ontology.v1.Resource.account:type_name -> confirmate.ontology.v1.Account
-	140,  // 968: confirmate.ontology.v1.Resource.job:type_name -> confirmate.ontology.v1.Job
-	274,  // 969: confirmate.ontology.v1.Resource.workflow:type_name -> confirmate.ontology.v1.Workflow
-	40,   // 970: confirmate.ontology.v1.Resource.code_repository:type_name -> confirmate.ontology.v1.CodeRepository
-	54,   // 971: confirmate.ontology.v1.Resource.container:type_name -> confirmate.ontology.v1.Container
-	105,  // 972: confirmate.ontology.v1.Resource.function:type_name -> confirmate.ontology.v1.Function
-	214,  // 973: confirmate.ontology.v1.Resource.qpu:type_name -> confirmate.ontology.v1.QPU
-	268,  // 974: confirmate.ontology.v1.Resource.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
-	56,   // 975: confirmate.ontology.v1.Resource.container_orchestration:type_name -> confirmate.ontology.v1.ContainerOrchestration
-	57,   // 976: confirmate.ontology.v1.Resource.container_registry:type_name -> confirmate.ontology.v1.ContainerRegistry
-	29,   // 977: confirmate.ontology.v1.Resource.certificate:type_name -> confirmate.ontology.v1.Certificate
-	143,  // 978: confirmate.ontology.v1.Resource.key:type_name -> confirmate.ontology.v1.Key
-	239,  // 979: confirmate.ontology.v1.Resource.secret:type_name -> confirmate.ontology.v1.Secret
-	130,  // 980: confirmate.ontology.v1.Resource.identity:type_name -> confirmate.ontology.v1.Identity
-	235,  // 981: confirmate.ontology.v1.Resource.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
-	55,   // 982: confirmate.ontology.v1.Resource.container_image:type_name -> confirmate.ontology.v1.ContainerImage
-	264,  // 983: confirmate.ontology.v1.Resource.vm_image:type_name -> confirmate.ontology.v1.VMImage
-	80,   // 984: confirmate.ontology.v1.Resource.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
-	177,  // 985: confirmate.ontology.v1.Resource.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
-	146,  // 986: confirmate.ontology.v1.Resource.key_vault:type_name -> confirmate.ontology.v1.KeyVault
-	183,  // 987: confirmate.ontology.v1.Resource.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
-	184,  // 988: confirmate.ontology.v1.Resource.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
-	106,  // 989: confirmate.ontology.v1.Resource.function_service:type_name -> confirmate.ontology.v1.FunctionService
-	109,  // 990: confirmate.ontology.v1.Resource.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
-	151,  // 991: confirmate.ontology.v1.Resource.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
-	166,  // 992: confirmate.ontology.v1.Resource.logging_service:type_name -> confirmate.ontology.v1.LoggingService
-	170,  // 993: confirmate.ontology.v1.Resource.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
-	243,  // 994: confirmate.ontology.v1.Resource.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
-	85,   // 995: confirmate.ontology.v1.Resource.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 996: confirmate.ontology.v1.Resource.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 997: confirmate.ontology.v1.Resource.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 998: confirmate.ontology.v1.Resource.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	102,  // 999: confirmate.ontology.v1.Resource.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
-	192,  // 1000: confirmate.ontology.v1.Resource.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
-	269,  // 1001: confirmate.ontology.v1.Resource.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
-	270,  // 1002: confirmate.ontology.v1.Resource.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
-	200,  // 1003: confirmate.ontology.v1.Resource.password_policy:type_name -> confirmate.ontology.v1.PasswordPolicy
-	231,  // 1004: confirmate.ontology.v1.Resource.resource_group:type_name -> confirmate.ontology.v1.ResourceGroup
-	24,   // 1005: confirmate.ontology.v1.Resource.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
-	77,   // 1006: confirmate.ontology.v1.Resource.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
-	101,  // 1007: confirmate.ontology.v1.Resource.file_storage:type_name -> confirmate.ontology.v1.FileStorage
-	190,  // 1008: confirmate.ontology.v1.Resource.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
-	45,   // 1009: confirmate.ontology.v1.Resource.configuration:type_name -> confirmate.ontology.v1.Configuration
-	47,   // 1010: confirmate.ontology.v1.Resource.configuration_group:type_name -> confirmate.ontology.v1.ConfigurationGroup
-	48,   // 1011: confirmate.ontology.v1.Resource.configuration_group_source:type_name -> confirmate.ontology.v1.ConfigurationGroupSource
-	50,   // 1012: confirmate.ontology.v1.Resource.configuration_option:type_name -> confirmate.ontology.v1.ConfigurationOption
-	51,   // 1013: confirmate.ontology.v1.Resource.configuration_option_source:type_name -> confirmate.ontology.v1.ConfigurationOptionSource
-	52,   // 1014: confirmate.ontology.v1.Resource.configuration_source:type_name -> confirmate.ontology.v1.ConfigurationSource
-	58,   // 1015: confirmate.ontology.v1.Resource.context:type_name -> confirmate.ontology.v1.Context
-	46,   // 1016: confirmate.ontology.v1.Resource.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
-	67,   // 1017: confirmate.ontology.v1.Resource.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
-	83,   // 1018: confirmate.ontology.v1.Resource.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
-	88,   // 1019: confirmate.ontology.v1.Resource.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
-	228,  // 1020: confirmate.ontology.v1.Resource.report_document:type_name -> confirmate.ontology.v1.ReportDocument
-	159,  // 1021: confirmate.ontology.v1.Resource.log_document:type_name -> confirmate.ontology.v1.LogDocument
-	203,  // 1022: confirmate.ontology.v1.Resource.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
-	209,  // 1023: confirmate.ontology.v1.Resource.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
-	236,  // 1024: confirmate.ontology.v1.Resource.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
-	241,  // 1025: confirmate.ontology.v1.Resource.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
-	248,  // 1026: confirmate.ontology.v1.Resource.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
-	263,  // 1027: confirmate.ontology.v1.Resource.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
-	97,   // 1028: confirmate.ontology.v1.Resource.file:type_name -> confirmate.ontology.v1.File
-	98,   // 1029: confirmate.ontology.v1.Resource.file_handle:type_name -> confirmate.ontology.v1.FileHandle
-	168,  // 1030: confirmate.ontology.v1.Resource.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
-	169,  // 1031: confirmate.ontology.v1.Resource.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
-	59,   // 1032: confirmate.ontology.v1.Resource.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
-	6,    // 1033: confirmate.ontology.v1.Resource.and_rule:type_name -> confirmate.ontology.v1.AndRule
-	258,  // 1034: confirmate.ontology.v1.Resource.token:type_name -> confirmate.ontology.v1.Token
-	266,  // 1035: confirmate.ontology.v1.Resource.value:type_name -> confirmate.ontology.v1.Value
-	174,  // 1036: confirmate.ontology.v1.Resource.memory:type_name -> confirmate.ontology.v1.Memory
-	208,  // 1037: confirmate.ontology.v1.Resource.product:type_name -> confirmate.ontology.v1.Product
-	8,    // 1038: confirmate.ontology.v1.Resource.application:type_name -> confirmate.ontology.v1.Application
-	149,  // 1039: confirmate.ontology.v1.Resource.library:type_name -> confirmate.ontology.v1.Library
-	197,  // 1040: confirmate.ontology.v1.Resource.package:type_name -> confirmate.ontology.v1.Package
-	253,  // 1041: confirmate.ontology.v1.Resource.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
-	4,    // 1042: confirmate.ontology.v1.Resource.agnostic:type_name -> confirmate.ontology.v1.Agnostic
-	69,   // 1043: confirmate.ontology.v1.Resource.darwin:type_name -> confirmate.ontology.v1.Darwin
-	196,  // 1044: confirmate.ontology.v1.Resource.posix:type_name -> confirmate.ontology.v1.POSIX
-	273,  // 1045: confirmate.ontology.v1.Resource.win32:type_name -> confirmate.ontology.v1.Win32
-	355,  // 1046: confirmate.ontology.v1.ResourceGroup.creation_time:type_name -> google.protobuf.Timestamp
-	338,  // 1047: confirmate.ontology.v1.ResourceGroup.labels:type_name -> confirmate.ontology.v1.ResourceGroup.LabelsEntry
-	31,   // 1048: confirmate.ontology.v1.ResourceGroup.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1049: confirmate.ontology.v1.ResourceGroup.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1050: confirmate.ontology.v1.ResourceGroup.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1051: confirmate.ontology.v1.ResourceGroup.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1052: confirmate.ontology.v1.ResourceGroup.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1053: confirmate.ontology.v1.ResourceGroup.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	356,  // 1054: confirmate.ontology.v1.ResourceLogging.retention_period:type_name -> google.protobuf.Duration
-	355,  // 1055: confirmate.ontology.v1.RoleAssignment.creation_time:type_name -> google.protobuf.Timestamp
-	339,  // 1056: confirmate.ontology.v1.RoleAssignment.labels:type_name -> confirmate.ontology.v1.RoleAssignment.LabelsEntry
-	18,   // 1057: confirmate.ontology.v1.RoleAssignment.authorization:type_name -> confirmate.ontology.v1.Authorization
-	31,   // 1058: confirmate.ontology.v1.RoleAssignment.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1059: confirmate.ontology.v1.RoleAssignment.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1060: confirmate.ontology.v1.RoleAssignment.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1061: confirmate.ontology.v1.RoleAssignment.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1062: confirmate.ontology.v1.RoleAssignment.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1063: confirmate.ontology.v1.RoleAssignment.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 1064: confirmate.ontology.v1.SBOMDocument.creation_time:type_name -> google.protobuf.Timestamp
-	340,  // 1065: confirmate.ontology.v1.SBOMDocument.labels:type_name -> confirmate.ontology.v1.SBOMDocument.LabelsEntry
-	64,   // 1066: confirmate.ontology.v1.SBOMDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 1067: confirmate.ontology.v1.SBOMDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 1068: confirmate.ontology.v1.SBOMDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 1069: confirmate.ontology.v1.SBOMDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 1070: confirmate.ontology.v1.SBOMDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	94,   // 1071: confirmate.ontology.v1.SchemaValidation.errors:type_name -> confirmate.ontology.v1.Error
-	355,  // 1072: confirmate.ontology.v1.Secret.creation_time:type_name -> google.protobuf.Timestamp
-	355,  // 1073: confirmate.ontology.v1.Secret.expiration_date:type_name -> google.protobuf.Timestamp
-	341,  // 1074: confirmate.ontology.v1.Secret.labels:type_name -> confirmate.ontology.v1.Secret.LabelsEntry
-	355,  // 1075: confirmate.ontology.v1.Secret.not_before_date:type_name -> google.protobuf.Timestamp
-	31,   // 1076: confirmate.ontology.v1.Secret.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	33,   // 1077: confirmate.ontology.v1.Secret.based_on:type_name -> confirmate.ontology.v1.Cipher
-	110,  // 1078: confirmate.ontology.v1.Secret.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	37,   // 1079: confirmate.ontology.v1.Secret.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
-	165,  // 1080: confirmate.ontology.v1.Secret.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1081: confirmate.ontology.v1.Secret.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1082: confirmate.ontology.v1.Secret.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1083: confirmate.ontology.v1.Secret.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	62,   // 1084: confirmate.ontology.v1.SecretOperation.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
-	113,  // 1085: confirmate.ontology.v1.SecretOperation.get_secret:type_name -> confirmate.ontology.v1.GetSecret
-	355,  // 1086: confirmate.ontology.v1.SecurityAdvisoryDocument.creation_time:type_name -> google.protobuf.Timestamp
-	342,  // 1087: confirmate.ontology.v1.SecurityAdvisoryDocument.labels:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument.LabelsEntry
-	64,   // 1088: confirmate.ontology.v1.SecurityAdvisoryDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 1089: confirmate.ontology.v1.SecurityAdvisoryDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 1090: confirmate.ontology.v1.SecurityAdvisoryDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 1091: confirmate.ontology.v1.SecurityAdvisoryDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 1092: confirmate.ontology.v1.SecurityAdvisoryDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	271,  // 1093: confirmate.ontology.v1.SecurityAdvisoryDocument.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
-	355,  // 1094: confirmate.ontology.v1.SecurityAdvisoryService.creation_time:type_name -> google.protobuf.Timestamp
-	343,  // 1095: confirmate.ontology.v1.SecurityAdvisoryService.labels:type_name -> confirmate.ontology.v1.SecurityAdvisoryService.LabelsEntry
-	31,   // 1096: confirmate.ontology.v1.SecurityAdvisoryService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1097: confirmate.ontology.v1.SecurityAdvisoryService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1098: confirmate.ontology.v1.SecurityAdvisoryService.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1099: confirmate.ontology.v1.SecurityAdvisoryService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1100: confirmate.ontology.v1.SecurityAdvisoryService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	242,  // 1101: confirmate.ontology.v1.SecurityAdvisoryService.security_advisory_feeds:type_name -> confirmate.ontology.v1.SecurityAdvisoryFeed
-	260,  // 1102: confirmate.ontology.v1.SecurityAdvisoryService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	262,  // 1103: confirmate.ontology.v1.SecurityAdvisoryService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	7,    // 1104: confirmate.ontology.v1.SecurityFeature.anomaly_detection:type_name -> confirmate.ontology.v1.AnomalyDetection
-	10,   // 1105: confirmate.ontology.v1.SecurityFeature.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
-	41,   // 1106: confirmate.ontology.v1.SecurityFeature.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
-	3,    // 1107: confirmate.ontology.v1.SecurityFeature.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	9,    // 1108: confirmate.ontology.v1.SecurityFeature.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
-	26,   // 1109: confirmate.ontology.v1.SecurityFeature.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
-	188,  // 1110: confirmate.ontology.v1.SecurityFeature.os_logging:type_name -> confirmate.ontology.v1.OSLogging
-	232,  // 1111: confirmate.ontology.v1.SecurityFeature.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	172,  // 1112: confirmate.ontology.v1.SecurityFeature.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	262,  // 1113: confirmate.ontology.v1.SecurityFeature.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	30,   // 1114: confirmate.ontology.v1.SecurityFeature.certificate_based_authentication:type_name -> confirmate.ontology.v1.CertificateBasedAuthentication
-	141,  // 1115: confirmate.ontology.v1.SecurityFeature.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
-	180,  // 1116: confirmate.ontology.v1.SecurityFeature.multi_factor_authentiation:type_name -> confirmate.ontology.v1.MultiFactorAuthentiation
-	187,  // 1117: confirmate.ontology.v1.SecurityFeature.no_authentication:type_name -> confirmate.ontology.v1.NoAuthentication
-	189,  // 1118: confirmate.ontology.v1.SecurityFeature.otp_based_authentication:type_name -> confirmate.ontology.v1.OTPBasedAuthentication
-	199,  // 1119: confirmate.ontology.v1.SecurityFeature.password_based_authentication:type_name -> confirmate.ontology.v1.PasswordBasedAuthentication
-	251,  // 1120: confirmate.ontology.v1.SecurityFeature.single_sign_on:type_name -> confirmate.ontology.v1.SingleSignOn
-	0,    // 1121: confirmate.ontology.v1.SecurityFeature.abac:type_name -> confirmate.ontology.v1.ABAC
-	147,  // 1122: confirmate.ontology.v1.SecurityFeature.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
-	272,  // 1123: confirmate.ontology.v1.SecurityFeature.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
-	216,  // 1124: confirmate.ontology.v1.SecurityFeature.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
-	215,  // 1125: confirmate.ontology.v1.SecurityFeature.rbac:type_name -> confirmate.ontology.v1.RBAC
-	23,   // 1126: confirmate.ontology.v1.SecurityFeature.backup:type_name -> confirmate.ontology.v1.Backup
-	68,   // 1127: confirmate.ontology.v1.SecurityFeature.d_do_s_protection:type_name -> confirmate.ontology.v1.DDoSProtection
-	110,  // 1128: confirmate.ontology.v1.SecurityFeature.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	111,  // 1129: confirmate.ontology.v1.SecurityFeature.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
-	158,  // 1130: confirmate.ontology.v1.SecurityFeature.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
-	275,  // 1131: confirmate.ontology.v1.SecurityFeature.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
-	66,   // 1132: confirmate.ontology.v1.SecurityFeature.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
-	81,   // 1133: confirmate.ontology.v1.SecurityFeature.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	173,  // 1134: confirmate.ontology.v1.SecurityFeature.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
-	260,  // 1135: confirmate.ontology.v1.SecurityFeature.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
-	90,   // 1136: confirmate.ontology.v1.SecurityFeature.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	155,  // 1137: confirmate.ontology.v1.SecurityFeature.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
-	225,  // 1138: confirmate.ontology.v1.SecurityFeature.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	20,   // 1139: confirmate.ontology.v1.SecurityFeature.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
-	64,   // 1140: confirmate.ontology.v1.SecurityFeature.cryptographic_hash:type_name -> confirmate.ontology.v1.CryptographicHash
-	132,  // 1141: confirmate.ontology.v1.SecurityFeature.immutability:type_name -> confirmate.ontology.v1.Immutability
-	249,  // 1142: confirmate.ontology.v1.SecurityFeature.document_signature:type_name -> confirmate.ontology.v1.DocumentSignature
-	250,  // 1143: confirmate.ontology.v1.SecurityFeature.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
-	267,  // 1144: confirmate.ontology.v1.SecurityFeature.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
-	96,   // 1145: confirmate.ontology.v1.SecurityFeature.explainable_results:type_name -> confirmate.ontology.v1.ExplainableResults
-	234,  // 1146: confirmate.ontology.v1.SecurityFeature.robustness_score:type_name -> confirmate.ontology.v1.RobustnessScore
-	355,  // 1147: confirmate.ontology.v1.ServiceMetadataDocument.creation_time:type_name -> google.protobuf.Timestamp
-	344,  // 1148: confirmate.ontology.v1.ServiceMetadataDocument.labels:type_name -> confirmate.ontology.v1.ServiceMetadataDocument.LabelsEntry
-	64,   // 1149: confirmate.ontology.v1.ServiceMetadataDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 1150: confirmate.ontology.v1.ServiceMetadataDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 1151: confirmate.ontology.v1.ServiceMetadataDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 1152: confirmate.ontology.v1.ServiceMetadataDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 1153: confirmate.ontology.v1.ServiceMetadataDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	94,   // 1154: confirmate.ontology.v1.DocumentSignature.errors:type_name -> confirmate.ontology.v1.Error
-	8,    // 1155: confirmate.ontology.v1.Code.application:type_name -> confirmate.ontology.v1.Application
-	149,  // 1156: confirmate.ontology.v1.Code.library:type_name -> confirmate.ontology.v1.Library
-	197,  // 1157: confirmate.ontology.v1.Code.package:type_name -> confirmate.ontology.v1.Package
-	253,  // 1158: confirmate.ontology.v1.Code.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
-	4,    // 1159: confirmate.ontology.v1.Code.agnostic:type_name -> confirmate.ontology.v1.Agnostic
-	69,   // 1160: confirmate.ontology.v1.Code.darwin:type_name -> confirmate.ontology.v1.Darwin
-	196,  // 1161: confirmate.ontology.v1.Code.posix:type_name -> confirmate.ontology.v1.POSIX
-	273,  // 1162: confirmate.ontology.v1.Code.win32:type_name -> confirmate.ontology.v1.Win32
-	355,  // 1163: confirmate.ontology.v1.SourceCodeFile.creation_time:type_name -> google.protobuf.Timestamp
-	345,  // 1164: confirmate.ontology.v1.SourceCodeFile.labels:type_name -> confirmate.ontology.v1.SourceCodeFile.LabelsEntry
-	107,  // 1165: confirmate.ontology.v1.SourceCodeFile.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	24,   // 1166: confirmate.ontology.v1.Storage.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
-	77,   // 1167: confirmate.ontology.v1.Storage.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
-	101,  // 1168: confirmate.ontology.v1.Storage.file_storage:type_name -> confirmate.ontology.v1.FileStorage
-	190,  // 1169: confirmate.ontology.v1.Storage.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
-	85,   // 1170: confirmate.ontology.v1.StorageService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
-	145,  // 1171: confirmate.ontology.v1.StorageService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
-	181,  // 1172: confirmate.ontology.v1.StorageService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
-	223,  // 1173: confirmate.ontology.v1.StorageService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
-	102,  // 1174: confirmate.ontology.v1.StorageService.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
-	192,  // 1175: confirmate.ontology.v1.StorageService.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
-	133,  // 1176: confirmate.ontology.v1.SymmetricCipher.initialization_vector:type_name -> confirmate.ontology.v1.InitializationVector
-	198,  // 1177: confirmate.ontology.v1.SymmetricCipher.padding:type_name -> confirmate.ontology.v1.Padding
-	355,  // 1178: confirmate.ontology.v1.Token.creation_time:type_name -> google.protobuf.Timestamp
-	346,  // 1179: confirmate.ontology.v1.Token.labels:type_name -> confirmate.ontology.v1.Token.LabelsEntry
-	72,   // 1180: confirmate.ontology.v1.Token.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	22,   // 1181: confirmate.ontology.v1.Training.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
-	246,  // 1182: confirmate.ontology.v1.Training.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
-	33,   // 1183: confirmate.ontology.v1.TransportEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
-	35,   // 1184: confirmate.ontology.v1.TransportEncryption.cipher_suites:type_name -> confirmate.ontology.v1.CipherSuite
-	39,   // 1185: confirmate.ontology.v1.UnlockEncryptedDisk.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	81,   // 1186: confirmate.ontology.v1.UnlockEncryptedDisk.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
-	355,  // 1187: confirmate.ontology.v1.UserInformationAndIntructionDocument.creation_time:type_name -> google.protobuf.Timestamp
-	347,  // 1188: confirmate.ontology.v1.UserInformationAndIntructionDocument.labels:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument.LabelsEntry
-	64,   // 1189: confirmate.ontology.v1.UserInformationAndIntructionDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
-	72,   // 1190: confirmate.ontology.v1.UserInformationAndIntructionDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	249,  // 1191: confirmate.ontology.v1.UserInformationAndIntructionDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
-	238,  // 1192: confirmate.ontology.v1.UserInformationAndIntructionDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
-	244,  // 1193: confirmate.ontology.v1.UserInformationAndIntructionDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
-	355,  // 1194: confirmate.ontology.v1.VMImage.creation_time:type_name -> google.protobuf.Timestamp
-	348,  // 1195: confirmate.ontology.v1.VMImage.labels:type_name -> confirmate.ontology.v1.VMImage.LabelsEntry
-	31,   // 1196: confirmate.ontology.v1.VMImage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1197: confirmate.ontology.v1.VMImage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1198: confirmate.ontology.v1.VMImage.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1199: confirmate.ontology.v1.VMImage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1200: confirmate.ontology.v1.VMImage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1201: confirmate.ontology.v1.VMImage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	17,   // 1202: confirmate.ontology.v1.ValidateJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
-	39,   // 1203: confirmate.ontology.v1.ValidateJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
-	355,  // 1204: confirmate.ontology.v1.Value.creation_time:type_name -> google.protobuf.Timestamp
-	349,  // 1205: confirmate.ontology.v1.Value.labels:type_name -> confirmate.ontology.v1.Value.LabelsEntry
-	72,   // 1206: confirmate.ontology.v1.Value.data_location:type_name -> confirmate.ontology.v1.DataLocation
-	355,  // 1207: confirmate.ontology.v1.VirtualMachine.creation_time:type_name -> google.protobuf.Timestamp
-	350,  // 1208: confirmate.ontology.v1.VirtualMachine.labels:type_name -> confirmate.ontology.v1.VirtualMachine.LabelsEntry
-	3,    // 1209: confirmate.ontology.v1.VirtualMachine.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
-	20,   // 1210: confirmate.ontology.v1.VirtualMachine.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
-	26,   // 1211: confirmate.ontology.v1.VirtualMachine.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
-	31,   // 1212: confirmate.ontology.v1.VirtualMachine.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	90,   // 1213: confirmate.ontology.v1.VirtualMachine.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
-	110,  // 1214: confirmate.ontology.v1.VirtualMachine.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1215: confirmate.ontology.v1.VirtualMachine.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1216: confirmate.ontology.v1.VirtualMachine.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	188,  // 1217: confirmate.ontology.v1.VirtualMachine.os_logging:type_name -> confirmate.ontology.v1.OSLogging
-	219,  // 1218: confirmate.ontology.v1.VirtualMachine.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	225,  // 1219: confirmate.ontology.v1.VirtualMachine.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
-	232,  // 1220: confirmate.ontology.v1.VirtualMachine.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
-	262,  // 1221: confirmate.ontology.v1.VirtualMachine.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 1222: confirmate.ontology.v1.VirtualNetwork.creation_time:type_name -> google.protobuf.Timestamp
-	351,  // 1223: confirmate.ontology.v1.VirtualNetwork.labels:type_name -> confirmate.ontology.v1.VirtualNetwork.LabelsEntry
-	31,   // 1224: confirmate.ontology.v1.VirtualNetwork.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1225: confirmate.ontology.v1.VirtualNetwork.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1226: confirmate.ontology.v1.VirtualNetwork.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1227: confirmate.ontology.v1.VirtualNetwork.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1228: confirmate.ontology.v1.VirtualNetwork.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1229: confirmate.ontology.v1.VirtualNetwork.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 1230: confirmate.ontology.v1.VirtualSubNetwork.creation_time:type_name -> google.protobuf.Timestamp
-	352,  // 1231: confirmate.ontology.v1.VirtualSubNetwork.labels:type_name -> confirmate.ontology.v1.VirtualSubNetwork.LabelsEntry
-	31,   // 1232: confirmate.ontology.v1.VirtualSubNetwork.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1233: confirmate.ontology.v1.VirtualSubNetwork.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1234: confirmate.ontology.v1.VirtualSubNetwork.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1235: confirmate.ontology.v1.VirtualSubNetwork.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1236: confirmate.ontology.v1.VirtualSubNetwork.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1237: confirmate.ontology.v1.VirtualSubNetwork.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	355,  // 1238: confirmate.ontology.v1.Win32.creation_time:type_name -> google.protobuf.Timestamp
-	353,  // 1239: confirmate.ontology.v1.Win32.labels:type_name -> confirmate.ontology.v1.Win32.LabelsEntry
-	107,  // 1240: confirmate.ontology.v1.Win32.functionalities:type_name -> confirmate.ontology.v1.Functionality
-	355,  // 1241: confirmate.ontology.v1.Workflow.creation_time:type_name -> google.protobuf.Timestamp
-	354,  // 1242: confirmate.ontology.v1.Workflow.labels:type_name -> confirmate.ontology.v1.Workflow.LabelsEntry
-	31,   // 1243: confirmate.ontology.v1.Workflow.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
-	110,  // 1244: confirmate.ontology.v1.Workflow.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
-	165,  // 1245: confirmate.ontology.v1.Workflow.loggings:type_name -> confirmate.ontology.v1.Logging
-	172,  // 1246: confirmate.ontology.v1.Workflow.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
-	219,  // 1247: confirmate.ontology.v1.Workflow.redundancies:type_name -> confirmate.ontology.v1.Redundancy
-	262,  // 1248: confirmate.ontology.v1.Workflow.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
-	110,  // 1249: confirmate.ontology.v1.ZoneRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
-	357,  // 1250: confirmate.ontology.v1.resource_type_names:extendee -> google.protobuf.MessageOptions
-	1251, // [1251:1251] is the sub-list for method output_type
-	1251, // [1251:1251] is the sub-list for method input_type
-	1251, // [1251:1251] is the sub-list for extension type_name
-	1250, // [1250:1251] is the sub-list for extension extendee
-	0,    // [0:1250] is the sub-list for field type_name
+	252,  // 16: confirmate.ontology.v1.Agnostic.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	39,   // 17: confirmate.ontology.v1.Allocate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 18: confirmate.ontology.v1.AndRule.creation_time:type_name -> google.protobuf.Timestamp
+	279,  // 19: confirmate.ontology.v1.AndRule.labels:type_name -> confirmate.ontology.v1.AndRule.LabelsEntry
+	72,   // 20: confirmate.ontology.v1.AndRule.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	9,    // 21: confirmate.ontology.v1.AnomalyDetection.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
+	356,  // 22: confirmate.ontology.v1.Application.creation_time:type_name -> google.protobuf.Timestamp
+	280,  // 23: confirmate.ontology.v1.Application.labels:type_name -> confirmate.ontology.v1.Application.LabelsEntry
+	20,   // 24: confirmate.ontology.v1.Application.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
+	107,  // 25: confirmate.ontology.v1.Application.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 26: confirmate.ontology.v1.Application.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	357,  // 27: confirmate.ontology.v1.ApplicationLogging.retention_period:type_name -> google.protobuf.Duration
+	198,  // 28: confirmate.ontology.v1.AsymmetricCipher.padding:type_name -> confirmate.ontology.v1.Padding
+	66,   // 29: confirmate.ontology.v1.AtRestEncryption.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
+	81,   // 30: confirmate.ontology.v1.AtRestEncryption.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	173,  // 31: confirmate.ontology.v1.AtRestEncryption.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
+	155,  // 32: confirmate.ontology.v1.Attestation.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
+	225,  // 33: confirmate.ontology.v1.Attestation.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	252,  // 34: confirmate.ontology.v1.Attestation.software_attestation:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	7,    // 35: confirmate.ontology.v1.Auditing.anomaly_detection:type_name -> confirmate.ontology.v1.AnomalyDetection
+	10,   // 36: confirmate.ontology.v1.Auditing.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
+	41,   // 37: confirmate.ontology.v1.Auditing.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
+	3,    // 38: confirmate.ontology.v1.Auditing.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	9,    // 39: confirmate.ontology.v1.Auditing.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
+	26,   // 40: confirmate.ontology.v1.Auditing.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
+	188,  // 41: confirmate.ontology.v1.Auditing.os_logging:type_name -> confirmate.ontology.v1.OSLogging
+	232,  // 42: confirmate.ontology.v1.Auditing.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	172,  // 43: confirmate.ontology.v1.Auditing.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	263,  // 44: confirmate.ontology.v1.Auditing.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	17,   // 45: confirmate.ontology.v1.Authenticate.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	39,   // 46: confirmate.ontology.v1.Authenticate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	15,   // 47: confirmate.ontology.v1.AuthenticationOperation.authenticate:type_name -> confirmate.ontology.v1.Authenticate
+	19,   // 48: confirmate.ontology.v1.AuthenticationOperation.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
+	139,  // 49: confirmate.ontology.v1.AuthenticationOperation.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
+	266,  // 50: confirmate.ontology.v1.AuthenticationOperation.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
+	30,   // 51: confirmate.ontology.v1.Authenticity.certificate_based_authentication:type_name -> confirmate.ontology.v1.CertificateBasedAuthentication
+	141,  // 52: confirmate.ontology.v1.Authenticity.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
+	180,  // 53: confirmate.ontology.v1.Authenticity.multi_factor_authentiation:type_name -> confirmate.ontology.v1.MultiFactorAuthentiation
+	187,  // 54: confirmate.ontology.v1.Authenticity.no_authentication:type_name -> confirmate.ontology.v1.NoAuthentication
+	189,  // 55: confirmate.ontology.v1.Authenticity.otp_based_authentication:type_name -> confirmate.ontology.v1.OTPBasedAuthentication
+	199,  // 56: confirmate.ontology.v1.Authenticity.password_based_authentication:type_name -> confirmate.ontology.v1.PasswordBasedAuthentication
+	251,  // 57: confirmate.ontology.v1.Authenticity.single_sign_on:type_name -> confirmate.ontology.v1.SingleSignOn
+	0,    // 58: confirmate.ontology.v1.Authorization.abac:type_name -> confirmate.ontology.v1.ABAC
+	147,  // 59: confirmate.ontology.v1.Authorization.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
+	273,  // 60: confirmate.ontology.v1.Authorization.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
+	216,  // 61: confirmate.ontology.v1.Authorization.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
+	215,  // 62: confirmate.ontology.v1.Authorization.rbac:type_name -> confirmate.ontology.v1.RBAC
+	17,   // 63: confirmate.ontology.v1.AuthorizeJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	39,   // 64: confirmate.ontology.v1.AuthorizeJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	357,  // 65: confirmate.ontology.v1.AutomaticUpdates.interval:type_name -> google.protobuf.Duration
+	23,   // 66: confirmate.ontology.v1.Availability.backup:type_name -> confirmate.ontology.v1.Backup
+	68,   // 67: confirmate.ontology.v1.Availability.d_do_s_protection:type_name -> confirmate.ontology.v1.DDoSProtection
+	110,  // 68: confirmate.ontology.v1.Availability.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	111,  // 69: confirmate.ontology.v1.Availability.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
+	158,  // 70: confirmate.ontology.v1.Availability.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
+	276,  // 71: confirmate.ontology.v1.Availability.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
+	357,  // 72: confirmate.ontology.v1.Backup.interval:type_name -> google.protobuf.Duration
+	357,  // 73: confirmate.ontology.v1.Backup.retention_period:type_name -> google.protobuf.Duration
+	261,  // 74: confirmate.ontology.v1.Backup.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	356,  // 75: confirmate.ontology.v1.BlockStorage.creation_time:type_name -> google.protobuf.Timestamp
+	281,  // 76: confirmate.ontology.v1.BlockStorage.labels:type_name -> confirmate.ontology.v1.BlockStorage.LabelsEntry
+	3,    // 77: confirmate.ontology.v1.BlockStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	12,   // 78: confirmate.ontology.v1.BlockStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
+	23,   // 79: confirmate.ontology.v1.BlockStorage.backups:type_name -> confirmate.ontology.v1.Backup
+	31,   // 80: confirmate.ontology.v1.BlockStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 81: confirmate.ontology.v1.BlockStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	132,  // 82: confirmate.ontology.v1.BlockStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
+	165,  // 83: confirmate.ontology.v1.BlockStorage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 84: confirmate.ontology.v1.BlockStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 85: confirmate.ontology.v1.BlockStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	232,  // 86: confirmate.ontology.v1.BlockStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 87: confirmate.ontology.v1.BlockStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	39,   // 88: confirmate.ontology.v1.BlockStorageOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	357,  // 89: confirmate.ontology.v1.BootLogging.retention_period:type_name -> google.protobuf.Duration
+	140,  // 90: confirmate.ontology.v1.CICDService.job:type_name -> confirmate.ontology.v1.Job
+	275,  // 91: confirmate.ontology.v1.CICDService.workflow:type_name -> confirmate.ontology.v1.Workflow
+	356,  // 92: confirmate.ontology.v1.Certificate.creation_time:type_name -> google.protobuf.Timestamp
+	356,  // 93: confirmate.ontology.v1.Certificate.expiration_date:type_name -> google.protobuf.Timestamp
+	282,  // 94: confirmate.ontology.v1.Certificate.labels:type_name -> confirmate.ontology.v1.Certificate.LabelsEntry
+	356,  // 95: confirmate.ontology.v1.Certificate.not_before_date:type_name -> google.protobuf.Timestamp
+	31,   // 96: confirmate.ontology.v1.Certificate.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 97: confirmate.ontology.v1.Certificate.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	37,   // 98: confirmate.ontology.v1.Certificate.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
+	165,  // 99: confirmate.ontology.v1.Certificate.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 100: confirmate.ontology.v1.Certificate.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 101: confirmate.ontology.v1.Certificate.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 102: confirmate.ontology.v1.Certificate.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	229,  // 103: confirmate.ontology.v1.ChangeAndConfigurationManagement.request_for_change:type_name -> confirmate.ontology.v1.RequestForChange
+	39,   // 104: confirmate.ontology.v1.CheckAccess.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	207,  // 105: confirmate.ontology.v1.CheckAccess.protected_asset:type_name -> confirmate.ontology.v1.ProtectedAsset
+	11,   // 106: confirmate.ontology.v1.Cipher.asymmetric_cipher:type_name -> confirmate.ontology.v1.AsymmetricCipher
+	128,  // 107: confirmate.ontology.v1.Cipher.hybrid_cipher:type_name -> confirmate.ontology.v1.HybridCipher
+	257,  // 108: confirmate.ontology.v1.Cipher.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
+	79,   // 109: confirmate.ontology.v1.CipherOperation.decryption:type_name -> confirmate.ontology.v1.Decryption
+	33,   // 110: confirmate.ontology.v1.CipherSuite.ciphers:type_name -> confirmate.ontology.v1.Cipher
+	2,    // 111: confirmate.ontology.v1.Infrastructure.account:type_name -> confirmate.ontology.v1.Account
+	140,  // 112: confirmate.ontology.v1.Infrastructure.job:type_name -> confirmate.ontology.v1.Job
+	275,  // 113: confirmate.ontology.v1.Infrastructure.workflow:type_name -> confirmate.ontology.v1.Workflow
+	40,   // 114: confirmate.ontology.v1.Infrastructure.code_repository:type_name -> confirmate.ontology.v1.CodeRepository
+	54,   // 115: confirmate.ontology.v1.Infrastructure.container:type_name -> confirmate.ontology.v1.Container
+	105,  // 116: confirmate.ontology.v1.Infrastructure.function:type_name -> confirmate.ontology.v1.Function
+	214,  // 117: confirmate.ontology.v1.Infrastructure.qpu:type_name -> confirmate.ontology.v1.QPU
+	269,  // 118: confirmate.ontology.v1.Infrastructure.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
+	56,   // 119: confirmate.ontology.v1.Infrastructure.container_orchestration:type_name -> confirmate.ontology.v1.ContainerOrchestration
+	57,   // 120: confirmate.ontology.v1.Infrastructure.container_registry:type_name -> confirmate.ontology.v1.ContainerRegistry
+	29,   // 121: confirmate.ontology.v1.Infrastructure.certificate:type_name -> confirmate.ontology.v1.Certificate
+	143,  // 122: confirmate.ontology.v1.Infrastructure.key:type_name -> confirmate.ontology.v1.Key
+	239,  // 123: confirmate.ontology.v1.Infrastructure.secret:type_name -> confirmate.ontology.v1.Secret
+	130,  // 124: confirmate.ontology.v1.Infrastructure.identity:type_name -> confirmate.ontology.v1.Identity
+	235,  // 125: confirmate.ontology.v1.Infrastructure.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
+	55,   // 126: confirmate.ontology.v1.Infrastructure.container_image:type_name -> confirmate.ontology.v1.ContainerImage
+	265,  // 127: confirmate.ontology.v1.Infrastructure.vm_image:type_name -> confirmate.ontology.v1.VMImage
+	80,   // 128: confirmate.ontology.v1.Infrastructure.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
+	177,  // 129: confirmate.ontology.v1.Infrastructure.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
+	146,  // 130: confirmate.ontology.v1.Infrastructure.key_vault:type_name -> confirmate.ontology.v1.KeyVault
+	183,  // 131: confirmate.ontology.v1.Infrastructure.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
+	184,  // 132: confirmate.ontology.v1.Infrastructure.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
+	106,  // 133: confirmate.ontology.v1.Infrastructure.function_service:type_name -> confirmate.ontology.v1.FunctionService
+	109,  // 134: confirmate.ontology.v1.Infrastructure.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
+	151,  // 135: confirmate.ontology.v1.Infrastructure.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
+	166,  // 136: confirmate.ontology.v1.Infrastructure.logging_service:type_name -> confirmate.ontology.v1.LoggingService
+	170,  // 137: confirmate.ontology.v1.Infrastructure.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
+	243,  // 138: confirmate.ontology.v1.Infrastructure.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
+	85,   // 139: confirmate.ontology.v1.Infrastructure.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 140: confirmate.ontology.v1.Infrastructure.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 141: confirmate.ontology.v1.Infrastructure.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 142: confirmate.ontology.v1.Infrastructure.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	102,  // 143: confirmate.ontology.v1.Infrastructure.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
+	192,  // 144: confirmate.ontology.v1.Infrastructure.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
+	270,  // 145: confirmate.ontology.v1.Infrastructure.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
+	271,  // 146: confirmate.ontology.v1.Infrastructure.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
+	200,  // 147: confirmate.ontology.v1.Infrastructure.password_policy:type_name -> confirmate.ontology.v1.PasswordPolicy
+	231,  // 148: confirmate.ontology.v1.Infrastructure.resource_group:type_name -> confirmate.ontology.v1.ResourceGroup
+	24,   // 149: confirmate.ontology.v1.Infrastructure.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
+	77,   // 150: confirmate.ontology.v1.Infrastructure.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
+	101,  // 151: confirmate.ontology.v1.Infrastructure.file_storage:type_name -> confirmate.ontology.v1.FileStorage
+	190,  // 152: confirmate.ontology.v1.Infrastructure.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
+	356,  // 153: confirmate.ontology.v1.CodeRepository.creation_time:type_name -> google.protobuf.Timestamp
+	283,  // 154: confirmate.ontology.v1.CodeRepository.labels:type_name -> confirmate.ontology.v1.CodeRepository.LabelsEntry
+	31,   // 155: confirmate.ontology.v1.CodeRepository.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	41,   // 156: confirmate.ontology.v1.CodeRepository.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
+	110,  // 157: confirmate.ontology.v1.CodeRepository.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 158: confirmate.ontology.v1.CodeRepository.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 159: confirmate.ontology.v1.CodeRepository.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 160: confirmate.ontology.v1.CodeRepository.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	250,  // 161: confirmate.ontology.v1.CodeRepository.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
+	263,  // 162: confirmate.ontology.v1.CodeRepository.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	268,  // 163: confirmate.ontology.v1.CodeRepository.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
+	8,    // 164: confirmate.ontology.v1.Component.application:type_name -> confirmate.ontology.v1.Application
+	149,  // 165: confirmate.ontology.v1.Component.library:type_name -> confirmate.ontology.v1.Library
+	54,   // 166: confirmate.ontology.v1.Compute.container:type_name -> confirmate.ontology.v1.Container
+	105,  // 167: confirmate.ontology.v1.Compute.function:type_name -> confirmate.ontology.v1.Function
+	214,  // 168: confirmate.ontology.v1.Compute.qpu:type_name -> confirmate.ontology.v1.QPU
+	269,  // 169: confirmate.ontology.v1.Compute.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
+	66,   // 170: confirmate.ontology.v1.Confidentiality.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
+	81,   // 171: confirmate.ontology.v1.Confidentiality.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	173,  // 172: confirmate.ontology.v1.Confidentiality.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
+	261,  // 173: confirmate.ontology.v1.Confidentiality.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	90,   // 174: confirmate.ontology.v1.Confidentiality.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	356,  // 175: confirmate.ontology.v1.Configuration.creation_time:type_name -> google.protobuf.Timestamp
+	284,  // 176: confirmate.ontology.v1.Configuration.labels:type_name -> confirmate.ontology.v1.Configuration.LabelsEntry
+	72,   // 177: confirmate.ontology.v1.Configuration.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 178: confirmate.ontology.v1.ConfigurationDocument.creation_time:type_name -> google.protobuf.Timestamp
+	285,  // 179: confirmate.ontology.v1.ConfigurationDocument.labels:type_name -> confirmate.ontology.v1.ConfigurationDocument.LabelsEntry
+	64,   // 180: confirmate.ontology.v1.ConfigurationDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 181: confirmate.ontology.v1.ConfigurationDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 182: confirmate.ontology.v1.ConfigurationDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 183: confirmate.ontology.v1.ConfigurationDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 184: confirmate.ontology.v1.ConfigurationDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	356,  // 185: confirmate.ontology.v1.ConfigurationGroup.creation_time:type_name -> google.protobuf.Timestamp
+	286,  // 186: confirmate.ontology.v1.ConfigurationGroup.labels:type_name -> confirmate.ontology.v1.ConfigurationGroup.LabelsEntry
+	72,   // 187: confirmate.ontology.v1.ConfigurationGroup.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 188: confirmate.ontology.v1.ConfigurationGroupSource.creation_time:type_name -> google.protobuf.Timestamp
+	287,  // 189: confirmate.ontology.v1.ConfigurationGroupSource.labels:type_name -> confirmate.ontology.v1.ConfigurationGroupSource.LabelsEntry
+	72,   // 190: confirmate.ontology.v1.ConfigurationGroupSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	152,  // 191: confirmate.ontology.v1.ConfigurationOperation.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
+	211,  // 192: confirmate.ontology.v1.ConfigurationOperation.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
+	212,  // 193: confirmate.ontology.v1.ConfigurationOperation.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
+	213,  // 194: confirmate.ontology.v1.ConfigurationOperation.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
+	217,  // 195: confirmate.ontology.v1.ConfigurationOperation.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
+	218,  // 196: confirmate.ontology.v1.ConfigurationOperation.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
+	220,  // 197: confirmate.ontology.v1.ConfigurationOperation.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
+	221,  // 198: confirmate.ontology.v1.ConfigurationOperation.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
+	356,  // 199: confirmate.ontology.v1.ConfigurationOption.creation_time:type_name -> google.protobuf.Timestamp
+	288,  // 200: confirmate.ontology.v1.ConfigurationOption.labels:type_name -> confirmate.ontology.v1.ConfigurationOption.LabelsEntry
+	72,   // 201: confirmate.ontology.v1.ConfigurationOption.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 202: confirmate.ontology.v1.ConfigurationOptionSource.creation_time:type_name -> google.protobuf.Timestamp
+	289,  // 203: confirmate.ontology.v1.ConfigurationOptionSource.labels:type_name -> confirmate.ontology.v1.ConfigurationOptionSource.LabelsEntry
+	72,   // 204: confirmate.ontology.v1.ConfigurationOptionSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 205: confirmate.ontology.v1.ConfigurationSource.creation_time:type_name -> google.protobuf.Timestamp
+	290,  // 206: confirmate.ontology.v1.ConfigurationSource.labels:type_name -> confirmate.ontology.v1.ConfigurationSource.LabelsEntry
+	72,   // 207: confirmate.ontology.v1.ConfigurationSource.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 208: confirmate.ontology.v1.Container.creation_time:type_name -> google.protobuf.Timestamp
+	291,  // 209: confirmate.ontology.v1.Container.labels:type_name -> confirmate.ontology.v1.Container.LabelsEntry
+	31,   // 210: confirmate.ontology.v1.Container.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	90,   // 211: confirmate.ontology.v1.Container.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	110,  // 212: confirmate.ontology.v1.Container.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 213: confirmate.ontology.v1.Container.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 214: confirmate.ontology.v1.Container.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 215: confirmate.ontology.v1.Container.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	225,  // 216: confirmate.ontology.v1.Container.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	232,  // 217: confirmate.ontology.v1.Container.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 218: confirmate.ontology.v1.Container.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 219: confirmate.ontology.v1.ContainerImage.creation_time:type_name -> google.protobuf.Timestamp
+	292,  // 220: confirmate.ontology.v1.ContainerImage.labels:type_name -> confirmate.ontology.v1.ContainerImage.LabelsEntry
+	31,   // 221: confirmate.ontology.v1.ContainerImage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 222: confirmate.ontology.v1.ContainerImage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 223: confirmate.ontology.v1.ContainerImage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 224: confirmate.ontology.v1.ContainerImage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 225: confirmate.ontology.v1.ContainerImage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 226: confirmate.ontology.v1.ContainerImage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 227: confirmate.ontology.v1.ContainerOrchestration.creation_time:type_name -> google.protobuf.Timestamp
+	293,  // 228: confirmate.ontology.v1.ContainerOrchestration.labels:type_name -> confirmate.ontology.v1.ContainerOrchestration.LabelsEntry
+	31,   // 229: confirmate.ontology.v1.ContainerOrchestration.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 230: confirmate.ontology.v1.ContainerOrchestration.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 231: confirmate.ontology.v1.ContainerOrchestration.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 232: confirmate.ontology.v1.ContainerOrchestration.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 233: confirmate.ontology.v1.ContainerOrchestration.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	232,  // 234: confirmate.ontology.v1.ContainerOrchestration.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 235: confirmate.ontology.v1.ContainerOrchestration.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 236: confirmate.ontology.v1.ContainerRegistry.creation_time:type_name -> google.protobuf.Timestamp
+	294,  // 237: confirmate.ontology.v1.ContainerRegistry.labels:type_name -> confirmate.ontology.v1.ContainerRegistry.LabelsEntry
+	31,   // 238: confirmate.ontology.v1.ContainerRegistry.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 239: confirmate.ontology.v1.ContainerRegistry.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 240: confirmate.ontology.v1.ContainerRegistry.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 241: confirmate.ontology.v1.ContainerRegistry.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 242: confirmate.ontology.v1.ContainerRegistry.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 243: confirmate.ontology.v1.ContainerRegistry.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 244: confirmate.ontology.v1.Context.creation_time:type_name -> google.protobuf.Timestamp
+	295,  // 245: confirmate.ontology.v1.Context.labels:type_name -> confirmate.ontology.v1.Context.LabelsEntry
+	72,   // 246: confirmate.ontology.v1.Context.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 247: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.creation_time:type_name -> google.protobuf.Timestamp
+	296,  // 248: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.labels:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.LabelsEntry
+	72,   // 249: confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	38,   // 250: confirmate.ontology.v1.Core.cloud_sdk:type_name -> confirmate.ontology.v1.CloudSDK
+	119,  // 251: confirmate.ontology.v1.Core.http_client_library:type_name -> confirmate.ontology.v1.HttpClientLibrary
+	127,  // 252: confirmate.ontology.v1.Core.http_server:type_name -> confirmate.ontology.v1.HttpServer
+	164,  // 253: confirmate.ontology.v1.Core.logger:type_name -> confirmate.ontology.v1.Logger
+	233,  // 254: confirmate.ontology.v1.Core.resource_type:type_name -> confirmate.ontology.v1.ResourceType
+	39,   // 255: confirmate.ontology.v1.CreateEncryptedDisk.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	81,   // 256: confirmate.ontology.v1.CreateEncryptedDisk.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	39,   // 257: confirmate.ontology.v1.CreateSecret.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	29,   // 258: confirmate.ontology.v1.Credential.certificate:type_name -> confirmate.ontology.v1.Certificate
+	143,  // 259: confirmate.ontology.v1.Credential.key:type_name -> confirmate.ontology.v1.Key
+	239,  // 260: confirmate.ontology.v1.Credential.secret:type_name -> confirmate.ontology.v1.Secret
+	94,   // 261: confirmate.ontology.v1.CryptographicHash.errors:type_name -> confirmate.ontology.v1.Error
+	116,  // 262: confirmate.ontology.v1.CryptographicOperation.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
+	33,   // 263: confirmate.ontology.v1.CustomerKeyEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
+	356,  // 264: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.creation_time:type_name -> google.protobuf.Timestamp
+	297,  // 265: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.labels:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.LabelsEntry
+	64,   // 266: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 267: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 268: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 269: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 270: confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	356,  // 271: confirmate.ontology.v1.Darwin.creation_time:type_name -> google.protobuf.Timestamp
+	298,  // 272: confirmate.ontology.v1.Darwin.labels:type_name -> confirmate.ontology.v1.Darwin.LabelsEntry
+	107,  // 273: confirmate.ontology.v1.Darwin.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 274: confirmate.ontology.v1.Darwin.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	45,   // 275: confirmate.ontology.v1.Data.configuration:type_name -> confirmate.ontology.v1.Configuration
+	47,   // 276: confirmate.ontology.v1.Data.configuration_group:type_name -> confirmate.ontology.v1.ConfigurationGroup
+	48,   // 277: confirmate.ontology.v1.Data.configuration_group_source:type_name -> confirmate.ontology.v1.ConfigurationGroupSource
+	50,   // 278: confirmate.ontology.v1.Data.configuration_option:type_name -> confirmate.ontology.v1.ConfigurationOption
+	51,   // 279: confirmate.ontology.v1.Data.configuration_option_source:type_name -> confirmate.ontology.v1.ConfigurationOptionSource
+	52,   // 280: confirmate.ontology.v1.Data.configuration_source:type_name -> confirmate.ontology.v1.ConfigurationSource
+	58,   // 281: confirmate.ontology.v1.Data.context:type_name -> confirmate.ontology.v1.Context
+	46,   // 282: confirmate.ontology.v1.Data.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
+	67,   // 283: confirmate.ontology.v1.Data.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
+	83,   // 284: confirmate.ontology.v1.Data.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
+	88,   // 285: confirmate.ontology.v1.Data.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
+	228,  // 286: confirmate.ontology.v1.Data.report_document:type_name -> confirmate.ontology.v1.ReportDocument
+	159,  // 287: confirmate.ontology.v1.Data.log_document:type_name -> confirmate.ontology.v1.LogDocument
+	203,  // 288: confirmate.ontology.v1.Data.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
+	209,  // 289: confirmate.ontology.v1.Data.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
+	236,  // 290: confirmate.ontology.v1.Data.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
+	241,  // 291: confirmate.ontology.v1.Data.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
+	248,  // 292: confirmate.ontology.v1.Data.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
+	264,  // 293: confirmate.ontology.v1.Data.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
+	97,   // 294: confirmate.ontology.v1.Data.file:type_name -> confirmate.ontology.v1.File
+	98,   // 295: confirmate.ontology.v1.Data.file_handle:type_name -> confirmate.ontology.v1.FileHandle
+	168,  // 296: confirmate.ontology.v1.Data.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
+	169,  // 297: confirmate.ontology.v1.Data.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
+	59,   // 298: confirmate.ontology.v1.Data.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
+	6,    // 299: confirmate.ontology.v1.Data.and_rule:type_name -> confirmate.ontology.v1.AndRule
+	259,  // 300: confirmate.ontology.v1.Data.token:type_name -> confirmate.ontology.v1.Token
+	267,  // 301: confirmate.ontology.v1.Data.value:type_name -> confirmate.ontology.v1.Value
+	156,  // 302: confirmate.ontology.v1.DataLocation.local_data_location:type_name -> confirmate.ontology.v1.LocalDataLocation
+	226,  // 303: confirmate.ontology.v1.DataLocation.remote_data_location:type_name -> confirmate.ontology.v1.RemoteDataLocation
+	39,   // 304: confirmate.ontology.v1.DatabaseConnect.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	73,   // 305: confirmate.ontology.v1.DatabaseOperation.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
+	75,   // 306: confirmate.ontology.v1.DatabaseOperation.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
+	39,   // 307: confirmate.ontology.v1.DatabaseQuery.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	85,   // 308: confirmate.ontology.v1.DatabaseService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 309: confirmate.ontology.v1.DatabaseService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 310: confirmate.ontology.v1.DatabaseService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 311: confirmate.ontology.v1.DatabaseService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	356,  // 312: confirmate.ontology.v1.DatabaseStorage.creation_time:type_name -> google.protobuf.Timestamp
+	299,  // 313: confirmate.ontology.v1.DatabaseStorage.labels:type_name -> confirmate.ontology.v1.DatabaseStorage.LabelsEntry
+	3,    // 314: confirmate.ontology.v1.DatabaseStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	12,   // 315: confirmate.ontology.v1.DatabaseStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
+	23,   // 316: confirmate.ontology.v1.DatabaseStorage.backups:type_name -> confirmate.ontology.v1.Backup
+	31,   // 317: confirmate.ontology.v1.DatabaseStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 318: confirmate.ontology.v1.DatabaseStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	132,  // 319: confirmate.ontology.v1.DatabaseStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
+	165,  // 320: confirmate.ontology.v1.DatabaseStorage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 321: confirmate.ontology.v1.DatabaseStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 322: confirmate.ontology.v1.DatabaseStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	232,  // 323: confirmate.ontology.v1.DatabaseStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 324: confirmate.ontology.v1.DatabaseStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	39,   // 325: confirmate.ontology.v1.DeAllocate.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	33,   // 326: confirmate.ontology.v1.Decryption.cipher:type_name -> confirmate.ontology.v1.Cipher
+	39,   // 327: confirmate.ontology.v1.Decryption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 328: confirmate.ontology.v1.DeviceProvisioningService.creation_time:type_name -> google.protobuf.Timestamp
+	300,  // 329: confirmate.ontology.v1.DeviceProvisioningService.labels:type_name -> confirmate.ontology.v1.DeviceProvisioningService.LabelsEntry
+	31,   // 330: confirmate.ontology.v1.DeviceProvisioningService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 331: confirmate.ontology.v1.DeviceProvisioningService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 332: confirmate.ontology.v1.DeviceProvisioningService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 333: confirmate.ontology.v1.DeviceProvisioningService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 334: confirmate.ontology.v1.DeviceProvisioningService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 335: confirmate.ontology.v1.DeviceProvisioningService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	24,   // 336: confirmate.ontology.v1.DiskEncryption.used_by:type_name -> confirmate.ontology.v1.BlockStorage
+	33,   // 337: confirmate.ontology.v1.DiskEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
+	61,   // 338: confirmate.ontology.v1.DiskEncryptionOperation.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
+	262,  // 339: confirmate.ontology.v1.DiskEncryptionOperation.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
+	356,  // 340: confirmate.ontology.v1.DistributionOfUpdatesDocument.creation_time:type_name -> google.protobuf.Timestamp
+	301,  // 341: confirmate.ontology.v1.DistributionOfUpdatesDocument.labels:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument.LabelsEntry
+	64,   // 342: confirmate.ontology.v1.DistributionOfUpdatesDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 343: confirmate.ontology.v1.DistributionOfUpdatesDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 344: confirmate.ontology.v1.DistributionOfUpdatesDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 345: confirmate.ontology.v1.DistributionOfUpdatesDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 346: confirmate.ontology.v1.DistributionOfUpdatesDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	46,   // 347: confirmate.ontology.v1.Document.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
+	67,   // 348: confirmate.ontology.v1.Document.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
+	83,   // 349: confirmate.ontology.v1.Document.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
+	88,   // 350: confirmate.ontology.v1.Document.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
+	228,  // 351: confirmate.ontology.v1.Document.report_document:type_name -> confirmate.ontology.v1.ReportDocument
+	159,  // 352: confirmate.ontology.v1.Document.log_document:type_name -> confirmate.ontology.v1.LogDocument
+	203,  // 353: confirmate.ontology.v1.Document.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
+	209,  // 354: confirmate.ontology.v1.Document.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
+	236,  // 355: confirmate.ontology.v1.Document.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
+	241,  // 356: confirmate.ontology.v1.Document.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
+	248,  // 357: confirmate.ontology.v1.Document.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
+	264,  // 358: confirmate.ontology.v1.Document.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
+	356,  // 359: confirmate.ontology.v1.DocumentDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
+	302,  // 360: confirmate.ontology.v1.DocumentDatabaseService.labels:type_name -> confirmate.ontology.v1.DocumentDatabaseService.LabelsEntry
+	3,    // 361: confirmate.ontology.v1.DocumentDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	7,    // 362: confirmate.ontology.v1.DocumentDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
+	31,   // 363: confirmate.ontology.v1.DocumentDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 364: confirmate.ontology.v1.DocumentDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 365: confirmate.ontology.v1.DocumentDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 366: confirmate.ontology.v1.DocumentDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 367: confirmate.ontology.v1.DocumentDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 368: confirmate.ontology.v1.DocumentDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 369: confirmate.ontology.v1.DocumentDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 370: confirmate.ontology.v1.DocumentDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	153,  // 371: confirmate.ontology.v1.DynamicLoadingOperation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
+	154,  // 372: confirmate.ontology.v1.DynamicLoadingOperation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
+	356,  // 373: confirmate.ontology.v1.EUDeclarationOfConformity.creation_time:type_name -> google.protobuf.Timestamp
+	303,  // 374: confirmate.ontology.v1.EUDeclarationOfConformity.labels:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity.LabelsEntry
+	64,   // 375: confirmate.ontology.v1.EUDeclarationOfConformity.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 376: confirmate.ontology.v1.EUDeclarationOfConformity.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 377: confirmate.ontology.v1.EUDeclarationOfConformity.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 378: confirmate.ontology.v1.EUDeclarationOfConformity.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 379: confirmate.ontology.v1.EUDeclarationOfConformity.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	66,   // 380: confirmate.ontology.v1.Encryption.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
+	81,   // 381: confirmate.ontology.v1.Encryption.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	173,  // 382: confirmate.ontology.v1.Encryption.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
+	261,  // 383: confirmate.ontology.v1.Encryption.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	39,   // 384: confirmate.ontology.v1.EncryptionOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	89,   // 385: confirmate.ontology.v1.EncryptionOperation.encryption:type_name -> confirmate.ontology.v1.Encryption
+	150,  // 386: confirmate.ontology.v1.EntryPoint.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
+	171,  // 387: confirmate.ontology.v1.EntryPoint.main:type_name -> confirmate.ontology.v1.Main
+	121,  // 388: confirmate.ontology.v1.EntryPoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	39,   // 389: confirmate.ontology.v1.EqualityCheck.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	206,  // 390: confirmate.ontology.v1.EqualityCheck.left_principal:type_name -> confirmate.ontology.v1.Principal
+	206,  // 391: confirmate.ontology.v1.EqualityCheck.right_principal:type_name -> confirmate.ontology.v1.Principal
+	27,   // 392: confirmate.ontology.v1.ExitBoundaryOperation.boundary:type_name -> confirmate.ontology.v1.Boundary
+	39,   // 393: confirmate.ontology.v1.ExitBoundaryOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 394: confirmate.ontology.v1.File.creation_time:type_name -> google.protobuf.Timestamp
+	304,  // 395: confirmate.ontology.v1.File.labels:type_name -> confirmate.ontology.v1.File.LabelsEntry
+	72,   // 396: confirmate.ontology.v1.File.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 397: confirmate.ontology.v1.FileHandle.creation_time:type_name -> google.protobuf.Timestamp
+	305,  // 398: confirmate.ontology.v1.FileHandle.labels:type_name -> confirmate.ontology.v1.FileHandle.LabelsEntry
+	72,   // 399: confirmate.ontology.v1.FileHandle.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	97,   // 400: confirmate.ontology.v1.FileLikeObject.file:type_name -> confirmate.ontology.v1.File
+	98,   // 401: confirmate.ontology.v1.FileLikeObject.file_handle:type_name -> confirmate.ontology.v1.FileHandle
+	39,   // 402: confirmate.ontology.v1.FileOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 403: confirmate.ontology.v1.FileStorage.creation_time:type_name -> google.protobuf.Timestamp
+	306,  // 404: confirmate.ontology.v1.FileStorage.labels:type_name -> confirmate.ontology.v1.FileStorage.LabelsEntry
+	3,    // 405: confirmate.ontology.v1.FileStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	12,   // 406: confirmate.ontology.v1.FileStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
+	23,   // 407: confirmate.ontology.v1.FileStorage.backups:type_name -> confirmate.ontology.v1.Backup
+	31,   // 408: confirmate.ontology.v1.FileStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 409: confirmate.ontology.v1.FileStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	132,  // 410: confirmate.ontology.v1.FileStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
+	165,  // 411: confirmate.ontology.v1.FileStorage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 412: confirmate.ontology.v1.FileStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 413: confirmate.ontology.v1.FileStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	232,  // 414: confirmate.ontology.v1.FileStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 415: confirmate.ontology.v1.FileStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 416: confirmate.ontology.v1.FileStorageService.creation_time:type_name -> google.protobuf.Timestamp
+	307,  // 417: confirmate.ontology.v1.FileStorageService.labels:type_name -> confirmate.ontology.v1.FileStorageService.LabelsEntry
+	3,    // 418: confirmate.ontology.v1.FileStorageService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	31,   // 419: confirmate.ontology.v1.FileStorageService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 420: confirmate.ontology.v1.FileStorageService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 421: confirmate.ontology.v1.FileStorageService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 422: confirmate.ontology.v1.FileStorageService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 423: confirmate.ontology.v1.FileStorageService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 424: confirmate.ontology.v1.FileStorageService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 425: confirmate.ontology.v1.FileStorageService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 426: confirmate.ontology.v1.FileStorageService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	147,  // 427: confirmate.ontology.v1.Firewall.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
+	273,  // 428: confirmate.ontology.v1.Firewall.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
+	38,   // 429: confirmate.ontology.v1.Framework.cloud_sdk:type_name -> confirmate.ontology.v1.CloudSDK
+	119,  // 430: confirmate.ontology.v1.Framework.http_client_library:type_name -> confirmate.ontology.v1.HttpClientLibrary
+	127,  // 431: confirmate.ontology.v1.Framework.http_server:type_name -> confirmate.ontology.v1.HttpServer
+	164,  // 432: confirmate.ontology.v1.Framework.logger:type_name -> confirmate.ontology.v1.Logger
+	356,  // 433: confirmate.ontology.v1.Function.creation_time:type_name -> google.protobuf.Timestamp
+	308,  // 434: confirmate.ontology.v1.Function.labels:type_name -> confirmate.ontology.v1.Function.LabelsEntry
+	31,   // 435: confirmate.ontology.v1.Function.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	90,   // 436: confirmate.ontology.v1.Function.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	110,  // 437: confirmate.ontology.v1.Function.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 438: confirmate.ontology.v1.Function.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 439: confirmate.ontology.v1.Function.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 440: confirmate.ontology.v1.Function.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	225,  // 441: confirmate.ontology.v1.Function.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	232,  // 442: confirmate.ontology.v1.Function.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 443: confirmate.ontology.v1.Function.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 444: confirmate.ontology.v1.FunctionService.creation_time:type_name -> google.protobuf.Timestamp
+	309,  // 445: confirmate.ontology.v1.FunctionService.labels:type_name -> confirmate.ontology.v1.FunctionService.LabelsEntry
+	31,   // 446: confirmate.ontology.v1.FunctionService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 447: confirmate.ontology.v1.FunctionService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 448: confirmate.ontology.v1.FunctionService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 449: confirmate.ontology.v1.FunctionService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 450: confirmate.ontology.v1.FunctionService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 451: confirmate.ontology.v1.FunctionService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 452: confirmate.ontology.v1.FunctionService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	27,   // 453: confirmate.ontology.v1.Functionality.boundary:type_name -> confirmate.ontology.v1.Boundary
+	31,   // 454: confirmate.ontology.v1.Functionality.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	11,   // 455: confirmate.ontology.v1.Functionality.asymmetric_cipher:type_name -> confirmate.ontology.v1.AsymmetricCipher
+	128,  // 456: confirmate.ontology.v1.Functionality.hybrid_cipher:type_name -> confirmate.ontology.v1.HybridCipher
+	257,  // 457: confirmate.ontology.v1.Functionality.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
+	35,   // 458: confirmate.ontology.v1.Functionality.cipher_suite:type_name -> confirmate.ontology.v1.CipherSuite
+	39,   // 459: confirmate.ontology.v1.Functionality.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	156,  // 460: confirmate.ontology.v1.Functionality.local_data_location:type_name -> confirmate.ontology.v1.LocalDataLocation
+	226,  // 461: confirmate.ontology.v1.Functionality.remote_data_location:type_name -> confirmate.ontology.v1.RemoteDataLocation
+	86,   // 462: confirmate.ontology.v1.Functionality.dynamic_loading:type_name -> confirmate.ontology.v1.DynamicLoading
+	150,  // 463: confirmate.ontology.v1.Functionality.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
+	171,  // 464: confirmate.ontology.v1.Functionality.main:type_name -> confirmate.ontology.v1.Main
+	121,  // 465: confirmate.ontology.v1.Functionality.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	94,   // 466: confirmate.ontology.v1.Functionality.error:type_name -> confirmate.ontology.v1.Error
+	53,   // 467: confirmate.ontology.v1.Functionality.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
+	179,  // 468: confirmate.ontology.v1.Functionality.monitoring_procedure:type_name -> confirmate.ontology.v1.MonitoringProcedure
+	22,   // 469: confirmate.ontology.v1.Functionality.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
+	246,  // 470: confirmate.ontology.v1.Functionality.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
+	118,  // 471: confirmate.ontology.v1.Functionality.http_client:type_name -> confirmate.ontology.v1.HttpClient
+	124,  // 472: confirmate.ontology.v1.Functionality.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
+	125,  // 473: confirmate.ontology.v1.Functionality.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
+	133,  // 474: confirmate.ontology.v1.Functionality.initialization_vector:type_name -> confirmate.ontology.v1.InitializationVector
+	134,  // 475: confirmate.ontology.v1.Functionality.input:type_name -> confirmate.ontology.v1.Input
+	144,  // 476: confirmate.ontology.v1.Functionality.key_derivation_function:type_name -> confirmate.ontology.v1.KeyDerivationFunction
+	176,  // 477: confirmate.ontology.v1.Functionality.message_authentication_code:type_name -> confirmate.ontology.v1.MessageAuthenticationCode
+	15,   // 478: confirmate.ontology.v1.Functionality.authenticate:type_name -> confirmate.ontology.v1.Authenticate
+	19,   // 479: confirmate.ontology.v1.Functionality.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
+	139,  // 480: confirmate.ontology.v1.Functionality.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
+	266,  // 481: confirmate.ontology.v1.Functionality.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
+	25,   // 482: confirmate.ontology.v1.Functionality.block_storage_operation:type_name -> confirmate.ontology.v1.BlockStorageOperation
+	79,   // 483: confirmate.ontology.v1.Functionality.decryption:type_name -> confirmate.ontology.v1.Decryption
+	152,  // 484: confirmate.ontology.v1.Functionality.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
+	211,  // 485: confirmate.ontology.v1.Functionality.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
+	212,  // 486: confirmate.ontology.v1.Functionality.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
+	213,  // 487: confirmate.ontology.v1.Functionality.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
+	217,  // 488: confirmate.ontology.v1.Functionality.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
+	218,  // 489: confirmate.ontology.v1.Functionality.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
+	220,  // 490: confirmate.ontology.v1.Functionality.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
+	221,  // 491: confirmate.ontology.v1.Functionality.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
+	116,  // 492: confirmate.ontology.v1.Functionality.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
+	73,   // 493: confirmate.ontology.v1.Functionality.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
+	75,   // 494: confirmate.ontology.v1.Functionality.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
+	61,   // 495: confirmate.ontology.v1.Functionality.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
+	262,  // 496: confirmate.ontology.v1.Functionality.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
+	91,   // 497: confirmate.ontology.v1.Functionality.encryption_operation:type_name -> confirmate.ontology.v1.EncryptionOperation
+	95,   // 498: confirmate.ontology.v1.Functionality.exit_boundary_operation:type_name -> confirmate.ontology.v1.ExitBoundaryOperation
+	100,  // 499: confirmate.ontology.v1.Functionality.file_operation:type_name -> confirmate.ontology.v1.FileOperation
+	112,  // 500: confirmate.ontology.v1.Functionality.get_current_time_operation:type_name -> confirmate.ontology.v1.GetCurrentTimeOperation
+	123,  // 501: confirmate.ontology.v1.Functionality.http_request:type_name -> confirmate.ontology.v1.HttpRequest
+	122,  // 502: confirmate.ontology.v1.Functionality.http_endpoint_operation:type_name -> confirmate.ontology.v1.HttpEndpointOperation
+	222,  // 503: confirmate.ontology.v1.Functionality.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
+	135,  // 504: confirmate.ontology.v1.Functionality.input_validation_operation:type_name -> confirmate.ontology.v1.InputValidationOperation
+	136,  // 505: confirmate.ontology.v1.Functionality.install_update_operation:type_name -> confirmate.ontology.v1.InstallUpdateOperation
+	160,  // 506: confirmate.ontology.v1.Functionality.log_get:type_name -> confirmate.ontology.v1.LogGet
+	163,  // 507: confirmate.ontology.v1.Functionality.log_write:type_name -> confirmate.ontology.v1.LogWrite
+	162,  // 508: confirmate.ontology.v1.Functionality.log_output:type_name -> confirmate.ontology.v1.LogOutput
+	5,    // 509: confirmate.ontology.v1.Functionality.allocate:type_name -> confirmate.ontology.v1.Allocate
+	78,   // 510: confirmate.ontology.v1.Functionality.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
+	153,  // 511: confirmate.ontology.v1.Functionality.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
+	154,  // 512: confirmate.ontology.v1.Functionality.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
+	191,  // 513: confirmate.ontology.v1.Functionality.object_storage_request:type_name -> confirmate.ontology.v1.ObjectStorageRequest
+	93,   // 514: confirmate.ontology.v1.Functionality.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
+	32,   // 515: confirmate.ontology.v1.Functionality.check_access:type_name -> confirmate.ontology.v1.CheckAccess
+	62,   // 516: confirmate.ontology.v1.Functionality.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
+	113,  // 517: confirmate.ontology.v1.Functionality.get_secret:type_name -> confirmate.ontology.v1.GetSecret
+	195,  // 518: confirmate.ontology.v1.Functionality.output:type_name -> confirmate.ontology.v1.Output
+	198,  // 519: confirmate.ontology.v1.Functionality.padding:type_name -> confirmate.ontology.v1.Padding
+	71,   // 520: confirmate.ontology.v1.Functionality.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
+	148,  // 521: confirmate.ontology.v1.Functionality.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
+	182,  // 522: confirmate.ontology.v1.Functionality.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
+	237,  // 523: confirmate.ontology.v1.Functionality.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
+	247,  // 524: confirmate.ontology.v1.Functionality.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
+	206,  // 525: confirmate.ontology.v1.Functionality.principal:type_name -> confirmate.ontology.v1.Principal
+	207,  // 526: confirmate.ontology.v1.Functionality.protected_asset:type_name -> confirmate.ontology.v1.ProtectedAsset
+	229,  // 527: confirmate.ontology.v1.Functionality.request_for_change:type_name -> confirmate.ontology.v1.RequestForChange
+	238,  // 528: confirmate.ontology.v1.Functionality.schema_validation:type_name -> confirmate.ontology.v1.SchemaValidation
+	242,  // 529: confirmate.ontology.v1.Functionality.security_advisory_feed:type_name -> confirmate.ontology.v1.SecurityAdvisoryFeed
+	245,  // 530: confirmate.ontology.v1.Functionality.security_incident:type_name -> confirmate.ontology.v1.SecurityIncident
+	258,  // 531: confirmate.ontology.v1.Functionality.time:type_name -> confirmate.ontology.v1.Time
+	272,  // 532: confirmate.ontology.v1.Functionality.vulnerability:type_name -> confirmate.ontology.v1.Vulnerability
+	228,  // 533: confirmate.ontology.v1.GenericDocument.report_document:type_name -> confirmate.ontology.v1.ReportDocument
+	356,  // 534: confirmate.ontology.v1.GenericNetworkService.creation_time:type_name -> google.protobuf.Timestamp
+	310,  // 535: confirmate.ontology.v1.GenericNetworkService.labels:type_name -> confirmate.ontology.v1.GenericNetworkService.LabelsEntry
+	31,   // 536: confirmate.ontology.v1.GenericNetworkService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 537: confirmate.ontology.v1.GenericNetworkService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 538: confirmate.ontology.v1.GenericNetworkService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 539: confirmate.ontology.v1.GenericNetworkService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 540: confirmate.ontology.v1.GenericNetworkService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 541: confirmate.ontology.v1.GenericNetworkService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 542: confirmate.ontology.v1.GenericNetworkService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	110,  // 543: confirmate.ontology.v1.GeoRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
+	39,   // 544: confirmate.ontology.v1.GetCurrentTimeOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	258,  // 545: confirmate.ontology.v1.GetCurrentTimeOperation.time:type_name -> confirmate.ontology.v1.Time
+	39,   // 546: confirmate.ontology.v1.GetSecret.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	53,   // 547: confirmate.ontology.v1.Governance.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
+	179,  // 548: confirmate.ontology.v1.Governance.monitoring_procedure:type_name -> confirmate.ontology.v1.MonitoringProcedure
+	22,   // 549: confirmate.ontology.v1.Governance.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
+	246,  // 550: confirmate.ontology.v1.Governance.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
+	174,  // 551: confirmate.ontology.v1.Hardware.memory:type_name -> confirmate.ontology.v1.Memory
+	39,   // 552: confirmate.ontology.v1.HashOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	244,  // 553: confirmate.ontology.v1.HashOperation.security_feature:type_name -> confirmate.ontology.v1.SecurityFeature
+	118,  // 554: confirmate.ontology.v1.Http.http_client:type_name -> confirmate.ontology.v1.HttpClient
+	124,  // 555: confirmate.ontology.v1.Http.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
+	125,  // 556: confirmate.ontology.v1.Http.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
+	17,   // 557: confirmate.ontology.v1.HttpClient.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	261,  // 558: confirmate.ontology.v1.HttpClient.uses:type_name -> confirmate.ontology.v1.TransportEncryption
+	123,  // 559: confirmate.ontology.v1.HttpClientOperation.http_request:type_name -> confirmate.ontology.v1.HttpRequest
+	17,   // 560: confirmate.ontology.v1.HttpEndpoint.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	18,   // 561: confirmate.ontology.v1.HttpEndpoint.authorization:type_name -> confirmate.ontology.v1.Authorization
+	124,  // 562: confirmate.ontology.v1.HttpEndpoint.http_request_context:type_name -> confirmate.ontology.v1.HttpRequestContext
+	216,  // 563: confirmate.ontology.v1.HttpEndpoint.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
+	261,  // 564: confirmate.ontology.v1.HttpEndpoint.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	39,   // 565: confirmate.ontology.v1.HttpEndpointOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	117,  // 566: confirmate.ontology.v1.HttpEndpointOperation.http:type_name -> confirmate.ontology.v1.Http
+	39,   // 567: confirmate.ontology.v1.HttpRequest.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	118,  // 568: confirmate.ontology.v1.HttpRequest.http_client:type_name -> confirmate.ontology.v1.HttpClient
+	121,  // 569: confirmate.ontology.v1.HttpRequest.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
+	121,  // 570: confirmate.ontology.v1.HttpRequestHandler.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
+	222,  // 571: confirmate.ontology.v1.HttpRequestHandlerOperation.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
+	125,  // 572: confirmate.ontology.v1.HttpServer.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
+	11,   // 573: confirmate.ontology.v1.HybridCipher.uses:type_name -> confirmate.ontology.v1.AsymmetricCipher
+	144,  // 574: confirmate.ontology.v1.HybridCipher.key_derivation_function:type_name -> confirmate.ontology.v1.KeyDerivationFunction
+	176,  // 575: confirmate.ontology.v1.HybridCipher.message_authentication_code:type_name -> confirmate.ontology.v1.MessageAuthenticationCode
+	198,  // 576: confirmate.ontology.v1.HybridCipher.padding:type_name -> confirmate.ontology.v1.Padding
+	257,  // 577: confirmate.ontology.v1.HybridCipher.symmetric_cipher:type_name -> confirmate.ontology.v1.SymmetricCipher
+	130,  // 578: confirmate.ontology.v1.Identifiable.identity:type_name -> confirmate.ontology.v1.Identity
+	235,  // 579: confirmate.ontology.v1.Identifiable.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
+	356,  // 580: confirmate.ontology.v1.Identity.creation_time:type_name -> google.protobuf.Timestamp
+	311,  // 581: confirmate.ontology.v1.Identity.labels:type_name -> confirmate.ontology.v1.Identity.LabelsEntry
+	356,  // 582: confirmate.ontology.v1.Identity.last_activity:type_name -> google.protobuf.Timestamp
+	18,   // 583: confirmate.ontology.v1.Identity.authorization:type_name -> confirmate.ontology.v1.Authorization
+	31,   // 584: confirmate.ontology.v1.Identity.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 585: confirmate.ontology.v1.Identity.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 586: confirmate.ontology.v1.Identity.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 587: confirmate.ontology.v1.Identity.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 588: confirmate.ontology.v1.Identity.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 589: confirmate.ontology.v1.Identity.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	55,   // 590: confirmate.ontology.v1.Image.container_image:type_name -> confirmate.ontology.v1.ContainerImage
+	265,  // 591: confirmate.ontology.v1.Image.vm_image:type_name -> confirmate.ontology.v1.VMImage
+	39,   // 592: confirmate.ontology.v1.InputValidationOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	134,  // 593: confirmate.ontology.v1.InputValidationOperation.input:type_name -> confirmate.ontology.v1.Input
+	195,  // 594: confirmate.ontology.v1.InputValidationOperation.output:type_name -> confirmate.ontology.v1.Output
+	20,   // 595: confirmate.ontology.v1.InstallUpdateOperation.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
+	39,   // 596: confirmate.ontology.v1.InstallUpdateOperation.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	155,  // 597: confirmate.ontology.v1.Integrity.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
+	225,  // 598: confirmate.ontology.v1.Integrity.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	252,  // 599: confirmate.ontology.v1.Integrity.software_attestation:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	20,   // 600: confirmate.ontology.v1.Integrity.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
+	64,   // 601: confirmate.ontology.v1.Integrity.cryptographic_hash:type_name -> confirmate.ontology.v1.CryptographicHash
+	132,  // 602: confirmate.ontology.v1.Integrity.immutability:type_name -> confirmate.ontology.v1.Immutability
+	249,  // 603: confirmate.ontology.v1.Integrity.document_signature:type_name -> confirmate.ontology.v1.DocumentSignature
+	250,  // 604: confirmate.ontology.v1.Integrity.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
+	268,  // 605: confirmate.ontology.v1.Integrity.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
+	80,   // 606: confirmate.ontology.v1.IoT.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
+	177,  // 607: confirmate.ontology.v1.IoT.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
+	17,   // 608: confirmate.ontology.v1.IssueJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	39,   // 609: confirmate.ontology.v1.IssueJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 610: confirmate.ontology.v1.Job.creation_time:type_name -> google.protobuf.Timestamp
+	312,  // 611: confirmate.ontology.v1.Job.labels:type_name -> confirmate.ontology.v1.Job.LabelsEntry
+	31,   // 612: confirmate.ontology.v1.Job.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 613: confirmate.ontology.v1.Job.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 614: confirmate.ontology.v1.Job.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 615: confirmate.ontology.v1.Job.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 616: confirmate.ontology.v1.Job.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 617: confirmate.ontology.v1.Job.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	141,  // 618: confirmate.ontology.v1.TokenBasedAuthentication.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
+	356,  // 619: confirmate.ontology.v1.Key.creation_time:type_name -> google.protobuf.Timestamp
+	356,  // 620: confirmate.ontology.v1.Key.expiration_date:type_name -> google.protobuf.Timestamp
+	313,  // 621: confirmate.ontology.v1.Key.labels:type_name -> confirmate.ontology.v1.Key.LabelsEntry
+	356,  // 622: confirmate.ontology.v1.Key.not_before_date:type_name -> google.protobuf.Timestamp
+	31,   // 623: confirmate.ontology.v1.Key.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 624: confirmate.ontology.v1.Key.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	37,   // 625: confirmate.ontology.v1.Key.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
+	165,  // 626: confirmate.ontology.v1.Key.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 627: confirmate.ontology.v1.Key.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 628: confirmate.ontology.v1.Key.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 629: confirmate.ontology.v1.Key.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	134,  // 630: confirmate.ontology.v1.KeyDerivationFunction.input:type_name -> confirmate.ontology.v1.Input
+	356,  // 631: confirmate.ontology.v1.KeyValueDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
+	314,  // 632: confirmate.ontology.v1.KeyValueDatabaseService.labels:type_name -> confirmate.ontology.v1.KeyValueDatabaseService.LabelsEntry
+	3,    // 633: confirmate.ontology.v1.KeyValueDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	7,    // 634: confirmate.ontology.v1.KeyValueDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
+	31,   // 635: confirmate.ontology.v1.KeyValueDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 636: confirmate.ontology.v1.KeyValueDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 637: confirmate.ontology.v1.KeyValueDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 638: confirmate.ontology.v1.KeyValueDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 639: confirmate.ontology.v1.KeyValueDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 640: confirmate.ontology.v1.KeyValueDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 641: confirmate.ontology.v1.KeyValueDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 642: confirmate.ontology.v1.KeyValueDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 643: confirmate.ontology.v1.KeyVault.creation_time:type_name -> google.protobuf.Timestamp
+	315,  // 644: confirmate.ontology.v1.KeyVault.labels:type_name -> confirmate.ontology.v1.KeyVault.LabelsEntry
+	31,   // 645: confirmate.ontology.v1.KeyVault.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 646: confirmate.ontology.v1.KeyVault.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 647: confirmate.ontology.v1.KeyVault.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 648: confirmate.ontology.v1.KeyVault.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 649: confirmate.ontology.v1.KeyVault.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 650: confirmate.ontology.v1.KeyVault.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 651: confirmate.ontology.v1.Library.creation_time:type_name -> google.protobuf.Timestamp
+	316,  // 652: confirmate.ontology.v1.Library.labels:type_name -> confirmate.ontology.v1.Library.LabelsEntry
+	107,  // 653: confirmate.ontology.v1.Library.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 654: confirmate.ontology.v1.Library.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	272,  // 655: confirmate.ontology.v1.Library.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
+	193,  // 656: confirmate.ontology.v1.LibraryEntryPoint.used_by:type_name -> confirmate.ontology.v1.OperatingSystemArchitecture
+	356,  // 657: confirmate.ontology.v1.LoadBalancer.creation_time:type_name -> google.protobuf.Timestamp
+	317,  // 658: confirmate.ontology.v1.LoadBalancer.labels:type_name -> confirmate.ontology.v1.LoadBalancer.LabelsEntry
+	1,    // 659: confirmate.ontology.v1.LoadBalancer.access_restriction:type_name -> confirmate.ontology.v1.AccessRestriction
+	31,   // 660: confirmate.ontology.v1.LoadBalancer.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 661: confirmate.ontology.v1.LoadBalancer.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 662: confirmate.ontology.v1.LoadBalancer.http_endpoints:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 663: confirmate.ontology.v1.LoadBalancer.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 664: confirmate.ontology.v1.LoadBalancer.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 665: confirmate.ontology.v1.LoadBalancer.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 666: confirmate.ontology.v1.LoadBalancer.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 667: confirmate.ontology.v1.LoadBalancer.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	39,   // 668: confirmate.ontology.v1.LoadConfiguration.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 669: confirmate.ontology.v1.LoadLibrary.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	92,   // 670: confirmate.ontology.v1.LoadLibrary.entry_points:type_name -> confirmate.ontology.v1.EntryPoint
+	39,   // 671: confirmate.ontology.v1.LoadSymbol.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	12,   // 672: confirmate.ontology.v1.LocalDataLocation.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
+	150,  // 673: confirmate.ontology.v1.LocalEntryPoint.library_entry_point:type_name -> confirmate.ontology.v1.LibraryEntryPoint
+	171,  // 674: confirmate.ontology.v1.LocalEntryPoint.main:type_name -> confirmate.ontology.v1.Main
+	110,  // 675: confirmate.ontology.v1.LocalRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
+	356,  // 676: confirmate.ontology.v1.LogDocument.creation_time:type_name -> google.protobuf.Timestamp
+	318,  // 677: confirmate.ontology.v1.LogDocument.labels:type_name -> confirmate.ontology.v1.LogDocument.LabelsEntry
+	64,   // 678: confirmate.ontology.v1.LogDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 679: confirmate.ontology.v1.LogDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 680: confirmate.ontology.v1.LogDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 681: confirmate.ontology.v1.LogDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 682: confirmate.ontology.v1.LogDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	39,   // 683: confirmate.ontology.v1.LogGet.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	165,  // 684: confirmate.ontology.v1.LogGet.logging:type_name -> confirmate.ontology.v1.Logging
+	160,  // 685: confirmate.ontology.v1.LogOperation.log_get:type_name -> confirmate.ontology.v1.LogGet
+	163,  // 686: confirmate.ontology.v1.LogOperation.log_write:type_name -> confirmate.ontology.v1.LogWrite
+	39,   // 687: confirmate.ontology.v1.LogOutput.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	165,  // 688: confirmate.ontology.v1.LogOutput.logging:type_name -> confirmate.ontology.v1.Logging
+	39,   // 689: confirmate.ontology.v1.LogWrite.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	165,  // 690: confirmate.ontology.v1.LogWrite.logging:type_name -> confirmate.ontology.v1.Logging
+	3,    // 691: confirmate.ontology.v1.Logging.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	9,    // 692: confirmate.ontology.v1.Logging.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
+	26,   // 693: confirmate.ontology.v1.Logging.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
+	188,  // 694: confirmate.ontology.v1.Logging.os_logging:type_name -> confirmate.ontology.v1.OSLogging
+	232,  // 695: confirmate.ontology.v1.Logging.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	356,  // 696: confirmate.ontology.v1.LoggingService.creation_time:type_name -> google.protobuf.Timestamp
+	319,  // 697: confirmate.ontology.v1.LoggingService.labels:type_name -> confirmate.ontology.v1.LoggingService.LabelsEntry
+	31,   // 698: confirmate.ontology.v1.LoggingService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 699: confirmate.ontology.v1.LoggingService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 700: confirmate.ontology.v1.LoggingService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 701: confirmate.ontology.v1.LoggingService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 702: confirmate.ontology.v1.LoggingService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 703: confirmate.ontology.v1.LoggingService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 704: confirmate.ontology.v1.LoggingService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	168,  // 705: confirmate.ontology.v1.MachineLearning.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
+	169,  // 706: confirmate.ontology.v1.MachineLearning.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
+	356,  // 707: confirmate.ontology.v1.MachineLearningDataset.creation_time:type_name -> google.protobuf.Timestamp
+	320,  // 708: confirmate.ontology.v1.MachineLearningDataset.labels:type_name -> confirmate.ontology.v1.MachineLearningDataset.LabelsEntry
+	72,   // 709: confirmate.ontology.v1.MachineLearningDataset.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 710: confirmate.ontology.v1.MachineLearningModel.creation_time:type_name -> google.protobuf.Timestamp
+	321,  // 711: confirmate.ontology.v1.MachineLearningModel.labels:type_name -> confirmate.ontology.v1.MachineLearningModel.LabelsEntry
+	72,   // 712: confirmate.ontology.v1.MachineLearningModel.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	272,  // 713: confirmate.ontology.v1.MachineLearningModel.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
+	356,  // 714: confirmate.ontology.v1.MachineLearningService.creation_time:type_name -> google.protobuf.Timestamp
+	322,  // 715: confirmate.ontology.v1.MachineLearningService.labels:type_name -> confirmate.ontology.v1.MachineLearningService.LabelsEntry
+	31,   // 716: confirmate.ontology.v1.MachineLearningService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 717: confirmate.ontology.v1.MachineLearningService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 718: confirmate.ontology.v1.MachineLearningService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 719: confirmate.ontology.v1.MachineLearningService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 720: confirmate.ontology.v1.MachineLearningService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 721: confirmate.ontology.v1.MachineLearningService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 722: confirmate.ontology.v1.MachineLearningService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	193,  // 723: confirmate.ontology.v1.Main.used_by:type_name -> confirmate.ontology.v1.OperatingSystemArchitecture
+	357,  // 724: confirmate.ontology.v1.MalwareProtection.duration_since_active:type_name -> google.protobuf.Duration
+	9,    // 725: confirmate.ontology.v1.MalwareProtection.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
+	33,   // 726: confirmate.ontology.v1.ManagedKeyEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
+	356,  // 727: confirmate.ontology.v1.Memory.creation_time:type_name -> google.protobuf.Timestamp
+	323,  // 728: confirmate.ontology.v1.Memory.labels:type_name -> confirmate.ontology.v1.Memory.LabelsEntry
+	5,    // 729: confirmate.ontology.v1.MemoryOperation.allocate:type_name -> confirmate.ontology.v1.Allocate
+	78,   // 730: confirmate.ontology.v1.MemoryOperation.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
+	153,  // 731: confirmate.ontology.v1.MemoryOperation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
+	154,  // 732: confirmate.ontology.v1.MemoryOperation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
+	134,  // 733: confirmate.ontology.v1.MessageAuthenticationCode.input:type_name -> confirmate.ontology.v1.Input
+	356,  // 734: confirmate.ontology.v1.MessagingHub.creation_time:type_name -> google.protobuf.Timestamp
+	324,  // 735: confirmate.ontology.v1.MessagingHub.labels:type_name -> confirmate.ontology.v1.MessagingHub.LabelsEntry
+	31,   // 736: confirmate.ontology.v1.MessagingHub.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 737: confirmate.ontology.v1.MessagingHub.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 738: confirmate.ontology.v1.MessagingHub.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 739: confirmate.ontology.v1.MessagingHub.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 740: confirmate.ontology.v1.MessagingHub.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 741: confirmate.ontology.v1.MessagingHub.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	197,  // 742: confirmate.ontology.v1.CodeModule.package:type_name -> confirmate.ontology.v1.Package
+	254,  // 743: confirmate.ontology.v1.CodeModule.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
+	17,   // 744: confirmate.ontology.v1.MultiFactorAuthentiation.authenticities:type_name -> confirmate.ontology.v1.Authenticity
+	356,  // 745: confirmate.ontology.v1.MultiModalDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
+	325,  // 746: confirmate.ontology.v1.MultiModalDatabaseService.labels:type_name -> confirmate.ontology.v1.MultiModalDatabaseService.LabelsEntry
+	3,    // 747: confirmate.ontology.v1.MultiModalDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	7,    // 748: confirmate.ontology.v1.MultiModalDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
+	31,   // 749: confirmate.ontology.v1.MultiModalDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 750: confirmate.ontology.v1.MultiModalDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 751: confirmate.ontology.v1.MultiModalDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 752: confirmate.ontology.v1.MultiModalDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 753: confirmate.ontology.v1.MultiModalDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 754: confirmate.ontology.v1.MultiModalDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 755: confirmate.ontology.v1.MultiModalDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 756: confirmate.ontology.v1.MultiModalDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 757: confirmate.ontology.v1.NetworkInterface.creation_time:type_name -> google.protobuf.Timestamp
+	326,  // 758: confirmate.ontology.v1.NetworkInterface.labels:type_name -> confirmate.ontology.v1.NetworkInterface.LabelsEntry
+	1,    // 759: confirmate.ontology.v1.NetworkInterface.access_restriction:type_name -> confirmate.ontology.v1.AccessRestriction
+	31,   // 760: confirmate.ontology.v1.NetworkInterface.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 761: confirmate.ontology.v1.NetworkInterface.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 762: confirmate.ontology.v1.NetworkInterface.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 763: confirmate.ontology.v1.NetworkInterface.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 764: confirmate.ontology.v1.NetworkInterface.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 765: confirmate.ontology.v1.NetworkInterface.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 766: confirmate.ontology.v1.NetworkSecurityGroup.creation_time:type_name -> google.protobuf.Timestamp
+	327,  // 767: confirmate.ontology.v1.NetworkSecurityGroup.labels:type_name -> confirmate.ontology.v1.NetworkSecurityGroup.LabelsEntry
+	31,   // 768: confirmate.ontology.v1.NetworkSecurityGroup.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 769: confirmate.ontology.v1.NetworkSecurityGroup.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 770: confirmate.ontology.v1.NetworkSecurityGroup.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 771: confirmate.ontology.v1.NetworkSecurityGroup.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 772: confirmate.ontology.v1.NetworkSecurityGroup.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 773: confirmate.ontology.v1.NetworkSecurityGroup.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	106,  // 774: confirmate.ontology.v1.NetworkService.function_service:type_name -> confirmate.ontology.v1.FunctionService
+	109,  // 775: confirmate.ontology.v1.NetworkService.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
+	151,  // 776: confirmate.ontology.v1.NetworkService.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
+	166,  // 777: confirmate.ontology.v1.NetworkService.logging_service:type_name -> confirmate.ontology.v1.LoggingService
+	170,  // 778: confirmate.ontology.v1.NetworkService.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
+	243,  // 779: confirmate.ontology.v1.NetworkService.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
+	85,   // 780: confirmate.ontology.v1.NetworkService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 781: confirmate.ontology.v1.NetworkService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 782: confirmate.ontology.v1.NetworkService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 783: confirmate.ontology.v1.NetworkService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	102,  // 784: confirmate.ontology.v1.NetworkService.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
+	192,  // 785: confirmate.ontology.v1.NetworkService.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
+	183,  // 786: confirmate.ontology.v1.Networking.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
+	184,  // 787: confirmate.ontology.v1.Networking.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
+	106,  // 788: confirmate.ontology.v1.Networking.function_service:type_name -> confirmate.ontology.v1.FunctionService
+	109,  // 789: confirmate.ontology.v1.Networking.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
+	151,  // 790: confirmate.ontology.v1.Networking.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
+	166,  // 791: confirmate.ontology.v1.Networking.logging_service:type_name -> confirmate.ontology.v1.LoggingService
+	170,  // 792: confirmate.ontology.v1.Networking.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
+	243,  // 793: confirmate.ontology.v1.Networking.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
+	85,   // 794: confirmate.ontology.v1.Networking.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 795: confirmate.ontology.v1.Networking.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 796: confirmate.ontology.v1.Networking.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 797: confirmate.ontology.v1.Networking.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	102,  // 798: confirmate.ontology.v1.Networking.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
+	192,  // 799: confirmate.ontology.v1.Networking.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
+	270,  // 800: confirmate.ontology.v1.Networking.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
+	271,  // 801: confirmate.ontology.v1.Networking.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
+	357,  // 802: confirmate.ontology.v1.OSLogging.retention_period:type_name -> google.protobuf.Duration
+	356,  // 803: confirmate.ontology.v1.ObjectStorage.creation_time:type_name -> google.protobuf.Timestamp
+	328,  // 804: confirmate.ontology.v1.ObjectStorage.labels:type_name -> confirmate.ontology.v1.ObjectStorage.LabelsEntry
+	3,    // 805: confirmate.ontology.v1.ObjectStorage.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	12,   // 806: confirmate.ontology.v1.ObjectStorage.at_rest_encryption:type_name -> confirmate.ontology.v1.AtRestEncryption
+	23,   // 807: confirmate.ontology.v1.ObjectStorage.backups:type_name -> confirmate.ontology.v1.Backup
+	31,   // 808: confirmate.ontology.v1.ObjectStorage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 809: confirmate.ontology.v1.ObjectStorage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	132,  // 810: confirmate.ontology.v1.ObjectStorage.immutability:type_name -> confirmate.ontology.v1.Immutability
+	165,  // 811: confirmate.ontology.v1.ObjectStorage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 812: confirmate.ontology.v1.ObjectStorage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 813: confirmate.ontology.v1.ObjectStorage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	232,  // 814: confirmate.ontology.v1.ObjectStorage.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 815: confirmate.ontology.v1.ObjectStorage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	39,   // 816: confirmate.ontology.v1.ObjectStorageRequest.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 817: confirmate.ontology.v1.ObjectStorageService.creation_time:type_name -> google.protobuf.Timestamp
+	329,  // 818: confirmate.ontology.v1.ObjectStorageService.labels:type_name -> confirmate.ontology.v1.ObjectStorageService.LabelsEntry
+	3,    // 819: confirmate.ontology.v1.ObjectStorageService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	31,   // 820: confirmate.ontology.v1.ObjectStorageService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 821: confirmate.ontology.v1.ObjectStorageService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 822: confirmate.ontology.v1.ObjectStorageService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 823: confirmate.ontology.v1.ObjectStorageService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 824: confirmate.ontology.v1.ObjectStorageService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 825: confirmate.ontology.v1.ObjectStorageService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 826: confirmate.ontology.v1.ObjectStorageService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 827: confirmate.ontology.v1.ObjectStorageService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	4,    // 828: confirmate.ontology.v1.OperatingSystemArchitecture.agnostic:type_name -> confirmate.ontology.v1.Agnostic
+	69,   // 829: confirmate.ontology.v1.OperatingSystemArchitecture.darwin:type_name -> confirmate.ontology.v1.Darwin
+	196,  // 830: confirmate.ontology.v1.OperatingSystemArchitecture.posix:type_name -> confirmate.ontology.v1.POSIX
+	274,  // 831: confirmate.ontology.v1.OperatingSystemArchitecture.win32:type_name -> confirmate.ontology.v1.Win32
+	15,   // 832: confirmate.ontology.v1.Operation.authenticate:type_name -> confirmate.ontology.v1.Authenticate
+	19,   // 833: confirmate.ontology.v1.Operation.authorize_jwt:type_name -> confirmate.ontology.v1.AuthorizeJwt
+	139,  // 834: confirmate.ontology.v1.Operation.issue_jwt:type_name -> confirmate.ontology.v1.IssueJwt
+	266,  // 835: confirmate.ontology.v1.Operation.validate_jwt:type_name -> confirmate.ontology.v1.ValidateJwt
+	25,   // 836: confirmate.ontology.v1.Operation.block_storage_operation:type_name -> confirmate.ontology.v1.BlockStorageOperation
+	79,   // 837: confirmate.ontology.v1.Operation.decryption:type_name -> confirmate.ontology.v1.Decryption
+	152,  // 838: confirmate.ontology.v1.Operation.load_configuration:type_name -> confirmate.ontology.v1.LoadConfiguration
+	211,  // 839: confirmate.ontology.v1.Operation.provide_configuration:type_name -> confirmate.ontology.v1.ProvideConfiguration
+	212,  // 840: confirmate.ontology.v1.Operation.provide_configuration_group:type_name -> confirmate.ontology.v1.ProvideConfigurationGroup
+	213,  // 841: confirmate.ontology.v1.Operation.provide_configuration_option:type_name -> confirmate.ontology.v1.ProvideConfigurationOption
+	217,  // 842: confirmate.ontology.v1.Operation.read_configuration_group:type_name -> confirmate.ontology.v1.ReadConfigurationGroup
+	218,  // 843: confirmate.ontology.v1.Operation.read_configuration_option:type_name -> confirmate.ontology.v1.ReadConfigurationOption
+	220,  // 844: confirmate.ontology.v1.Operation.register_configuration_group:type_name -> confirmate.ontology.v1.RegisterConfigurationGroup
+	221,  // 845: confirmate.ontology.v1.Operation.register_configuration_option:type_name -> confirmate.ontology.v1.RegisterConfigurationOption
+	116,  // 846: confirmate.ontology.v1.Operation.hash_operation:type_name -> confirmate.ontology.v1.HashOperation
+	73,   // 847: confirmate.ontology.v1.Operation.database_connect:type_name -> confirmate.ontology.v1.DatabaseConnect
+	75,   // 848: confirmate.ontology.v1.Operation.database_query:type_name -> confirmate.ontology.v1.DatabaseQuery
+	61,   // 849: confirmate.ontology.v1.Operation.create_encrypted_disk:type_name -> confirmate.ontology.v1.CreateEncryptedDisk
+	262,  // 850: confirmate.ontology.v1.Operation.unlock_encrypted_disk:type_name -> confirmate.ontology.v1.UnlockEncryptedDisk
+	91,   // 851: confirmate.ontology.v1.Operation.encryption_operation:type_name -> confirmate.ontology.v1.EncryptionOperation
+	95,   // 852: confirmate.ontology.v1.Operation.exit_boundary_operation:type_name -> confirmate.ontology.v1.ExitBoundaryOperation
+	100,  // 853: confirmate.ontology.v1.Operation.file_operation:type_name -> confirmate.ontology.v1.FileOperation
+	112,  // 854: confirmate.ontology.v1.Operation.get_current_time_operation:type_name -> confirmate.ontology.v1.GetCurrentTimeOperation
+	123,  // 855: confirmate.ontology.v1.Operation.http_request:type_name -> confirmate.ontology.v1.HttpRequest
+	122,  // 856: confirmate.ontology.v1.Operation.http_endpoint_operation:type_name -> confirmate.ontology.v1.HttpEndpointOperation
+	222,  // 857: confirmate.ontology.v1.Operation.register_http_endpoint:type_name -> confirmate.ontology.v1.RegisterHttpEndpoint
+	135,  // 858: confirmate.ontology.v1.Operation.input_validation_operation:type_name -> confirmate.ontology.v1.InputValidationOperation
+	136,  // 859: confirmate.ontology.v1.Operation.install_update_operation:type_name -> confirmate.ontology.v1.InstallUpdateOperation
+	160,  // 860: confirmate.ontology.v1.Operation.log_get:type_name -> confirmate.ontology.v1.LogGet
+	163,  // 861: confirmate.ontology.v1.Operation.log_write:type_name -> confirmate.ontology.v1.LogWrite
+	162,  // 862: confirmate.ontology.v1.Operation.log_output:type_name -> confirmate.ontology.v1.LogOutput
+	5,    // 863: confirmate.ontology.v1.Operation.allocate:type_name -> confirmate.ontology.v1.Allocate
+	78,   // 864: confirmate.ontology.v1.Operation.de_allocate:type_name -> confirmate.ontology.v1.DeAllocate
+	153,  // 865: confirmate.ontology.v1.Operation.load_library:type_name -> confirmate.ontology.v1.LoadLibrary
+	154,  // 866: confirmate.ontology.v1.Operation.load_symbol:type_name -> confirmate.ontology.v1.LoadSymbol
+	191,  // 867: confirmate.ontology.v1.Operation.object_storage_request:type_name -> confirmate.ontology.v1.ObjectStorageRequest
+	93,   // 868: confirmate.ontology.v1.Operation.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
+	32,   // 869: confirmate.ontology.v1.Operation.check_access:type_name -> confirmate.ontology.v1.CheckAccess
+	62,   // 870: confirmate.ontology.v1.Operation.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
+	113,  // 871: confirmate.ontology.v1.Operation.get_secret:type_name -> confirmate.ontology.v1.GetSecret
+	356,  // 872: confirmate.ontology.v1.POSIX.creation_time:type_name -> google.protobuf.Timestamp
+	330,  // 873: confirmate.ontology.v1.POSIX.labels:type_name -> confirmate.ontology.v1.POSIX.LabelsEntry
+	107,  // 874: confirmate.ontology.v1.POSIX.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 875: confirmate.ontology.v1.POSIX.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	356,  // 876: confirmate.ontology.v1.Package.creation_time:type_name -> google.protobuf.Timestamp
+	331,  // 877: confirmate.ontology.v1.Package.labels:type_name -> confirmate.ontology.v1.Package.LabelsEntry
+	107,  // 878: confirmate.ontology.v1.Package.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 879: confirmate.ontology.v1.Package.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	356,  // 880: confirmate.ontology.v1.PasswordPolicy.creation_time:type_name -> google.protobuf.Timestamp
+	332,  // 881: confirmate.ontology.v1.PasswordPolicy.labels:type_name -> confirmate.ontology.v1.PasswordPolicy.LabelsEntry
+	31,   // 882: confirmate.ontology.v1.PasswordPolicy.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 883: confirmate.ontology.v1.PasswordPolicy.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 884: confirmate.ontology.v1.PasswordPolicy.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 885: confirmate.ontology.v1.PasswordPolicy.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 886: confirmate.ontology.v1.PasswordPolicy.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 887: confirmate.ontology.v1.PasswordPolicy.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	71,   // 888: confirmate.ontology.v1.Policies.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
+	148,  // 889: confirmate.ontology.v1.Policies.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
+	182,  // 890: confirmate.ontology.v1.Policies.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
+	237,  // 891: confirmate.ontology.v1.Policies.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
+	247,  // 892: confirmate.ontology.v1.Policies.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
+	59,   // 893: confirmate.ontology.v1.Policy.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
+	356,  // 894: confirmate.ontology.v1.PolicyDocument.creation_time:type_name -> google.protobuf.Timestamp
+	333,  // 895: confirmate.ontology.v1.PolicyDocument.labels:type_name -> confirmate.ontology.v1.PolicyDocument.LabelsEntry
+	10,   // 896: confirmate.ontology.v1.PolicyDocument.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
+	23,   // 897: confirmate.ontology.v1.PolicyDocument.backup:type_name -> confirmate.ontology.v1.Backup
+	36,   // 898: confirmate.ontology.v1.PolicyDocument.cloud_feature:type_name -> confirmate.ontology.v1.CloudFeature
+	64,   // 899: confirmate.ontology.v1.PolicyDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	71,   // 900: confirmate.ontology.v1.PolicyDocument.data_confidentiality_sdn_policy:type_name -> confirmate.ontology.v1.DataConfidentialitySDNPolicy
+	72,   // 901: confirmate.ontology.v1.PolicyDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 902: confirmate.ontology.v1.PolicyDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	114,  // 903: confirmate.ontology.v1.PolicyDocument.governances:type_name -> confirmate.ontology.v1.Governance
+	148,  // 904: confirmate.ontology.v1.PolicyDocument.least_privilege_policy:type_name -> confirmate.ontology.v1.LeastPrivilegePolicy
+	182,  // 905: confirmate.ontology.v1.PolicyDocument.need_to_know_policy:type_name -> confirmate.ontology.v1.NeedToKnowPolicy
+	237,  // 906: confirmate.ontology.v1.PolicyDocument.sdn_function_validation_policy:type_name -> confirmate.ontology.v1.SDNFunctionValidationPolicy
+	238,  // 907: confirmate.ontology.v1.PolicyDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 908: confirmate.ontology.v1.PolicyDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	245,  // 909: confirmate.ontology.v1.PolicyDocument.security_incident:type_name -> confirmate.ontology.v1.SecurityIncident
+	247,  // 910: confirmate.ontology.v1.PolicyDocument.separation_of_duties_policy:type_name -> confirmate.ontology.v1.SeparationOfDutiesPolicy
+	93,   // 911: confirmate.ontology.v1.PolicyOperation.equality_check:type_name -> confirmate.ontology.v1.EqualityCheck
+	6,    // 912: confirmate.ontology.v1.PolicyRule.and_rule:type_name -> confirmate.ontology.v1.AndRule
+	230,  // 913: confirmate.ontology.v1.ProtectedAsset.protects:type_name -> confirmate.ontology.v1.Resource
+	356,  // 914: confirmate.ontology.v1.Product.creation_time:type_name -> google.protobuf.Timestamp
+	334,  // 915: confirmate.ontology.v1.Product.labels:type_name -> confirmate.ontology.v1.Product.LabelsEntry
+	356,  // 916: confirmate.ontology.v1.Product.support_ends:type_name -> google.protobuf.Timestamp
+	53,   // 917: confirmate.ontology.v1.Product.contact_person:type_name -> confirmate.ontology.v1.ContactPerson
+	114,  // 918: confirmate.ontology.v1.Product.governances:type_name -> confirmate.ontology.v1.Governance
+	356,  // 919: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.creation_time:type_name -> google.protobuf.Timestamp
+	335,  // 920: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.labels:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.LabelsEntry
+	64,   // 921: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 922: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 923: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 924: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 925: confirmate.ontology.v1.ProductionAndMonitoringProcessDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	32,   // 926: confirmate.ontology.v1.ProtectedAssetOperation.check_access:type_name -> confirmate.ontology.v1.CheckAccess
+	39,   // 927: confirmate.ontology.v1.ProvideConfiguration.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 928: confirmate.ontology.v1.ProvideConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 929: confirmate.ontology.v1.ProvideConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 930: confirmate.ontology.v1.QPU.creation_time:type_name -> google.protobuf.Timestamp
+	336,  // 931: confirmate.ontology.v1.QPU.labels:type_name -> confirmate.ontology.v1.QPU.LabelsEntry
+	31,   // 932: confirmate.ontology.v1.QPU.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	90,   // 933: confirmate.ontology.v1.QPU.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	110,  // 934: confirmate.ontology.v1.QPU.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 935: confirmate.ontology.v1.QPU.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 936: confirmate.ontology.v1.QPU.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 937: confirmate.ontology.v1.QPU.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	225,  // 938: confirmate.ontology.v1.QPU.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	232,  // 939: confirmate.ontology.v1.QPU.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 940: confirmate.ontology.v1.QPU.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	39,   // 941: confirmate.ontology.v1.ReadConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 942: confirmate.ontology.v1.ReadConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	111,  // 943: confirmate.ontology.v1.Redundancy.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
+	158,  // 944: confirmate.ontology.v1.Redundancy.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
+	276,  // 945: confirmate.ontology.v1.Redundancy.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
+	39,   // 946: confirmate.ontology.v1.RegisterConfigurationGroup.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 947: confirmate.ontology.v1.RegisterConfigurationOption.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	39,   // 948: confirmate.ontology.v1.RegisterHttpEndpoint.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	121,  // 949: confirmate.ontology.v1.RegisterHttpEndpoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	125,  // 950: confirmate.ontology.v1.RegisterHttpEndpoint.http_request_handler:type_name -> confirmate.ontology.v1.HttpRequestHandler
+	356,  // 951: confirmate.ontology.v1.RelationalDatabaseService.creation_time:type_name -> google.protobuf.Timestamp
+	337,  // 952: confirmate.ontology.v1.RelationalDatabaseService.labels:type_name -> confirmate.ontology.v1.RelationalDatabaseService.LabelsEntry
+	3,    // 953: confirmate.ontology.v1.RelationalDatabaseService.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	7,    // 954: confirmate.ontology.v1.RelationalDatabaseService.anomaly_detections:type_name -> confirmate.ontology.v1.AnomalyDetection
+	31,   // 955: confirmate.ontology.v1.RelationalDatabaseService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 956: confirmate.ontology.v1.RelationalDatabaseService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	121,  // 957: confirmate.ontology.v1.RelationalDatabaseService.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	165,  // 958: confirmate.ontology.v1.RelationalDatabaseService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 959: confirmate.ontology.v1.RelationalDatabaseService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 960: confirmate.ontology.v1.RelationalDatabaseService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	261,  // 961: confirmate.ontology.v1.RelationalDatabaseService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 962: confirmate.ontology.v1.RelationalDatabaseService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	96,   // 963: confirmate.ontology.v1.Reliability.explainable_results:type_name -> confirmate.ontology.v1.ExplainableResults
+	234,  // 964: confirmate.ontology.v1.Reliability.robustness_score:type_name -> confirmate.ontology.v1.RobustnessScore
+	356,  // 965: confirmate.ontology.v1.RemoteAttestation.creation_time:type_name -> google.protobuf.Timestamp
+	17,   // 966: confirmate.ontology.v1.RemoteDataLocation.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	261,  // 967: confirmate.ontology.v1.RemoteDataLocation.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	121,  // 968: confirmate.ontology.v1.RemoteEntryPoint.http_endpoint:type_name -> confirmate.ontology.v1.HttpEndpoint
+	356,  // 969: confirmate.ontology.v1.ReportDocument.creation_time:type_name -> google.protobuf.Timestamp
+	338,  // 970: confirmate.ontology.v1.ReportDocument.labels:type_name -> confirmate.ontology.v1.ReportDocument.LabelsEntry
+	64,   // 971: confirmate.ontology.v1.ReportDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 972: confirmate.ontology.v1.ReportDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 973: confirmate.ontology.v1.ReportDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 974: confirmate.ontology.v1.ReportDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 975: confirmate.ontology.v1.ReportDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	2,    // 976: confirmate.ontology.v1.Resource.account:type_name -> confirmate.ontology.v1.Account
+	140,  // 977: confirmate.ontology.v1.Resource.job:type_name -> confirmate.ontology.v1.Job
+	275,  // 978: confirmate.ontology.v1.Resource.workflow:type_name -> confirmate.ontology.v1.Workflow
+	40,   // 979: confirmate.ontology.v1.Resource.code_repository:type_name -> confirmate.ontology.v1.CodeRepository
+	54,   // 980: confirmate.ontology.v1.Resource.container:type_name -> confirmate.ontology.v1.Container
+	105,  // 981: confirmate.ontology.v1.Resource.function:type_name -> confirmate.ontology.v1.Function
+	214,  // 982: confirmate.ontology.v1.Resource.qpu:type_name -> confirmate.ontology.v1.QPU
+	269,  // 983: confirmate.ontology.v1.Resource.virtual_machine:type_name -> confirmate.ontology.v1.VirtualMachine
+	56,   // 984: confirmate.ontology.v1.Resource.container_orchestration:type_name -> confirmate.ontology.v1.ContainerOrchestration
+	57,   // 985: confirmate.ontology.v1.Resource.container_registry:type_name -> confirmate.ontology.v1.ContainerRegistry
+	29,   // 986: confirmate.ontology.v1.Resource.certificate:type_name -> confirmate.ontology.v1.Certificate
+	143,  // 987: confirmate.ontology.v1.Resource.key:type_name -> confirmate.ontology.v1.Key
+	239,  // 988: confirmate.ontology.v1.Resource.secret:type_name -> confirmate.ontology.v1.Secret
+	130,  // 989: confirmate.ontology.v1.Resource.identity:type_name -> confirmate.ontology.v1.Identity
+	235,  // 990: confirmate.ontology.v1.Resource.role_assignment:type_name -> confirmate.ontology.v1.RoleAssignment
+	55,   // 991: confirmate.ontology.v1.Resource.container_image:type_name -> confirmate.ontology.v1.ContainerImage
+	265,  // 992: confirmate.ontology.v1.Resource.vm_image:type_name -> confirmate.ontology.v1.VMImage
+	80,   // 993: confirmate.ontology.v1.Resource.device_provisioning_service:type_name -> confirmate.ontology.v1.DeviceProvisioningService
+	177,  // 994: confirmate.ontology.v1.Resource.messaging_hub:type_name -> confirmate.ontology.v1.MessagingHub
+	146,  // 995: confirmate.ontology.v1.Resource.key_vault:type_name -> confirmate.ontology.v1.KeyVault
+	183,  // 996: confirmate.ontology.v1.Resource.network_interface:type_name -> confirmate.ontology.v1.NetworkInterface
+	184,  // 997: confirmate.ontology.v1.Resource.network_security_group:type_name -> confirmate.ontology.v1.NetworkSecurityGroup
+	106,  // 998: confirmate.ontology.v1.Resource.function_service:type_name -> confirmate.ontology.v1.FunctionService
+	109,  // 999: confirmate.ontology.v1.Resource.generic_network_service:type_name -> confirmate.ontology.v1.GenericNetworkService
+	151,  // 1000: confirmate.ontology.v1.Resource.load_balancer:type_name -> confirmate.ontology.v1.LoadBalancer
+	166,  // 1001: confirmate.ontology.v1.Resource.logging_service:type_name -> confirmate.ontology.v1.LoggingService
+	170,  // 1002: confirmate.ontology.v1.Resource.machine_learning_service:type_name -> confirmate.ontology.v1.MachineLearningService
+	243,  // 1003: confirmate.ontology.v1.Resource.security_advisory_service:type_name -> confirmate.ontology.v1.SecurityAdvisoryService
+	85,   // 1004: confirmate.ontology.v1.Resource.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 1005: confirmate.ontology.v1.Resource.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 1006: confirmate.ontology.v1.Resource.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 1007: confirmate.ontology.v1.Resource.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	102,  // 1008: confirmate.ontology.v1.Resource.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
+	192,  // 1009: confirmate.ontology.v1.Resource.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
+	270,  // 1010: confirmate.ontology.v1.Resource.virtual_network:type_name -> confirmate.ontology.v1.VirtualNetwork
+	271,  // 1011: confirmate.ontology.v1.Resource.virtual_sub_network:type_name -> confirmate.ontology.v1.VirtualSubNetwork
+	200,  // 1012: confirmate.ontology.v1.Resource.password_policy:type_name -> confirmate.ontology.v1.PasswordPolicy
+	231,  // 1013: confirmate.ontology.v1.Resource.resource_group:type_name -> confirmate.ontology.v1.ResourceGroup
+	24,   // 1014: confirmate.ontology.v1.Resource.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
+	77,   // 1015: confirmate.ontology.v1.Resource.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
+	101,  // 1016: confirmate.ontology.v1.Resource.file_storage:type_name -> confirmate.ontology.v1.FileStorage
+	190,  // 1017: confirmate.ontology.v1.Resource.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
+	45,   // 1018: confirmate.ontology.v1.Resource.configuration:type_name -> confirmate.ontology.v1.Configuration
+	47,   // 1019: confirmate.ontology.v1.Resource.configuration_group:type_name -> confirmate.ontology.v1.ConfigurationGroup
+	48,   // 1020: confirmate.ontology.v1.Resource.configuration_group_source:type_name -> confirmate.ontology.v1.ConfigurationGroupSource
+	50,   // 1021: confirmate.ontology.v1.Resource.configuration_option:type_name -> confirmate.ontology.v1.ConfigurationOption
+	51,   // 1022: confirmate.ontology.v1.Resource.configuration_option_source:type_name -> confirmate.ontology.v1.ConfigurationOptionSource
+	52,   // 1023: confirmate.ontology.v1.Resource.configuration_source:type_name -> confirmate.ontology.v1.ConfigurationSource
+	58,   // 1024: confirmate.ontology.v1.Resource.context:type_name -> confirmate.ontology.v1.Context
+	46,   // 1025: confirmate.ontology.v1.Resource.configuration_document:type_name -> confirmate.ontology.v1.ConfigurationDocument
+	67,   // 1026: confirmate.ontology.v1.Resource.cyber_security_risk_assessment_document:type_name -> confirmate.ontology.v1.CyberSecurityRiskAssessmentDocument
+	83,   // 1027: confirmate.ontology.v1.Resource.distribution_of_updates_document:type_name -> confirmate.ontology.v1.DistributionOfUpdatesDocument
+	88,   // 1028: confirmate.ontology.v1.Resource.eu_declaration_of_conformity:type_name -> confirmate.ontology.v1.EUDeclarationOfConformity
+	228,  // 1029: confirmate.ontology.v1.Resource.report_document:type_name -> confirmate.ontology.v1.ReportDocument
+	159,  // 1030: confirmate.ontology.v1.Resource.log_document:type_name -> confirmate.ontology.v1.LogDocument
+	203,  // 1031: confirmate.ontology.v1.Resource.policy_document:type_name -> confirmate.ontology.v1.PolicyDocument
+	209,  // 1032: confirmate.ontology.v1.Resource.production_and_monitoring_process_document:type_name -> confirmate.ontology.v1.ProductionAndMonitoringProcessDocument
+	236,  // 1033: confirmate.ontology.v1.Resource.sbom_document:type_name -> confirmate.ontology.v1.SBOMDocument
+	241,  // 1034: confirmate.ontology.v1.Resource.security_advisory_document:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument
+	248,  // 1035: confirmate.ontology.v1.Resource.service_metadata_document:type_name -> confirmate.ontology.v1.ServiceMetadataDocument
+	264,  // 1036: confirmate.ontology.v1.Resource.user_information_and_intruction_document:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument
+	97,   // 1037: confirmate.ontology.v1.Resource.file:type_name -> confirmate.ontology.v1.File
+	98,   // 1038: confirmate.ontology.v1.Resource.file_handle:type_name -> confirmate.ontology.v1.FileHandle
+	168,  // 1039: confirmate.ontology.v1.Resource.machine_learning_dataset:type_name -> confirmate.ontology.v1.MachineLearningDataset
+	169,  // 1040: confirmate.ontology.v1.Resource.machine_learning_model:type_name -> confirmate.ontology.v1.MachineLearningModel
+	59,   // 1041: confirmate.ontology.v1.Resource.coordinated_vulnerability_disclosure_policy:type_name -> confirmate.ontology.v1.CoordinatedVulnerabilityDisclosurePolicy
+	6,    // 1042: confirmate.ontology.v1.Resource.and_rule:type_name -> confirmate.ontology.v1.AndRule
+	259,  // 1043: confirmate.ontology.v1.Resource.token:type_name -> confirmate.ontology.v1.Token
+	267,  // 1044: confirmate.ontology.v1.Resource.value:type_name -> confirmate.ontology.v1.Value
+	174,  // 1045: confirmate.ontology.v1.Resource.memory:type_name -> confirmate.ontology.v1.Memory
+	208,  // 1046: confirmate.ontology.v1.Resource.product:type_name -> confirmate.ontology.v1.Product
+	8,    // 1047: confirmate.ontology.v1.Resource.application:type_name -> confirmate.ontology.v1.Application
+	149,  // 1048: confirmate.ontology.v1.Resource.library:type_name -> confirmate.ontology.v1.Library
+	197,  // 1049: confirmate.ontology.v1.Resource.package:type_name -> confirmate.ontology.v1.Package
+	254,  // 1050: confirmate.ontology.v1.Resource.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
+	4,    // 1051: confirmate.ontology.v1.Resource.agnostic:type_name -> confirmate.ontology.v1.Agnostic
+	69,   // 1052: confirmate.ontology.v1.Resource.darwin:type_name -> confirmate.ontology.v1.Darwin
+	196,  // 1053: confirmate.ontology.v1.Resource.posix:type_name -> confirmate.ontology.v1.POSIX
+	274,  // 1054: confirmate.ontology.v1.Resource.win32:type_name -> confirmate.ontology.v1.Win32
+	356,  // 1055: confirmate.ontology.v1.ResourceGroup.creation_time:type_name -> google.protobuf.Timestamp
+	339,  // 1056: confirmate.ontology.v1.ResourceGroup.labels:type_name -> confirmate.ontology.v1.ResourceGroup.LabelsEntry
+	31,   // 1057: confirmate.ontology.v1.ResourceGroup.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1058: confirmate.ontology.v1.ResourceGroup.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1059: confirmate.ontology.v1.ResourceGroup.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1060: confirmate.ontology.v1.ResourceGroup.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1061: confirmate.ontology.v1.ResourceGroup.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1062: confirmate.ontology.v1.ResourceGroup.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	357,  // 1063: confirmate.ontology.v1.ResourceLogging.retention_period:type_name -> google.protobuf.Duration
+	356,  // 1064: confirmate.ontology.v1.RoleAssignment.creation_time:type_name -> google.protobuf.Timestamp
+	340,  // 1065: confirmate.ontology.v1.RoleAssignment.labels:type_name -> confirmate.ontology.v1.RoleAssignment.LabelsEntry
+	18,   // 1066: confirmate.ontology.v1.RoleAssignment.authorization:type_name -> confirmate.ontology.v1.Authorization
+	31,   // 1067: confirmate.ontology.v1.RoleAssignment.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1068: confirmate.ontology.v1.RoleAssignment.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1069: confirmate.ontology.v1.RoleAssignment.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1070: confirmate.ontology.v1.RoleAssignment.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1071: confirmate.ontology.v1.RoleAssignment.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1072: confirmate.ontology.v1.RoleAssignment.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 1073: confirmate.ontology.v1.SBOMDocument.creation_time:type_name -> google.protobuf.Timestamp
+	341,  // 1074: confirmate.ontology.v1.SBOMDocument.labels:type_name -> confirmate.ontology.v1.SBOMDocument.LabelsEntry
+	64,   // 1075: confirmate.ontology.v1.SBOMDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 1076: confirmate.ontology.v1.SBOMDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 1077: confirmate.ontology.v1.SBOMDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 1078: confirmate.ontology.v1.SBOMDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 1079: confirmate.ontology.v1.SBOMDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	94,   // 1080: confirmate.ontology.v1.SchemaValidation.errors:type_name -> confirmate.ontology.v1.Error
+	356,  // 1081: confirmate.ontology.v1.Secret.creation_time:type_name -> google.protobuf.Timestamp
+	356,  // 1082: confirmate.ontology.v1.Secret.expiration_date:type_name -> google.protobuf.Timestamp
+	342,  // 1083: confirmate.ontology.v1.Secret.labels:type_name -> confirmate.ontology.v1.Secret.LabelsEntry
+	356,  // 1084: confirmate.ontology.v1.Secret.not_before_date:type_name -> google.protobuf.Timestamp
+	31,   // 1085: confirmate.ontology.v1.Secret.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	33,   // 1086: confirmate.ontology.v1.Secret.based_on:type_name -> confirmate.ontology.v1.Cipher
+	110,  // 1087: confirmate.ontology.v1.Secret.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	37,   // 1088: confirmate.ontology.v1.Secret.used_by_multiple:type_name -> confirmate.ontology.v1.Infrastructure
+	165,  // 1089: confirmate.ontology.v1.Secret.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1090: confirmate.ontology.v1.Secret.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1091: confirmate.ontology.v1.Secret.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1092: confirmate.ontology.v1.Secret.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	62,   // 1093: confirmate.ontology.v1.SecretOperation.create_secret:type_name -> confirmate.ontology.v1.CreateSecret
+	113,  // 1094: confirmate.ontology.v1.SecretOperation.get_secret:type_name -> confirmate.ontology.v1.GetSecret
+	356,  // 1095: confirmate.ontology.v1.SecurityAdvisoryDocument.creation_time:type_name -> google.protobuf.Timestamp
+	343,  // 1096: confirmate.ontology.v1.SecurityAdvisoryDocument.labels:type_name -> confirmate.ontology.v1.SecurityAdvisoryDocument.LabelsEntry
+	64,   // 1097: confirmate.ontology.v1.SecurityAdvisoryDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 1098: confirmate.ontology.v1.SecurityAdvisoryDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 1099: confirmate.ontology.v1.SecurityAdvisoryDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 1100: confirmate.ontology.v1.SecurityAdvisoryDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 1101: confirmate.ontology.v1.SecurityAdvisoryDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	272,  // 1102: confirmate.ontology.v1.SecurityAdvisoryDocument.vulnerabilities:type_name -> confirmate.ontology.v1.Vulnerability
+	356,  // 1103: confirmate.ontology.v1.SecurityAdvisoryService.creation_time:type_name -> google.protobuf.Timestamp
+	344,  // 1104: confirmate.ontology.v1.SecurityAdvisoryService.labels:type_name -> confirmate.ontology.v1.SecurityAdvisoryService.LabelsEntry
+	31,   // 1105: confirmate.ontology.v1.SecurityAdvisoryService.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1106: confirmate.ontology.v1.SecurityAdvisoryService.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1107: confirmate.ontology.v1.SecurityAdvisoryService.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1108: confirmate.ontology.v1.SecurityAdvisoryService.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1109: confirmate.ontology.v1.SecurityAdvisoryService.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	242,  // 1110: confirmate.ontology.v1.SecurityAdvisoryService.security_advisory_feeds:type_name -> confirmate.ontology.v1.SecurityAdvisoryFeed
+	261,  // 1111: confirmate.ontology.v1.SecurityAdvisoryService.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	263,  // 1112: confirmate.ontology.v1.SecurityAdvisoryService.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	7,    // 1113: confirmate.ontology.v1.SecurityFeature.anomaly_detection:type_name -> confirmate.ontology.v1.AnomalyDetection
+	10,   // 1114: confirmate.ontology.v1.SecurityFeature.asset_inventory:type_name -> confirmate.ontology.v1.AssetInventory
+	41,   // 1115: confirmate.ontology.v1.SecurityFeature.code_signoff:type_name -> confirmate.ontology.v1.CodeSignoff
+	3,    // 1116: confirmate.ontology.v1.SecurityFeature.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	9,    // 1117: confirmate.ontology.v1.SecurityFeature.application_logging:type_name -> confirmate.ontology.v1.ApplicationLogging
+	26,   // 1118: confirmate.ontology.v1.SecurityFeature.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
+	188,  // 1119: confirmate.ontology.v1.SecurityFeature.os_logging:type_name -> confirmate.ontology.v1.OSLogging
+	232,  // 1120: confirmate.ontology.v1.SecurityFeature.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	172,  // 1121: confirmate.ontology.v1.SecurityFeature.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	263,  // 1122: confirmate.ontology.v1.SecurityFeature.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	30,   // 1123: confirmate.ontology.v1.SecurityFeature.certificate_based_authentication:type_name -> confirmate.ontology.v1.CertificateBasedAuthentication
+	141,  // 1124: confirmate.ontology.v1.SecurityFeature.jwt_authentication:type_name -> confirmate.ontology.v1.JwtAuthentication
+	180,  // 1125: confirmate.ontology.v1.SecurityFeature.multi_factor_authentiation:type_name -> confirmate.ontology.v1.MultiFactorAuthentiation
+	187,  // 1126: confirmate.ontology.v1.SecurityFeature.no_authentication:type_name -> confirmate.ontology.v1.NoAuthentication
+	189,  // 1127: confirmate.ontology.v1.SecurityFeature.otp_based_authentication:type_name -> confirmate.ontology.v1.OTPBasedAuthentication
+	199,  // 1128: confirmate.ontology.v1.SecurityFeature.password_based_authentication:type_name -> confirmate.ontology.v1.PasswordBasedAuthentication
+	251,  // 1129: confirmate.ontology.v1.SecurityFeature.single_sign_on:type_name -> confirmate.ontology.v1.SingleSignOn
+	0,    // 1130: confirmate.ontology.v1.SecurityFeature.abac:type_name -> confirmate.ontology.v1.ABAC
+	147,  // 1131: confirmate.ontology.v1.SecurityFeature.l3_firewall:type_name -> confirmate.ontology.v1.L3Firewall
+	273,  // 1132: confirmate.ontology.v1.SecurityFeature.web_application_firewall:type_name -> confirmate.ontology.v1.WebApplicationFirewall
+	216,  // 1133: confirmate.ontology.v1.SecurityFeature.rate_limiting:type_name -> confirmate.ontology.v1.RateLimiting
+	215,  // 1134: confirmate.ontology.v1.SecurityFeature.rbac:type_name -> confirmate.ontology.v1.RBAC
+	23,   // 1135: confirmate.ontology.v1.SecurityFeature.backup:type_name -> confirmate.ontology.v1.Backup
+	68,   // 1136: confirmate.ontology.v1.SecurityFeature.d_do_s_protection:type_name -> confirmate.ontology.v1.DDoSProtection
+	110,  // 1137: confirmate.ontology.v1.SecurityFeature.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	111,  // 1138: confirmate.ontology.v1.SecurityFeature.geo_redundancy:type_name -> confirmate.ontology.v1.GeoRedundancy
+	158,  // 1139: confirmate.ontology.v1.SecurityFeature.local_redundancy:type_name -> confirmate.ontology.v1.LocalRedundancy
+	276,  // 1140: confirmate.ontology.v1.SecurityFeature.zone_redundancy:type_name -> confirmate.ontology.v1.ZoneRedundancy
+	66,   // 1141: confirmate.ontology.v1.SecurityFeature.customer_key_encryption:type_name -> confirmate.ontology.v1.CustomerKeyEncryption
+	81,   // 1142: confirmate.ontology.v1.SecurityFeature.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	173,  // 1143: confirmate.ontology.v1.SecurityFeature.managed_key_encryption:type_name -> confirmate.ontology.v1.ManagedKeyEncryption
+	261,  // 1144: confirmate.ontology.v1.SecurityFeature.transport_encryption:type_name -> confirmate.ontology.v1.TransportEncryption
+	90,   // 1145: confirmate.ontology.v1.SecurityFeature.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	155,  // 1146: confirmate.ontology.v1.SecurityFeature.local_attestation:type_name -> confirmate.ontology.v1.LocalAttestation
+	225,  // 1147: confirmate.ontology.v1.SecurityFeature.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	252,  // 1148: confirmate.ontology.v1.SecurityFeature.software_attestation:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	20,   // 1149: confirmate.ontology.v1.SecurityFeature.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
+	64,   // 1150: confirmate.ontology.v1.SecurityFeature.cryptographic_hash:type_name -> confirmate.ontology.v1.CryptographicHash
+	132,  // 1151: confirmate.ontology.v1.SecurityFeature.immutability:type_name -> confirmate.ontology.v1.Immutability
+	249,  // 1152: confirmate.ontology.v1.SecurityFeature.document_signature:type_name -> confirmate.ontology.v1.DocumentSignature
+	250,  // 1153: confirmate.ontology.v1.SecurityFeature.signed_commits:type_name -> confirmate.ontology.v1.SignedCommits
+	268,  // 1154: confirmate.ontology.v1.SecurityFeature.verified_commits:type_name -> confirmate.ontology.v1.VerifiedCommits
+	96,   // 1155: confirmate.ontology.v1.SecurityFeature.explainable_results:type_name -> confirmate.ontology.v1.ExplainableResults
+	234,  // 1156: confirmate.ontology.v1.SecurityFeature.robustness_score:type_name -> confirmate.ontology.v1.RobustnessScore
+	356,  // 1157: confirmate.ontology.v1.ServiceMetadataDocument.creation_time:type_name -> google.protobuf.Timestamp
+	345,  // 1158: confirmate.ontology.v1.ServiceMetadataDocument.labels:type_name -> confirmate.ontology.v1.ServiceMetadataDocument.LabelsEntry
+	64,   // 1159: confirmate.ontology.v1.ServiceMetadataDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 1160: confirmate.ontology.v1.ServiceMetadataDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 1161: confirmate.ontology.v1.ServiceMetadataDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 1162: confirmate.ontology.v1.ServiceMetadataDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 1163: confirmate.ontology.v1.ServiceMetadataDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	94,   // 1164: confirmate.ontology.v1.DocumentSignature.errors:type_name -> confirmate.ontology.v1.Error
+	8,    // 1165: confirmate.ontology.v1.Code.application:type_name -> confirmate.ontology.v1.Application
+	149,  // 1166: confirmate.ontology.v1.Code.library:type_name -> confirmate.ontology.v1.Library
+	197,  // 1167: confirmate.ontology.v1.Code.package:type_name -> confirmate.ontology.v1.Package
+	254,  // 1168: confirmate.ontology.v1.Code.source_code_file:type_name -> confirmate.ontology.v1.SourceCodeFile
+	4,    // 1169: confirmate.ontology.v1.Code.agnostic:type_name -> confirmate.ontology.v1.Agnostic
+	69,   // 1170: confirmate.ontology.v1.Code.darwin:type_name -> confirmate.ontology.v1.Darwin
+	196,  // 1171: confirmate.ontology.v1.Code.posix:type_name -> confirmate.ontology.v1.POSIX
+	274,  // 1172: confirmate.ontology.v1.Code.win32:type_name -> confirmate.ontology.v1.Win32
+	356,  // 1173: confirmate.ontology.v1.SourceCodeFile.creation_time:type_name -> google.protobuf.Timestamp
+	346,  // 1174: confirmate.ontology.v1.SourceCodeFile.labels:type_name -> confirmate.ontology.v1.SourceCodeFile.LabelsEntry
+	107,  // 1175: confirmate.ontology.v1.SourceCodeFile.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 1176: confirmate.ontology.v1.SourceCodeFile.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	24,   // 1177: confirmate.ontology.v1.Storage.block_storage:type_name -> confirmate.ontology.v1.BlockStorage
+	77,   // 1178: confirmate.ontology.v1.Storage.database_storage:type_name -> confirmate.ontology.v1.DatabaseStorage
+	101,  // 1179: confirmate.ontology.v1.Storage.file_storage:type_name -> confirmate.ontology.v1.FileStorage
+	190,  // 1180: confirmate.ontology.v1.Storage.object_storage:type_name -> confirmate.ontology.v1.ObjectStorage
+	85,   // 1181: confirmate.ontology.v1.StorageService.document_database_service:type_name -> confirmate.ontology.v1.DocumentDatabaseService
+	145,  // 1182: confirmate.ontology.v1.StorageService.key_value_database_service:type_name -> confirmate.ontology.v1.KeyValueDatabaseService
+	181,  // 1183: confirmate.ontology.v1.StorageService.multi_modal_database_service:type_name -> confirmate.ontology.v1.MultiModalDatabaseService
+	223,  // 1184: confirmate.ontology.v1.StorageService.relational_database_service:type_name -> confirmate.ontology.v1.RelationalDatabaseService
+	102,  // 1185: confirmate.ontology.v1.StorageService.file_storage_service:type_name -> confirmate.ontology.v1.FileStorageService
+	192,  // 1186: confirmate.ontology.v1.StorageService.object_storage_service:type_name -> confirmate.ontology.v1.ObjectStorageService
+	133,  // 1187: confirmate.ontology.v1.SymmetricCipher.initialization_vector:type_name -> confirmate.ontology.v1.InitializationVector
+	198,  // 1188: confirmate.ontology.v1.SymmetricCipher.padding:type_name -> confirmate.ontology.v1.Padding
+	356,  // 1189: confirmate.ontology.v1.Token.creation_time:type_name -> google.protobuf.Timestamp
+	347,  // 1190: confirmate.ontology.v1.Token.labels:type_name -> confirmate.ontology.v1.Token.LabelsEntry
+	72,   // 1191: confirmate.ontology.v1.Token.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	22,   // 1192: confirmate.ontology.v1.Training.awareness_training:type_name -> confirmate.ontology.v1.AwarenessTraining
+	246,  // 1193: confirmate.ontology.v1.Training.security_training:type_name -> confirmate.ontology.v1.SecurityTraining
+	33,   // 1194: confirmate.ontology.v1.TransportEncryption.based_on:type_name -> confirmate.ontology.v1.Cipher
+	35,   // 1195: confirmate.ontology.v1.TransportEncryption.cipher_suites:type_name -> confirmate.ontology.v1.CipherSuite
+	39,   // 1196: confirmate.ontology.v1.UnlockEncryptedDisk.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	81,   // 1197: confirmate.ontology.v1.UnlockEncryptedDisk.disk_encryption:type_name -> confirmate.ontology.v1.DiskEncryption
+	356,  // 1198: confirmate.ontology.v1.UserInformationAndIntructionDocument.creation_time:type_name -> google.protobuf.Timestamp
+	348,  // 1199: confirmate.ontology.v1.UserInformationAndIntructionDocument.labels:type_name -> confirmate.ontology.v1.UserInformationAndIntructionDocument.LabelsEntry
+	64,   // 1200: confirmate.ontology.v1.UserInformationAndIntructionDocument.cryptographic_hashs:type_name -> confirmate.ontology.v1.CryptographicHash
+	72,   // 1201: confirmate.ontology.v1.UserInformationAndIntructionDocument.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	249,  // 1202: confirmate.ontology.v1.UserInformationAndIntructionDocument.document_signatures:type_name -> confirmate.ontology.v1.DocumentSignature
+	238,  // 1203: confirmate.ontology.v1.UserInformationAndIntructionDocument.validated_by:type_name -> confirmate.ontology.v1.SchemaValidation
+	244,  // 1204: confirmate.ontology.v1.UserInformationAndIntructionDocument.security_features:type_name -> confirmate.ontology.v1.SecurityFeature
+	356,  // 1205: confirmate.ontology.v1.VMImage.creation_time:type_name -> google.protobuf.Timestamp
+	349,  // 1206: confirmate.ontology.v1.VMImage.labels:type_name -> confirmate.ontology.v1.VMImage.LabelsEntry
+	31,   // 1207: confirmate.ontology.v1.VMImage.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1208: confirmate.ontology.v1.VMImage.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1209: confirmate.ontology.v1.VMImage.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1210: confirmate.ontology.v1.VMImage.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1211: confirmate.ontology.v1.VMImage.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1212: confirmate.ontology.v1.VMImage.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	17,   // 1213: confirmate.ontology.v1.ValidateJwt.authenticity:type_name -> confirmate.ontology.v1.Authenticity
+	39,   // 1214: confirmate.ontology.v1.ValidateJwt.code_region:type_name -> confirmate.ontology.v1.CodeRegion
+	356,  // 1215: confirmate.ontology.v1.Value.creation_time:type_name -> google.protobuf.Timestamp
+	350,  // 1216: confirmate.ontology.v1.Value.labels:type_name -> confirmate.ontology.v1.Value.LabelsEntry
+	72,   // 1217: confirmate.ontology.v1.Value.data_location:type_name -> confirmate.ontology.v1.DataLocation
+	356,  // 1218: confirmate.ontology.v1.VirtualMachine.creation_time:type_name -> google.protobuf.Timestamp
+	351,  // 1219: confirmate.ontology.v1.VirtualMachine.labels:type_name -> confirmate.ontology.v1.VirtualMachine.LabelsEntry
+	3,    // 1220: confirmate.ontology.v1.VirtualMachine.activity_logging:type_name -> confirmate.ontology.v1.ActivityLogging
+	20,   // 1221: confirmate.ontology.v1.VirtualMachine.automatic_updates:type_name -> confirmate.ontology.v1.AutomaticUpdates
+	26,   // 1222: confirmate.ontology.v1.VirtualMachine.boot_logging:type_name -> confirmate.ontology.v1.BootLogging
+	31,   // 1223: confirmate.ontology.v1.VirtualMachine.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	90,   // 1224: confirmate.ontology.v1.VirtualMachine.encryption_in_use:type_name -> confirmate.ontology.v1.EncryptionInUse
+	110,  // 1225: confirmate.ontology.v1.VirtualMachine.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1226: confirmate.ontology.v1.VirtualMachine.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1227: confirmate.ontology.v1.VirtualMachine.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	188,  // 1228: confirmate.ontology.v1.VirtualMachine.os_logging:type_name -> confirmate.ontology.v1.OSLogging
+	219,  // 1229: confirmate.ontology.v1.VirtualMachine.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	225,  // 1230: confirmate.ontology.v1.VirtualMachine.remote_attestation:type_name -> confirmate.ontology.v1.RemoteAttestation
+	232,  // 1231: confirmate.ontology.v1.VirtualMachine.resource_logging:type_name -> confirmate.ontology.v1.ResourceLogging
+	263,  // 1232: confirmate.ontology.v1.VirtualMachine.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 1233: confirmate.ontology.v1.VirtualNetwork.creation_time:type_name -> google.protobuf.Timestamp
+	352,  // 1234: confirmate.ontology.v1.VirtualNetwork.labels:type_name -> confirmate.ontology.v1.VirtualNetwork.LabelsEntry
+	31,   // 1235: confirmate.ontology.v1.VirtualNetwork.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1236: confirmate.ontology.v1.VirtualNetwork.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1237: confirmate.ontology.v1.VirtualNetwork.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1238: confirmate.ontology.v1.VirtualNetwork.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1239: confirmate.ontology.v1.VirtualNetwork.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1240: confirmate.ontology.v1.VirtualNetwork.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 1241: confirmate.ontology.v1.VirtualSubNetwork.creation_time:type_name -> google.protobuf.Timestamp
+	353,  // 1242: confirmate.ontology.v1.VirtualSubNetwork.labels:type_name -> confirmate.ontology.v1.VirtualSubNetwork.LabelsEntry
+	31,   // 1243: confirmate.ontology.v1.VirtualSubNetwork.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1244: confirmate.ontology.v1.VirtualSubNetwork.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1245: confirmate.ontology.v1.VirtualSubNetwork.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1246: confirmate.ontology.v1.VirtualSubNetwork.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1247: confirmate.ontology.v1.VirtualSubNetwork.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1248: confirmate.ontology.v1.VirtualSubNetwork.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	356,  // 1249: confirmate.ontology.v1.Win32.creation_time:type_name -> google.protobuf.Timestamp
+	354,  // 1250: confirmate.ontology.v1.Win32.labels:type_name -> confirmate.ontology.v1.Win32.LabelsEntry
+	107,  // 1251: confirmate.ontology.v1.Win32.functionalities:type_name -> confirmate.ontology.v1.Functionality
+	252,  // 1252: confirmate.ontology.v1.Win32.software_attestations:type_name -> confirmate.ontology.v1.SoftwareAttestation
+	356,  // 1253: confirmate.ontology.v1.Workflow.creation_time:type_name -> google.protobuf.Timestamp
+	355,  // 1254: confirmate.ontology.v1.Workflow.labels:type_name -> confirmate.ontology.v1.Workflow.LabelsEntry
+	31,   // 1255: confirmate.ontology.v1.Workflow.change_and_configuration_management:type_name -> confirmate.ontology.v1.ChangeAndConfigurationManagement
+	110,  // 1256: confirmate.ontology.v1.Workflow.geo_location:type_name -> confirmate.ontology.v1.GeoLocation
+	165,  // 1257: confirmate.ontology.v1.Workflow.loggings:type_name -> confirmate.ontology.v1.Logging
+	172,  // 1258: confirmate.ontology.v1.Workflow.malware_protection:type_name -> confirmate.ontology.v1.MalwareProtection
+	219,  // 1259: confirmate.ontology.v1.Workflow.redundancies:type_name -> confirmate.ontology.v1.Redundancy
+	263,  // 1260: confirmate.ontology.v1.Workflow.usage_statistics:type_name -> confirmate.ontology.v1.UsageStatistics
+	110,  // 1261: confirmate.ontology.v1.ZoneRedundancy.geo_locations:type_name -> confirmate.ontology.v1.GeoLocation
+	358,  // 1262: confirmate.ontology.v1.resource_type_names:extendee -> google.protobuf.MessageOptions
+	1263, // [1263:1263] is the sub-list for method output_type
+	1263, // [1263:1263] is the sub-list for method input_type
+	1263, // [1263:1263] is the sub-list for extension type_name
+	1262, // [1262:1263] is the sub-list for extension extendee
+	0,    // [0:1262] is the sub-list for field type_name
 }
 
 func init() { file_policies_security_metrics_ontology_v1_ontology_proto_init() }
@@ -37188,6 +37397,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[13].OneofWrappers = []any{
 		(*Attestation_LocalAttestation)(nil),
 		(*Attestation_RemoteAttestation)(nil),
+		(*Attestation_SoftwareAttestation)(nil),
 	}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[14].OneofWrappers = []any{
 		(*Auditing_AnomalyDetection)(nil),
@@ -37539,6 +37749,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 		(*Functionality_RequestForChange)(nil),
 		(*Functionality_SchemaValidation)(nil),
 		(*Functionality_SecurityAdvisoryFeed)(nil),
+		(*Functionality_SecurityIncident)(nil),
 		(*Functionality_Time)(nil),
 		(*Functionality_Vulnerability)(nil),
 	}
@@ -37580,6 +37791,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[137].OneofWrappers = []any{
 		(*Integrity_LocalAttestation)(nil),
 		(*Integrity_RemoteAttestation)(nil),
+		(*Integrity_SoftwareAttestation)(nil),
 		(*Integrity_AutomaticUpdates)(nil),
 		(*Integrity_CryptographicHash)(nil),
 		(*Integrity_Immutability)(nil),
@@ -37904,6 +38116,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 		(*SecurityFeature_EncryptionInUse)(nil),
 		(*SecurityFeature_LocalAttestation)(nil),
 		(*SecurityFeature_RemoteAttestation)(nil),
+		(*SecurityFeature_SoftwareAttestation)(nil),
 		(*SecurityFeature_AutomaticUpdates)(nil),
 		(*SecurityFeature_CryptographicHash)(nil),
 		(*SecurityFeature_Immutability)(nil),
@@ -37914,7 +38127,7 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 		(*SecurityFeature_RobustnessScore)(nil),
 	}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[248].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[252].OneofWrappers = []any{
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253].OneofWrappers = []any{
 		(*Code_Application)(nil),
 		(*Code_Library)(nil),
 		(*Code_Package)(nil),
@@ -37924,14 +38137,14 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 		(*Code_Posix)(nil),
 		(*Code_Win32)(nil),
 	}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[253].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254].OneofWrappers = []any{
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[254].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255].OneofWrappers = []any{
 		(*Storage_BlockStorage)(nil),
 		(*Storage_DatabaseStorage)(nil),
 		(*Storage_FileStorage)(nil),
 		(*Storage_ObjectStorage)(nil),
 	}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[255].OneofWrappers = []any{
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[256].OneofWrappers = []any{
 		(*StorageService_DocumentDatabaseService)(nil),
 		(*StorageService_KeyValueDatabaseService)(nil),
 		(*StorageService_MultiModalDatabaseService)(nil),
@@ -37939,27 +38152,27 @@ func file_policies_security_metrics_ontology_v1_ontology_proto_init() {
 		(*StorageService_FileStorageService)(nil),
 		(*StorageService_ObjectStorageService)(nil),
 	}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[258].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259].OneofWrappers = []any{
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[259].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260].OneofWrappers = []any{
 		(*Training_AwarenessTraining)(nil),
 		(*Training_SecurityTraining)(nil),
 	}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[260].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[263].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[261].OneofWrappers = []any{}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[264].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[266].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[268].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[265].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[267].OneofWrappers = []any{}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[269].OneofWrappers = []any{}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[270].OneofWrappers = []any{}
-	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[273].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[271].OneofWrappers = []any{}
 	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[274].OneofWrappers = []any{}
+	file_policies_security_metrics_ontology_v1_ontology_proto_msgTypes[275].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc), len(file_policies_security_metrics_ontology_v1_ontology_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   355,
+			NumMessages:   356,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -5,7 +5,7 @@ openapi: 3.0.3
 info:
     title: Orchestrator API
     description: Manages the orchestration of components within the confirmate architecture
-    version: core/v0.2.15-25-g8885487
+    version: core/v0.2.15-15-g97e68af
 paths:
     /v1/orchestrator/assessment_results:
         get:

--- a/core/persistence/db.go
+++ b/core/persistence/db.go
@@ -65,6 +65,10 @@ type DB interface {
 	// Count retrieves the count of records in the database that match the provided conditions.
 	Count(r any, conds ...any) (count int64, err error)
 
+	// Pluck retrieves distinct values for a single column from the database, scanning results
+	// into dest. Optional conds are applied as WHERE conditions.
+	Pluck(model any, column string, dest any, conds ...any) (err error)
+
 	// Raw executes a raw SQL query and scans the result into the provided destination. Returns an error
 	// if the query fails.
 	Raw(r any, query string, args ...any) (err error)

--- a/core/persistence/operations.go
+++ b/core/persistence/operations.go
@@ -159,6 +159,12 @@ func (s *gormDB) Count(r any, conds ...any) (count int64, err error) {
 // Advanced and customizable operations
 // ================================================================================================
 
+// Pluck retrieves distinct values for a single column from the database.
+func (s *gormDB) Pluck(model any, column string, dest any, conds ...any) (err error) {
+	db := applyWhere(s.DB.Model(model).Distinct(column), conds...)
+	return db.Pluck(column, dest).Error
+}
+
 // Raw executes a raw SQL query and scans the result into the provided destination. Returns an error
 // if the query fails.
 func (s *gormDB) Raw(r any, query string, args ...any) (err error) {

--- a/core/persistence/persistencetest/db.go
+++ b/core/persistence/persistencetest/db.go
@@ -32,6 +32,7 @@ type errorDB struct {
 	getErr    error
 	listErr   error
 	countErr  error
+	pluckErr  error
 	rawErr    error
 }
 
@@ -99,6 +100,14 @@ func RawErrorDB(t *testing.T, err error, types []any, joinTable []persistence.Cu
 	}
 }
 
+// PluckErrorDB returns an ErrorDB that fails on Pluck with the provided error.
+func PluckErrorDB(t *testing.T, err error, types []any, joinTable []persistence.CustomJoinTable, init ...func(persistence.DB)) persistence.DB {
+	return &errorDB{
+		pluckErr: err,
+		DB:       NewInMemoryDB(t, types, joinTable, init...),
+	}
+}
+
 // MultiErrorDB returns an [persistence.DB] that can fail on multiple operations with the provided
 // errors.
 func MultiErrorDB(t *testing.T,
@@ -109,6 +118,7 @@ func MultiErrorDB(t *testing.T,
 	getErr,
 	listErr,
 	countErr,
+	pluckErr,
 	rawErr error,
 	types []any, joinTable []persistence.CustomJoinTable, init ...func(persistence.DB)) persistence.DB {
 	return &errorDB{
@@ -119,6 +129,7 @@ func MultiErrorDB(t *testing.T,
 		getErr:    getErr,
 		listErr:   listErr,
 		countErr:  countErr,
+		pluckErr:  pluckErr,
 		rawErr:    rawErr,
 		DB:        NewInMemoryDB(t, types, joinTable, init...),
 	}
@@ -180,6 +191,14 @@ func (t *errorDB) Count(r any, conds ...any) (int64, error) {
 	return t.DB.Count(r, conds...)
 }
 
+func (t *errorDB) Pluck(model any, column string, dest any, conds ...any) error {
+	if t.pluckErr != nil {
+		return t.pluckErr
+	}
+
+	return t.DB.Pluck(model, column, dest, conds...)
+}
+
 func (t *errorDB) Raw(r any, query string, args ...any) error {
 	if t.rawErr != nil {
 		return t.rawErr
@@ -199,6 +218,7 @@ func (t *errorDB) Transaction(fn func(tx persistence.DB) error) error {
 			getErr:    t.getErr,
 			listErr:   t.listErr,
 			countErr:  t.countErr,
+			pluckErr:  t.pluckErr,
 			rawErr:    t.rawErr,
 		})
 	})

--- a/core/persistence/persistencetest/db_test.go
+++ b/core/persistence/persistencetest/db_test.go
@@ -173,6 +173,7 @@ func TestErrorDB_Passthrough(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		types,
 		nil,
 	)

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -91,13 +91,6 @@ type Service struct {
 	// hookMutex is used for (un)locking result hook calls
 	hookMutex sync.Mutex
 
-	// toolIds is an in-memory cache of tool IDs that have provided evidence.
-	// It is a map[string]struct{} (a set) rather than a slice to guarantee
-	// uniqueness with O(1) insertion — no duplicate scan needed on each
-	// StoreEvidence call.
-	toolIds   map[string]struct{}
-	toolIdsMu sync.RWMutex
-
 	// authz defines our authorization strategy for target-of-evaluation scoped access.
 	authz service.AuthorizationStrategy
 }
@@ -125,8 +118,7 @@ func WithAuthorizationStrategyPermissionStore() service.Option[Service] {
 
 func NewService(opts ...service.Option[Service]) (svc *Service, err error) {
 	svc = &Service{
-		cfg:     DefaultConfig,
-		toolIds: make(map[string]struct{}),
+		cfg: DefaultConfig,
 	}
 
 	// Apply configuration options
@@ -259,11 +251,6 @@ func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evid
 		slog.String("evidence_id", req.Msg.Evidence.Id),
 		slog.String("tool_id", req.Msg.Evidence.ToolId),
 		slog.String("target_of_evaluation_id", req.Msg.Evidence.TargetOfEvaluationId))
-
-	// Cache the tool ID for ListTools.
-	svc.toolIdsMu.Lock()
-	svc.toolIds[req.Msg.Evidence.GetToolId()] = struct{}{}
-	svc.toolIdsMu.Unlock()
 
 	// Store resource snapshot. This will hold the latest sync state of the resource and its
 	// association to ToE for our storage layer.
@@ -462,24 +449,39 @@ func (svc *Service) ListSupportedResourceTypes(_ context.Context, req *connect.R
 }
 
 // ListTools returns the IDs of all evidence collecting tools that have provided evidence so far.
-// The result is served from an in-memory cache that is populated on each [StoreEvidence] call.
 // This implements the [evidenceconnect.EvidenceStoreHandler.ListTools] RPC method.
 func (svc *Service) ListTools(_ context.Context, req *connect.Request[evidence.ListToolsRequest]) (
 	res *connect.Response[evidence.ListToolsResponse], err error) {
 
-	res = connect.NewResponse(&evidence.ListToolsResponse{})
+	var (
+		toolIds []string
+		args    []any
+	)
 
 	// Validate request
 	if err = service.Validate(req); err != nil {
 		return nil, err
 	}
 
-	svc.toolIdsMu.RLock()
-	for id := range svc.toolIds {
-		res.Msg.ToolIds = append(res.Msg.ToolIds, id)
-	}
-	svc.toolIdsMu.RUnlock()
+	// Use PostgreSQL DISTINCT to get unique tool IDs from the evidence table
+	var query string
+	query = `
+		SELECT DISTINCT tool_id
+		FROM evidences
+		ORDER BY tool_id DESC
+	`
 
+	err = svc.db.Raw(&toolIds, query, args...)
+	if err = service.HandleDatabaseError(err); err != nil {
+		return nil, err
+	}
+
+	// Since we used raw SQL, we need to handle pagination differently
+	// For now, return all results without pagination support
+	res = connect.NewResponse(&evidence.ListToolsResponse{
+		ToolIds:       toolIds,
+		NextPageToken: "",
+	})
 	return
 }
 

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -453,31 +453,18 @@ func (svc *Service) ListSupportedResourceTypes(_ context.Context, req *connect.R
 func (svc *Service) ListTools(_ context.Context, req *connect.Request[evidence.ListToolsRequest]) (
 	res *connect.Response[evidence.ListToolsResponse], err error) {
 
-	var (
-		toolIds []string
-		args    []any
-	)
+	var toolIds []string
 
 	// Validate request
 	if err = service.Validate(req); err != nil {
 		return nil, err
 	}
 
-	// Use PostgreSQL DISTINCT to get unique tool IDs from the evidence table
-	var query string
-	query = `
-		SELECT DISTINCT tool_id
-		FROM evidences
-		ORDER BY tool_id DESC
-	`
-
-	err = svc.db.Raw(&toolIds, query, args...)
+	err = svc.db.Pluck(&evidence.Evidence{}, "tool_id", &toolIds)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
 
-	// Since we used raw SQL, we need to handle pagination differently
-	// For now, return all results without pagination support
 	res = connect.NewResponse(&evidence.ListToolsResponse{
 		ToolIds:       toolIds,
 		NextPageToken: "",

--- a/core/service/evidence/service_test.go
+++ b/core/service/evidence/service_test.go
@@ -381,7 +381,6 @@ func TestService_StoreEvidence(t *testing.T) {
 			svc = &Service{
 				db:              tt.fields.db,
 				channelEvidence: make(chan *evidence.Evidence, defaultEvidenceQueueSize),
-				toolIds:         make(map[string]struct{}),
 			}
 
 			res, err = svc.StoreEvidence(tt.args.ctx, tt.args.req)
@@ -480,9 +479,8 @@ func TestService_StoreEvidences(t *testing.T) {
 
 			// Initialize service directly with DB from test fields
 			svc = &Service{
-				db:      tt.fields.db,
-				cfg:     DefaultConfig,
-				toolIds: make(map[string]struct{}),
+				db:  tt.fields.db,
+				cfg: DefaultConfig,
 			}
 			svc.cfg.AssessmentAddress = assessmentSrv.URL
 			svc.cfg.AssessmentHTTPClient = assessmentSrv.Client()
@@ -611,7 +609,6 @@ func TestService_StoreEvidences_SendErrors(t *testing.T) {
 			svc := &Service{
 				db:              tt.fields.db,
 				channelEvidence: make(chan *evidence.Evidence, 1),
-				toolIds:         make(map[string]struct{}),
 			}
 
 			stream := &fakeEvidenceStream{
@@ -914,26 +911,38 @@ func TestService_ListSupportedResourceTypes(t *testing.T) {
 
 // TestService_ListTools covers the empty-cache case and population via StoreEvidence.
 func TestService_ListTools(t *testing.T) {
+	type fields struct {
+		db persistence.DB
+	}
+	type args struct {
+		ctx context.Context
+		req *connect.Request[evidence.ListToolsRequest]
+	}
 	tests := []struct {
-		name      string
-		evidences []*evidence.Evidence
-		req       *connect.Request[evidence.ListToolsRequest]
-		want      assert.Want[*connect.Response[evidence.ListToolsResponse]]
-		wantErr   assert.WantErr
+		name    string
+		args    args
+		fields  fields
+		want    assert.Want[*connect.Response[evidence.ListToolsResponse]]
+		wantErr assert.WantErr
 	}{
 		{
-			name:      "error - nil request",
-			evidences: nil,
-			req:       nil,
-			want:      assert.Nil[*connect.Response[evidence.ListToolsResponse]],
+			name: "error - nil request",
+			args: args{
+				req: nil,
+			},
+			want: assert.Nil[*connect.Response[evidence.ListToolsResponse]],
 			wantErr: func(t *testing.T, err error, msgAndArgs ...any) bool {
 				return assert.IsConnectError(t, err, connect.CodeInvalidArgument)
 			},
 		},
 		{
-			name:      "happy path - empty cache returns empty list",
-			evidences: nil,
-			req:       &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
+			name: "happy path - empty cache returns empty list",
+			args: args{
+				req: &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
+			},
+			fields: fields{
+				db: persistencetest.NewInMemoryDB(t, types, nil),
+			},
 			want: func(t *testing.T, got *connect.Response[evidence.ListToolsResponse], msgAndArgs ...any) bool {
 				assert.NotNil(t, got)
 				return assert.Equal(t, 0, len(got.Msg.ToolIds))
@@ -942,25 +951,34 @@ func TestService_ListTools(t *testing.T) {
 		},
 		{
 			name: "happy path - deduplicates same tool across multiple evidences",
-			evidences: []*evidence.Evidence{
-				evidencetest.MockEvidenceListA, // tool-a
-				evidencetest.MockEvidenceListB, // tool-a (same tool, different ToE)
+			args: args{
+				req: &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
 			},
-			req: &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
+			fields: fields{
+				db: persistencetest.NewInMemoryDB(t, types, nil, func(db persistence.DB) {
+					assert.NoError(t, db.Create(evidencetest.MockEvidenceListA)) // tool-a
+					assert.NoError(t, db.Create(evidencetest.MockEvidenceListB)) // tool-a (same tool, different ToE)
+				}),
+			},
 			want: func(t *testing.T, got *connect.Response[evidence.ListToolsResponse], msgAndArgs ...any) bool {
 				assert.NotNil(t, got)
-				return assert.Equal(t, 1, len(got.Msg.ToolIds))
+				return assert.Equal(t, 1, len(got.Msg.ToolIds)) &&
+					assert.Equal(t, evidencetest.MockEvidenceListA.ToolId, got.Msg.ToolIds[0])
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "happy path - returns all distinct tool ids",
-			evidences: []*evidence.Evidence{
-				evidencetest.MockEvidenceListA, // tool-a
-				evidencetest.MockEvidenceListB, // tool-a
-				evidencetest.MockEvidenceListC, // tool-b
+			args: args{
+				req: &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
 			},
-			req: &connect.Request[evidence.ListToolsRequest]{Msg: &evidence.ListToolsRequest{}},
+			fields: fields{
+				db: persistencetest.NewInMemoryDB(t, types, nil, func(db persistence.DB) {
+					assert.NoError(t, db.Create(evidencetest.MockEvidenceListA)) // tool-a
+					assert.NoError(t, db.Create(evidencetest.MockEvidenceListB)) // tool-a (same tool, different ToE)
+					assert.NoError(t, db.Create(evidencetest.MockEvidenceListC)) // tool-b
+				}),
+			},
 			want: func(t *testing.T, got *connect.Response[evidence.ListToolsResponse], msgAndArgs ...any) bool {
 				assert.NotNil(t, got)
 				if !assert.Equal(t, 2, len(got.Msg.ToolIds)) {
@@ -977,16 +995,10 @@ func TestService_ListTools(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := &Service{
-				toolIds: make(map[string]struct{}),
+				db: tt.fields.db,
 			}
 
-			for _, ev := range tt.evidences {
-				svc.toolIdsMu.Lock()
-				svc.toolIds[ev.ToolId] = struct{}{}
-				svc.toolIdsMu.Unlock()
-			}
-
-			res, err := svc.ListTools(context.Background(), tt.req)
+			res, err := svc.ListTools(tt.args.ctx, tt.args.req)
 			tt.wantErr(t, err)
 			tt.want(t, res)
 		})

--- a/core/service/orchestrator/catalogs.go
+++ b/core/service/orchestrator/catalogs.go
@@ -205,7 +205,7 @@ func (svc *Service) RemoveCatalog(
 		return nil, err
 	}
 
-	// Only admins may grant or revoke permissions.
+	// Check access via the configured auth strategy
 	allowed, _, err = CheckAccess(ctx, svc.authz, svc, orchestrator.RequestType_REQUEST_TYPE_UPDATED, "", orchestrator.ObjectType_OBJECT_TYPE_CATALOG)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)


### PR DESCRIPTION
This PR changes the ListTools() endpoint.

**Before:** An in-memory cache was used for the information.
**Now:** The tool_ids are called from the DB. 