### PR TITLE
service/orchestrator: ListControls returns only top-level controls

### DIFF
--- a/core/service/orchestrator/catalogs.go
+++ b/core/service/orchestrator/catalogs.go
@@ -273,7 +273,16 @@ func (svc *Service) ListControls(
 		req.Msg.Asc = true
 	}
 
-	controls, npt, err = service.PaginateStorage[*orchestrator.Control](req.Msg, svc.db, service.DefaultPaginationOpts, persistence.WithoutPreload())
+	// Only return top-level controls; children are preloaded two levels deep.
+	// catalog_id is not yet a DB column in this branch, so catalog filtering
+	// is left to the caller (the UI buckets controls by category, which is
+	// already catalog-scoped).
+	controls, npt, err = service.PaginateStorage[*orchestrator.Control](
+		req.Msg, svc.db, service.DefaultPaginationOpts,
+		persistence.WithPreload("Metrics"),
+		persistence.WithPreload("Controls.Metrics"),
+		"parent_control_id IS NULL",
+	)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Adds `parent_control_id IS NULL` filter to `ListControls` so sub-controls are not returned as duplicate top-level entries
- Sub-controls are already preloaded two levels deep via `WithPreload("Controls.Metrics")`, so callers get the full hierarchy through the top-level records

## Test plan
- [ ] `ListControls` response contains only top-level controls; sub-controls accessible via `.controls` field
- [ ] Pagination counts are correct (no inflated numbers from sub-controls)
🤖 Generated with [Claude Code](https://claude.com/claude-code)