### PR TITLE
service/orchestrator: add WithSeedUsers option; register UI OAuth2 client

### DIFF
--- a/core/server/oauth_server.go
+++ b/core/server/oauth_server.go
@@ -36,6 +36,8 @@ const (
 	DefaultOAuth2LoginPassword   = "confirmate"
 	DefaultOAuth2CLIClientID     = "cli"
 	DefaultOAuth2CLIRedirectURI  = "http://localhost:10000/callback"
+	DefaultOAuth2UIClientID      = "ui"
+	DefaultOAuth2UIRedirectURI   = "http://localhost:5173/auth/callback"
 	DefaultOAuth2ServiceClientID = "confirmate"
 	DefaultOAuth2ServiceSecret   = "confirmate"
 )
@@ -66,6 +68,7 @@ func WithEmbeddedOAuth2Server(keyPath string, keyPassword string, saveOnCreate b
 
 		opts = append(opts,
 			oauth2.WithClient(DefaultOAuth2CLIClientID, "", DefaultOAuth2CLIRedirectURI),
+			oauth2.WithClient(DefaultOAuth2UIClientID, "", DefaultOAuth2UIRedirectURI),
 			oauth2.WithClient(DefaultOAuth2ServiceClientID, DefaultOAuth2ServiceSecret, ""),
 			login.WithLoginPage(
 				login.WithBaseURL("/v1/auth"),

--- a/core/service/orchestrator/service.go
+++ b/core/service/orchestrator/service.go
@@ -17,6 +17,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -44,6 +45,9 @@ type Service struct {
 
 	// authz defines our authorization strategy for target-of-evaluation scoped access.
 	authz service.AuthorizationStrategy
+
+	// seedUsers are pre-created at startup (e.g. demo users from the embedded OAuth2 server).
+	seedUsers []*orchestrator.User
 
 	// subscribers is a map of subscribers for change events
 	subscribers      map[int64]*subscriber
@@ -91,6 +95,14 @@ type Config struct {
 
 	// PersistenceConfig is the configuration for the persistence layer. If not set, defaults will be used.
 	PersistenceConfig persistence.Config
+}
+
+// WithSeedUsers registers users that will be created in the database at startup if they do not
+// already exist. Intended for demo / embedded-OAuth2 setups where users are known ahead of time.
+func WithSeedUsers(users []*orchestrator.User) service.Option[Service] {
+	return func(svc *Service) {
+		svc.seedUsers = users
+	}
 }
 
 // WithConfig sets the service configuration, overriding the default configuration.
@@ -163,6 +175,18 @@ func NewService(opts ...service.Option[Service]) (handler orchestratorconnect.Or
 
 	if err = svc.loadMetrics(); err != nil {
 		slog.Warn("Could not load metrics, continuing with empty metric list", log.Err(err))
+	}
+
+	// Pre-create seed users (e.g. demo users) if they don't already exist.
+	for _, u := range svc.seedUsers {
+		var existing orchestrator.User
+		if err = svc.db.Get(&existing, "id = ?", u.Id); errors.Is(err, persistence.ErrRecordNotFound) {
+			if err = svc.db.Create(u); err != nil {
+				return nil, fmt.Errorf("could not seed user %s: %w", u.Id, err)
+			}
+		} else if err != nil {
+			return nil, fmt.Errorf("could not check seed user %s: %w", u.Id, err)
+		}
 	}
 
 	// Create default target of evaluation if enabled and none exists


### PR DESCRIPTION
## Summary
- Adds `WithSeedUsers([]*orchestrator.User)` service option: users are created at startup if they don't already exist (idempotent on restart)
- Registers the UI OAuth2 client (`client_id=ui`, redirect `http://localhost:5173/auth/callback`) in the embedded OAuth2 server so the SvelteKit dev server can complete the PKCE flow without manual configuration

## Test plan
- [ ] Start server with `--oauth2-embedded`; pass `WithSeedUsers(...)` and verify users appear in the DB
- [ ] UI PKCE login flow completes without client_id error
🤖 Generated with [Claude Code](https://claude.com/claude-code)