### PR TITLE
orchestrator: Fix Postgres error for ListAssessmentResults() call with filter

### DIFF
--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -158,11 +158,10 @@ func (svc *Service) ListAssessmentResults(
 		}
 		if len(req.Msg.Filter.AssessmentResultIds) > 0 {
 			// Build IN clause dynamically to support ramsql (doesn't support array binding)
-			var marks []string
-			for range req.Msg.Filter.AssessmentResultIds {
-				marks = append(marks, "?")
-			}
-			whereClauses = append(whereClauses, "id IN ("+strings.Join(marks, ",")+")")
+			var placeholders string
+			placeholders = strings.Repeat("?,", len(req.Msg.Filter.AssessmentResultIds))
+			placeholders = placeholders[:len(placeholders)-1] // Remove trailing comma
+			whereClauses = append(whereClauses, "id IN ("+placeholders+")")
 			for _, id := range req.Msg.Filter.AssessmentResultIds {
 				args = append(args, id)
 			}
@@ -184,12 +183,14 @@ func (svc *Service) ListAssessmentResults(
 	}
 
 	// If access is not allowed to all objects, add a condition to filter by the allowed object IDs
+	// Note: The authorization filter is added in addition to any request ToE filter.
+	// Since all where clauses are combined with AND later, a requested ToE must also
+	// be part of the allowed toeIds; otherwise, the query returns no results.
 	if !all {
-		var marks []string
-		for range toeIds {
-			marks = append(marks, "?")
-		}
-		whereClauses = append(whereClauses, "target_of_evaluation_id IN ("+strings.Join(marks, ",")+")")
+		var placeholders string
+		placeholders = strings.Repeat("?,", len(toeIds))
+		placeholders = placeholders[:len(placeholders)-1] // Remove trailing comma
+		whereClauses = append(whereClauses, "target_of_evaluation_id IN ("+placeholders+")")
 		for _, id := range toeIds {
 			args = append(args, id)
 		}

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -191,7 +191,11 @@ func (svc *Service) ListAssessmentResults(
 
 	// If access is not allowed to all objects, add a condition to filter by the allowed object IDs
 	if !all {
-		conds = append(conds, "target_of_evaluation_id IN ?", toeIds)
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(toeIds)), ",")
+		whereClauses = append(whereClauses, "target_of_evaluation_id IN ("+placeholders+")")
+		for _, id := range toeIds {
+			args = append(args, id)
+		}
 	}
 
 	// Handle latest_by_resource_id filter
@@ -205,12 +209,15 @@ func (svc *Service) ListAssessmentResults(
 
 		// Add filter for allowed ToE IDs if not allowed to access all
 		if !all {
+			placeholders := strings.TrimRight(strings.Repeat("?,", len(toeIds)), ",")
 			wherePrefix := "WHERE "
 			if where != "" {
 				wherePrefix = " AND "
 			}
-			where += wherePrefix + "target_of_evaluation_id IN ?"
-			args = append(args, toeIds)
+			where += wherePrefix + "target_of_evaluation_id IN (" + placeholders + ")"
+			for _, id := range toeIds {
+				args = append(args, id)
+			}
 		}
 
 		// Use PostgreSQL DISTINCT ON with ORDER BY to get latest result per (resource_id, metric_id)

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -172,13 +172,6 @@ func (svc *Service) ListAssessmentResults(
 		}
 	}
 
-	// Combine all WHERE clauses with AND
-	if len(whereClauses) > 0 {
-		where = strings.Join(whereClauses, " AND ")
-		conds = append(conds, where)
-		conds = append(conds, args...)
-	}
-
 	// Retrieve list of all allowed ToE IDs for the user to filter results by access permissions.
 	all, toeIds = svc.authz.AllowedTargetOfEvaluations(ctx)
 	if !all && len(toeIds) == 0 {
@@ -198,6 +191,13 @@ func (svc *Service) ListAssessmentResults(
 		}
 	}
 
+	// Combine all WHERE clauses with AND
+	if len(whereClauses) > 0 {
+		where = strings.Join(whereClauses, " AND ")
+		conds = append(conds, where)
+		conds = append(conds, args...)
+	}
+
 	// Handle latest_by_resource_id filter
 	// This returns only the most recent assessment result for each unique (resource_id, metric_id) pair
 	// Uses PostgreSQL's DISTINCT ON for efficient grouping
@@ -205,19 +205,6 @@ func (svc *Service) ListAssessmentResults(
 		// Reuse the WHERE query and args directly.
 		if where != "" {
 			where = "WHERE " + where
-		}
-
-		// Add filter for allowed ToE IDs if not allowed to access all
-		if !all {
-			placeholders := strings.TrimRight(strings.Repeat("?,", len(toeIds)), ",")
-			wherePrefix := "WHERE "
-			if where != "" {
-				wherePrefix = " AND "
-			}
-			where += wherePrefix + "target_of_evaluation_id IN (" + placeholders + ")"
-			for _, id := range toeIds {
-				args = append(args, id)
-			}
 		}
 
 		// Use PostgreSQL DISTINCT ON with ORDER BY to get latest result per (resource_id, metric_id)

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -158,10 +158,11 @@ func (svc *Service) ListAssessmentResults(
 		}
 		if len(req.Msg.Filter.AssessmentResultIds) > 0 {
 			// Build IN clause dynamically to support ramsql (doesn't support array binding)
-			var placeholders string
-			placeholders = strings.Repeat("?,", len(req.Msg.Filter.AssessmentResultIds))
-			placeholders = placeholders[:len(placeholders)-1] // Remove trailing comma
-			whereClauses = append(whereClauses, "id IN ("+placeholders+")")
+			var marks []string
+			for range req.Msg.Filter.AssessmentResultIds {
+				marks = append(marks, "?")
+			}
+			whereClauses = append(whereClauses, "id IN ("+strings.Join(marks, ",")+")")
 			for _, id := range req.Msg.Filter.AssessmentResultIds {
 				args = append(args, id)
 			}
@@ -184,8 +185,11 @@ func (svc *Service) ListAssessmentResults(
 
 	// If access is not allowed to all objects, add a condition to filter by the allowed object IDs
 	if !all {
-		placeholders := strings.TrimRight(strings.Repeat("?,", len(toeIds)), ",")
-		whereClauses = append(whereClauses, "target_of_evaluation_id IN ("+placeholders+")")
+		var marks []string
+		for range toeIds {
+			marks = append(marks, "?")
+		}
+		whereClauses = append(whereClauses, "target_of_evaluation_id IN ("+strings.Join(marks, ",")+")")
 		for _, id := range toeIds {
 			args = append(args, id)
 		}


### PR DESCRIPTION
This PR fixes a Postgres error in ListAssessmentResults when access is restricted to specific Target of Evaluation IDs (`all=false`).
The query previously passed `toeIds` as a slice to `IN ?`, which caused Postgres to fail with:
`ERROR: could not determine data type of parameter $2`
The filter now uses explicit `IN (...)` placeholders instead of slice binding.