### PR TITLE
API additions for the new UI (re-targeted to main)

### DIFF
--- a/core/api/evidence/evidence.pb.go
+++ b/core/api/evidence/evidence.pb.go
@@ -497,10 +497,10 @@ const file_api_evidence_evidence_proto_rawDesc = "" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06source\x12\"\n" +
 	"\x06target\x18\x03 \x01(\tB\n" +
 	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\x06target\x12\x17\n" +
-	"\x04type\x18\x04 \x01(\tB\x03\xe0A\x02R\x04type2\xc2\x02\n" +
+	"\x04type\x18\x04 \x01(\tB\x03\xe0A\x02R\x04type2\xc8\x02\n" +
 	"\tResources\x12\xa0\x01\n" +
-	"\x0eUpdateResource\x12-.confirmate.evidence.v1.UpdateResourceRequest\x1a(.confirmate.evidence.v1.ResourceSnapshot\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/evidence_store/resources/{resource.id}\x12\x91\x01\n" +
-	"\x0eListGraphEdges\x12-.confirmate.evidence.v1.ListGraphEdgesRequest\x1a..confirmate.evidence.v1.ListGraphEdgesResponse\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/evidence/graph/edgesB!Z\x1fconfirmate.io/core/api/evidenceb\x06proto3"
+	"\x0eUpdateResource\x12-.confirmate.evidence.v1.UpdateResourceRequest\x1a(.confirmate.evidence.v1.ResourceSnapshot\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/evidence_store/resources/{resource.id}\x12\x97\x01\n" +
+	"\x0eListGraphEdges\x12-.confirmate.evidence.v1.ListGraphEdgesRequest\x1a..confirmate.evidence.v1.ListGraphEdgesResponse\"&\x82\xd3\xe4\x93\x02 \x12\x1e/v1/evidence_store/graph/edgesB!Z\x1fconfirmate.io/core/api/evidenceb\x06proto3"
 
 var (
 	file_api_evidence_evidence_proto_rawDescOnce sync.Once

--- a/core/api/evidence/evidence.proto
+++ b/core/api/evidence/evidence.proto
@@ -104,7 +104,12 @@ service Resources {
   // ListGraphEdges returns the edges (relationship) between resources in our
   // resource graph.
   rpc ListGraphEdges(ListGraphEdgesRequest) returns (ListGraphEdgesResponse) {
-    option (google.api.http) = {get: "/v1/evidence/graph/edges"};
+    // Path lives under /graph/ rather than /resources/edges so it does not
+    // collide with the parameterized UpdateResource path
+    // (/v1/evidence_store/resources/{resource.id}). The Vanguard transcoder
+    // otherwise treats "edges" as a value for {resource.id} and only matches
+    // the POST verb.
+    option (google.api.http) = {get: "/v1/evidence_store/graph/edges"};
   }
 }
 

--- a/core/api/evidence/evidence.proto
+++ b/core/api/evidence/evidence.proto
@@ -104,11 +104,6 @@ service Resources {
   // ListGraphEdges returns the edges (relationship) between resources in our
   // resource graph.
   rpc ListGraphEdges(ListGraphEdgesRequest) returns (ListGraphEdgesResponse) {
-    // Path lives under /graph/ rather than /resources/edges so it does not
-    // collide with the parameterized UpdateResource path
-    // (/v1/evidence_store/resources/{resource.id}). The Vanguard transcoder
-    // otherwise treats "edges" as a value for {resource.id} and only matches
-    // the POST verb.
     option (google.api.http) = {get: "/v1/evidence_store/graph/edges"};
   }
 }

--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -4,47 +4,9 @@
 openapi: 3.0.3
 info:
     title: Evidence Store API
+    version: core/v0.2.16-54-g72d4e5bb
     version: core/v0.2.16-3-g24a503b
 paths:
-    /v1/evidence/graph/edges:
-        get:
-            tags:
-                - Resources
-            description: |-
-                ListGraphEdges returns the edges (relationship) between resources in our
-                 resource graph.
-            operationId: Resources_ListGraphEdges
-            parameters:
-                - name: pageSize
-                  in: query
-                  schema:
-                    type: integer
-                    format: int32
-                - name: pageToken
-                  in: query
-                  schema:
-                    type: string
-                - name: orderBy
-                  in: query
-                  schema:
-                    type: string
-                - name: asc
-                  in: query
-                  schema:
-                    type: boolean
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ListGraphEdgesResponse'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
     /v1/evidence_store/evidence:
         post:
             tags:
@@ -139,6 +101,45 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Evidence'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/evidence_store/graph/edges:
+        get:
+            tags:
+                - Resources
+            description: |-
+                ListGraphEdges returns the edges (relationship) between resources in our
+                 resource graph.
+            operationId: Resources_ListGraphEdges
+            parameters:
+                - name: pageSize
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  schema:
+                    type: string
+                - name: orderBy
+                  in: query
+                  schema:
+                    type: string
+                - name: asc
+                  in: query
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListGraphEdgesResponse'
                 default:
                     description: Default error response
                     content:
@@ -379,10 +380,6 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Agnostic is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents an agnostic architecture, which is not tied to a specific operating system.
@@ -480,10 +477,6 @@ components:
                         type: string
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Application is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  This encapsulates the whole (source) code of an application.
@@ -865,10 +858,6 @@ components:
                     items:
                         $ref: '#/components/schemas/Cipher'
             description: CipherSuite is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-        CloudFeature:
-            type: object
-            properties: {}
-            description: CloudFeature is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         CodeRegion:
             type: object
             properties:
@@ -1551,18 +1540,40 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Darwin is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Darwin architecture, commonly found on macOS systems. macOS is a certified. [UNIX](https://www.opengroup.org/openbrand/register/apple.htm) and is (mostly) POSIX compatible.
         DataConfidentialitySDNPolicy:
             type: object
             properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
                 isDefined:
                     type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
             description: |-
                 DataConfidentialitySDNPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a policy section within a [PolicyDocument] describing data confidentiality requirements for Software Defined Networking (SDN). isDefined: whether this policy section is present and defined.
@@ -2450,16 +2461,6 @@ components:
                     $ref: '#/components/schemas/Output'
                 padding:
                     $ref: '#/components/schemas/Padding'
-                dataConfidentialitySdnPolicy:
-                    $ref: '#/components/schemas/DataConfidentialitySDNPolicy'
-                leastPrivilegePolicy:
-                    $ref: '#/components/schemas/LeastPrivilegePolicy'
-                needToKnowPolicy:
-                    $ref: '#/components/schemas/NeedToKnowPolicy'
-                sdnFunctionValidationPolicy:
-                    $ref: '#/components/schemas/SDNFunctionValidationPolicy'
-                separationOfDutiesPolicy:
-                    $ref: '#/components/schemas/SeparationOfDutiesPolicy'
                 principal:
                     $ref: '#/components/schemas/Principal'
                 protectedAsset:
@@ -2470,8 +2471,6 @@ components:
                     $ref: '#/components/schemas/SchemaValidation'
                 securityAdvisoryFeed:
                     $ref: '#/components/schemas/SecurityAdvisoryFeed'
-                securityIncident:
-                    $ref: '#/components/schemas/SecurityIncident'
                 time:
                     $ref: '#/components/schemas/Time'
                 vulnerability:
@@ -3524,8 +3523,34 @@ components:
         LeastPrivilegePolicy:
             type: object
             properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
                 isDefined:
                     type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
             description: |-
                 LeastPrivilegePolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a policy section within a [PolicyDocument] describing least privilege requirements. isDefined: whether this policy section is present and defined.
@@ -3564,10 +3589,6 @@ components:
                         type: string
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
                 vulnerabilities:
                     type: array
                     items:
@@ -4277,8 +4298,34 @@ components:
         NeedToKnowPolicy:
             type: object
             properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
                 isDefined:
                     type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
             description: |-
                 NeedToKnowPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a policy section within a [PolicyDocument] describing need-to-know access control requirements. isDefined: whether this policy section is present and defined.
@@ -4598,10 +4645,6 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 POSIX is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a POSIX architecture, commonly found on Linux systems.
@@ -4636,10 +4679,6 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Package is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a grouping of (source) code into logical unit, for example a package for a namespace.
@@ -4728,18 +4767,12 @@ components:
                 raw:
                     type: string
                     description: The raw field contains the raw information that is used to fill in the fields of the ontology.
-                assetInventory:
-                    $ref: '#/components/schemas/AssetInventory'
-                backup:
-                    $ref: '#/components/schemas/Backup'
-                cloudFeature:
-                    $ref: '#/components/schemas/CloudFeature'
                 cryptographicHashs:
                     type: array
                     items:
                         $ref: '#/components/schemas/CryptographicHash'
-                dataConfidentialitySdnPolicy:
-                    $ref: '#/components/schemas/DataConfidentialitySDNPolicy'
+                dataConfidentialitySdnPolicyId:
+                    type: string
                 dataLocation:
                     $ref: '#/components/schemas/DataLocation'
                 documentSignatures:
@@ -4750,24 +4783,22 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Governance'
-                leastPrivilegePolicy:
-                    $ref: '#/components/schemas/LeastPrivilegePolicy'
-                needToKnowPolicy:
-                    $ref: '#/components/schemas/NeedToKnowPolicy'
+                leastPrivilegePolicyId:
+                    type: string
+                needToKnowPolicyId:
+                    type: string
                 parentId:
                     type: string
-                sdnFunctionValidationPolicy:
-                    $ref: '#/components/schemas/SDNFunctionValidationPolicy'
+                sdnFunctionValidationPolicyId:
+                    type: string
                 validatedBy:
                     $ref: '#/components/schemas/SchemaValidation'
                 securityFeatures:
                     type: array
                     items:
                         $ref: '#/components/schemas/SecurityFeature'
-                securityIncident:
-                    $ref: '#/components/schemas/SecurityIncident'
-                separationOfDutiesPolicy:
-                    $ref: '#/components/schemas/SeparationOfDutiesPolicy'
+                separationOfDutiesPolicyId:
+                    type: string
             description: PolicyDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Principal:
             type: object
@@ -5360,6 +5391,16 @@ components:
                     $ref: '#/components/schemas/MachineLearningModel'
                 coordinatedVulnerabilityDisclosurePolicy:
                     $ref: '#/components/schemas/CoordinatedVulnerabilityDisclosurePolicy'
+                dataConfidentialitySdnPolicy:
+                    $ref: '#/components/schemas/DataConfidentialitySDNPolicy'
+                leastPrivilegePolicy:
+                    $ref: '#/components/schemas/LeastPrivilegePolicy'
+                needToKnowPolicy:
+                    $ref: '#/components/schemas/NeedToKnowPolicy'
+                sdnFunctionValidationPolicy:
+                    $ref: '#/components/schemas/SDNFunctionValidationPolicy'
+                separationOfDutiesPolicy:
+                    $ref: '#/components/schemas/SeparationOfDutiesPolicy'
                 andRule:
                     $ref: '#/components/schemas/AndRule'
                 token:
@@ -5575,8 +5616,34 @@ components:
         SDNFunctionValidationPolicy:
             type: object
             properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
                 isDefined:
                     type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
             description: |-
                 SDNFunctionValidationPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a policy section within a [PolicyDocument] describing validation and testing requirements for SDN functions. isDefined: whether this policy section is present and defined.
@@ -5842,8 +5909,6 @@ components:
                     $ref: '#/components/schemas/LocalAttestation'
                 remoteAttestation:
                     $ref: '#/components/schemas/RemoteAttestation'
-                softwareAttestation:
-                    $ref: '#/components/schemas/SoftwareAttestation'
                 automaticUpdates:
                     $ref: '#/components/schemas/AutomaticUpdates'
                 cryptographicHash:
@@ -5861,14 +5926,6 @@ components:
                 robustnessScore:
                     $ref: '#/components/schemas/RobustnessScore'
             description: SecurityFeature is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
-        SecurityIncident:
-            type: object
-            properties:
-                team:
-                    type: array
-                    items:
-                        type: string
-            description: SecurityIncident is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SecurityTraining:
             type: object
             properties:
@@ -5880,8 +5937,34 @@ components:
         SeparationOfDutiesPolicy:
             type: object
             properties:
+                creationTime:
+                    type: string
+                    format: date-time
+                description:
+                    type: string
+                id:
+                    type: string
                 isDefined:
                     type: boolean
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                name:
+                    type: string
+                raw:
+                    type: string
+                    description: The raw field contains the raw information that is used to fill in the fields of the ontology.
+                contextId:
+                    type: string
+                dataLocation:
+                    $ref: '#/components/schemas/DataLocation'
+                policyRuleIds:
+                    type: array
+                    items:
+                        type: string
+                parentId:
+                    type: string
             description: |-
                 SeparationOfDutiesPolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a policy section within a [PolicyDocument] describing separation of duties requirements. isDefined: whether this policy section is present and defined.
@@ -5952,12 +6035,6 @@ components:
                     description: Maximum password rotation interval in months
                     format: int32
             description: SingleSignOn is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-        SoftwareAttestation:
-            type: object
-            properties:
-                enabled:
-                    type: boolean
-            description: SoftwareAttestation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         SourceCodeFile:
             type: object
             properties:
@@ -5989,10 +6066,6 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: SourceCodeFile is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
         Status:
             type: object
@@ -6452,10 +6525,6 @@ components:
                         $ref: '#/components/schemas/Functionality'
                 parentId:
                     type: string
-                softwareAttestations:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/SoftwareAttestation'
             description: |-
                 Win32 is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
                  Represents a Win32 architecture, commonly found on Windows systems.

--- a/core/api/evidence/openapi.yaml
+++ b/core/api/evidence/openapi.yaml
@@ -5,7 +5,6 @@ openapi: 3.0.3
 info:
     title: Evidence Store API
     version: core/v0.2.16-54-g72d4e5bb
-    version: core/v0.2.16-3-g24a503b
 paths:
     /v1/evidence_store/evidence:
         post:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -5,6 +5,7 @@ openapi: 3.0.3
 info:
     title: Orchestrator API
     description: Manages the orchestration of components within the confirmate architecture
+    version: core/v0.2.16-54-g72d4e5bb
     version: core/v0.2.16-3-g24a503b
 paths:
     /v1/orchestrator/assessment_results:
@@ -884,6 +885,11 @@ paths:
                   description: Optional. Filter by assignee.
                   schema:
                     type: string
+                - name: filter.controlId
+                  in: query
+                  description: Optional. Filter by control ID.
+                  schema:
+                    type: string
                 - name: pageSize
                   in: query
                   schema:
@@ -1006,6 +1012,11 @@ paths:
                 - name: id
                   in: path
                   required: true
+                  schema:
+                    type: string
+                - name: comment
+                  in: query
+                  description: Comment explains why this control is being removed from scope.
                   schema:
                     type: string
             responses:
@@ -2647,6 +2658,9 @@ components:
                 assigneeId:
                     type: string
                     description: AssigneeId is the ID of the orchestrator User entity initially responsible for this control.
+                comment:
+                    type: string
+                    description: Comment explains why this control is being brought into scope.
         Dependency:
             type: object
             properties:

--- a/core/api/orchestrator/openapi.yaml
+++ b/core/api/orchestrator/openapi.yaml
@@ -6,7 +6,6 @@ info:
     title: Orchestrator API
     description: Manages the orchestration of components within the confirmate architecture
     version: core/v0.2.16-54-g72d4e5bb
-    version: core/v0.2.16-3-g24a503b
 paths:
     /v1/orchestrator/assessment_results:
         get:

--- a/core/api/orchestrator/workflow.pb.go
+++ b/core/api/orchestrator/workflow.pb.go
@@ -453,6 +453,115 @@ func (x *ControlInScopeTransitionEvent) GetToState() ControlInScopeState {
 	return ControlInScopeState_CONTROL_IN_SCOPE_STATE_UNSPECIFIED
 }
 
+// ControlInScopeAssigneeChangedEvent is emitted when the assignee of a ControlInScope changes.
+type ControlInScopeAssigneeChangedEvent struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ControlInScopeId string                 `protobuf:"bytes,1,opt,name=control_in_scope_id,json=controlInScopeId,proto3" json:"control_in_scope_id,omitempty"`
+	// previous_assignee_id is empty when there was no prior assignee.
+	PreviousAssigneeId *string `protobuf:"bytes,2,opt,name=previous_assignee_id,json=previousAssigneeId,proto3,oneof" json:"previous_assignee_id,omitempty"`
+	// new_assignee_id is empty when the assignee is removed.
+	NewAssigneeId *string `protobuf:"bytes,3,opt,name=new_assignee_id,json=newAssigneeId,proto3,oneof" json:"new_assignee_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ControlInScopeAssigneeChangedEvent) Reset() {
+	*x = ControlInScopeAssigneeChangedEvent{}
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ControlInScopeAssigneeChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ControlInScopeAssigneeChangedEvent) ProtoMessage() {}
+
+func (x *ControlInScopeAssigneeChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ControlInScopeAssigneeChangedEvent.ProtoReflect.Descriptor instead.
+func (*ControlInScopeAssigneeChangedEvent) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ControlInScopeAssigneeChangedEvent) GetControlInScopeId() string {
+	if x != nil {
+		return x.ControlInScopeId
+	}
+	return ""
+}
+
+func (x *ControlInScopeAssigneeChangedEvent) GetPreviousAssigneeId() string {
+	if x != nil && x.PreviousAssigneeId != nil {
+		return *x.PreviousAssigneeId
+	}
+	return ""
+}
+
+func (x *ControlInScopeAssigneeChangedEvent) GetNewAssigneeId() string {
+	if x != nil && x.NewAssigneeId != nil {
+		return *x.NewAssigneeId
+	}
+	return ""
+}
+
+// ControlInScopeDetailsChangedEvent is emitted when implementation_details is updated.
+// The content of the details is intentionally not included.
+type ControlInScopeDetailsChangedEvent struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ControlInScopeId string                 `protobuf:"bytes,1,opt,name=control_in_scope_id,json=controlInScopeId,proto3" json:"control_in_scope_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ControlInScopeDetailsChangedEvent) Reset() {
+	*x = ControlInScopeDetailsChangedEvent{}
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ControlInScopeDetailsChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ControlInScopeDetailsChangedEvent) ProtoMessage() {}
+
+func (x *ControlInScopeDetailsChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ControlInScopeDetailsChangedEvent.ProtoReflect.Descriptor instead.
+func (*ControlInScopeDetailsChangedEvent) Descriptor() ([]byte, []int) {
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ControlInScopeDetailsChangedEvent) GetControlInScopeId() string {
+	if x != nil {
+		return x.ControlInScopeId
+	}
+	return ""
+}
+
 type CreateControlInScopeRequest struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	AuditScopeId string                 `protobuf:"bytes,1,opt,name=audit_scope_id,json=auditScopeId,proto3" json:"audit_scope_id,omitempty"`
@@ -461,14 +570,16 @@ type CreateControlInScopeRequest struct {
 	// It is required here so the server can avoid a round-trip fetch of the AuditScope.
 	TargetOfEvaluationId string `protobuf:"bytes,4,opt,name=target_of_evaluation_id,json=targetOfEvaluationId,proto3" json:"target_of_evaluation_id,omitempty"`
 	// AssigneeId is the ID of the orchestrator User entity initially responsible for this control.
-	AssigneeId    *string `protobuf:"bytes,3,opt,name=assignee_id,json=assigneeId,proto3,oneof" json:"assignee_id,omitempty"`
+	AssigneeId *string `protobuf:"bytes,3,opt,name=assignee_id,json=assigneeId,proto3,oneof" json:"assignee_id,omitempty"`
+	// Comment explains why this control is being brought into scope.
+	Comment       *string `protobuf:"bytes,5,opt,name=comment,proto3,oneof" json:"comment,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateControlInScopeRequest) Reset() {
 	*x = CreateControlInScopeRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[4]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -480,7 +591,7 @@ func (x *CreateControlInScopeRequest) String() string {
 func (*CreateControlInScopeRequest) ProtoMessage() {}
 
 func (x *CreateControlInScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[4]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -493,7 +604,7 @@ func (x *CreateControlInScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateControlInScopeRequest.ProtoReflect.Descriptor instead.
 func (*CreateControlInScopeRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{4}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateControlInScopeRequest) GetAuditScopeId() string {
@@ -524,6 +635,13 @@ func (x *CreateControlInScopeRequest) GetAssigneeId() string {
 	return ""
 }
 
+func (x *CreateControlInScopeRequest) GetComment() string {
+	if x != nil && x.Comment != nil {
+		return *x.Comment
+	}
+	return ""
+}
+
 type GetControlInScopeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -533,7 +651,7 @@ type GetControlInScopeRequest struct {
 
 func (x *GetControlInScopeRequest) Reset() {
 	*x = GetControlInScopeRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[5]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -545,7 +663,7 @@ func (x *GetControlInScopeRequest) String() string {
 func (*GetControlInScopeRequest) ProtoMessage() {}
 
 func (x *GetControlInScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[5]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -558,7 +676,7 @@ func (x *GetControlInScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetControlInScopeRequest.ProtoReflect.Descriptor instead.
 func (*GetControlInScopeRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{5}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetControlInScopeRequest) GetId() string {
@@ -581,7 +699,7 @@ type ListControlsInScopeRequest struct {
 
 func (x *ListControlsInScopeRequest) Reset() {
 	*x = ListControlsInScopeRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[6]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -593,7 +711,7 @@ func (x *ListControlsInScopeRequest) String() string {
 func (*ListControlsInScopeRequest) ProtoMessage() {}
 
 func (x *ListControlsInScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[6]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -606,7 +724,7 @@ func (x *ListControlsInScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListControlsInScopeRequest.ProtoReflect.Descriptor instead.
 func (*ListControlsInScopeRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{6}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListControlsInScopeRequest) GetFilter() *ListControlsInScopeRequest_Filter {
@@ -654,7 +772,7 @@ type ListControlsInScopeResponse struct {
 
 func (x *ListControlsInScopeResponse) Reset() {
 	*x = ListControlsInScopeResponse{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[7]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -666,7 +784,7 @@ func (x *ListControlsInScopeResponse) String() string {
 func (*ListControlsInScopeResponse) ProtoMessage() {}
 
 func (x *ListControlsInScopeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[7]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -679,7 +797,7 @@ func (x *ListControlsInScopeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListControlsInScopeResponse.ProtoReflect.Descriptor instead.
 func (*ListControlsInScopeResponse) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{7}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListControlsInScopeResponse) GetControlsInScope() []*ControlInScope {
@@ -708,7 +826,7 @@ type UpdateControlInScopeRequest struct {
 
 func (x *UpdateControlInScopeRequest) Reset() {
 	*x = UpdateControlInScopeRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[8]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -720,7 +838,7 @@ func (x *UpdateControlInScopeRequest) String() string {
 func (*UpdateControlInScopeRequest) ProtoMessage() {}
 
 func (x *UpdateControlInScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[8]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -733,7 +851,7 @@ func (x *UpdateControlInScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateControlInScopeRequest.ProtoReflect.Descriptor instead.
 func (*UpdateControlInScopeRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{8}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *UpdateControlInScopeRequest) GetId() string {
@@ -769,7 +887,7 @@ type TransitionControlInScopeStateRequest struct {
 
 func (x *TransitionControlInScopeStateRequest) Reset() {
 	*x = TransitionControlInScopeStateRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[9]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -781,7 +899,7 @@ func (x *TransitionControlInScopeStateRequest) String() string {
 func (*TransitionControlInScopeStateRequest) ProtoMessage() {}
 
 func (x *TransitionControlInScopeStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[9]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -794,7 +912,7 @@ func (x *TransitionControlInScopeStateRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use TransitionControlInScopeStateRequest.ProtoReflect.Descriptor instead.
 func (*TransitionControlInScopeStateRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{9}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *TransitionControlInScopeStateRequest) GetId() string {
@@ -819,15 +937,17 @@ func (x *TransitionControlInScopeStateRequest) GetComment() string {
 }
 
 type RemoveControlInScopeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Comment explains why this control is being removed from scope.
+	Comment       *string `protobuf:"bytes,2,opt,name=comment,proto3,oneof" json:"comment,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RemoveControlInScopeRequest) Reset() {
 	*x = RemoveControlInScopeRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[10]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -839,7 +959,7 @@ func (x *RemoveControlInScopeRequest) String() string {
 func (*RemoveControlInScopeRequest) ProtoMessage() {}
 
 func (x *RemoveControlInScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[10]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -852,12 +972,19 @@ func (x *RemoveControlInScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveControlInScopeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveControlInScopeRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{10}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RemoveControlInScopeRequest) GetId() string {
 	if x != nil {
 		return x.Id
+	}
+	return ""
+}
+
+func (x *RemoveControlInScopeRequest) GetComment() string {
+	if x != nil && x.Comment != nil {
+		return *x.Comment
 	}
 	return ""
 }
@@ -875,7 +1002,7 @@ type ListAuditTrailEventsRequest struct {
 
 func (x *ListAuditTrailEventsRequest) Reset() {
 	*x = ListAuditTrailEventsRequest{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[11]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -887,7 +1014,7 @@ func (x *ListAuditTrailEventsRequest) String() string {
 func (*ListAuditTrailEventsRequest) ProtoMessage() {}
 
 func (x *ListAuditTrailEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[11]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -900,7 +1027,7 @@ func (x *ListAuditTrailEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAuditTrailEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListAuditTrailEventsRequest) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{11}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListAuditTrailEventsRequest) GetFilter() *ListAuditTrailEventsRequest_Filter {
@@ -948,7 +1075,7 @@ type ListAuditTrailEventsResponse struct {
 
 func (x *ListAuditTrailEventsResponse) Reset() {
 	*x = ListAuditTrailEventsResponse{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[12]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -960,7 +1087,7 @@ func (x *ListAuditTrailEventsResponse) String() string {
 func (*ListAuditTrailEventsResponse) ProtoMessage() {}
 
 func (x *ListAuditTrailEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[12]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -973,7 +1100,7 @@ func (x *ListAuditTrailEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAuditTrailEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListAuditTrailEventsResponse) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{12}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ListAuditTrailEventsResponse) GetAuditTrailEvents() []*AuditTrailEvent {
@@ -997,14 +1124,16 @@ type ListControlsInScopeRequest_Filter struct {
 	// Optional. Filter by current state.
 	State *ControlInScopeState `protobuf:"varint,2,opt,name=state,proto3,enum=confirmate.orchestrator.v1.ControlInScopeState,oneof" json:"state,omitempty"`
 	// Optional. Filter by assignee.
-	AssigneeId    *string `protobuf:"bytes,3,opt,name=assignee_id,json=assigneeId,proto3,oneof" json:"assignee_id,omitempty"`
+	AssigneeId *string `protobuf:"bytes,3,opt,name=assignee_id,json=assigneeId,proto3,oneof" json:"assignee_id,omitempty"`
+	// Optional. Filter by control ID.
+	ControlId     *string `protobuf:"bytes,4,opt,name=control_id,json=controlId,proto3,oneof" json:"control_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListControlsInScopeRequest_Filter) Reset() {
 	*x = ListControlsInScopeRequest_Filter{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[13]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1016,7 +1145,7 @@ func (x *ListControlsInScopeRequest_Filter) String() string {
 func (*ListControlsInScopeRequest_Filter) ProtoMessage() {}
 
 func (x *ListControlsInScopeRequest_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[13]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1029,7 +1158,7 @@ func (x *ListControlsInScopeRequest_Filter) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListControlsInScopeRequest_Filter.ProtoReflect.Descriptor instead.
 func (*ListControlsInScopeRequest_Filter) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{6, 0}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{8, 0}
 }
 
 func (x *ListControlsInScopeRequest_Filter) GetAuditScopeId() string {
@@ -1053,6 +1182,13 @@ func (x *ListControlsInScopeRequest_Filter) GetAssigneeId() string {
 	return ""
 }
 
+func (x *ListControlsInScopeRequest_Filter) GetControlId() string {
+	if x != nil && x.ControlId != nil {
+		return *x.ControlId
+	}
+	return ""
+}
+
 type ListAuditTrailEventsRequest_Filter struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional. Filter by audit scope.
@@ -1067,7 +1203,7 @@ type ListAuditTrailEventsRequest_Filter struct {
 
 func (x *ListAuditTrailEventsRequest_Filter) Reset() {
 	*x = ListAuditTrailEventsRequest_Filter{}
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[14]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1079,7 +1215,7 @@ func (x *ListAuditTrailEventsRequest_Filter) String() string {
 func (*ListAuditTrailEventsRequest_Filter) ProtoMessage() {}
 
 func (x *ListAuditTrailEventsRequest_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_orchestrator_workflow_proto_msgTypes[14]
+	mi := &file_api_orchestrator_workflow_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1092,7 +1228,7 @@ func (x *ListAuditTrailEventsRequest_Filter) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use ListAuditTrailEventsRequest_Filter.ProtoReflect.Descriptor instead.
 func (*ListAuditTrailEventsRequest_Filter) Descriptor() ([]byte, []int) {
-	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{11, 0}
+	return file_api_orchestrator_workflow_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *ListAuditTrailEventsRequest_Filter) GetAuditScopeId() string {
@@ -1158,17 +1294,28 @@ const file_api_orchestrator_workflow_proto_rawDesc = "" +
 	"\x13control_in_scope_id\x18\x01 \x01(\tR\x10controlInScopeId\x12N\n" +
 	"\n" +
 	"from_state\x18\x02 \x01(\x0e2/.confirmate.orchestrator.v1.ControlInScopeStateR\tfromState\x12J\n" +
-	"\bto_state\x18\x03 \x01(\x0e2/.confirmate.orchestrator.v1.ControlInScopeStateR\atoState\"\xf6\x01\n" +
+	"\bto_state\x18\x03 \x01(\x0e2/.confirmate.orchestrator.v1.ControlInScopeStateR\atoState\"\xe4\x01\n" +
+	"\"ControlInScopeAssigneeChangedEvent\x12-\n" +
+	"\x13control_in_scope_id\x18\x01 \x01(\tR\x10controlInScopeId\x125\n" +
+	"\x14previous_assignee_id\x18\x02 \x01(\tH\x00R\x12previousAssigneeId\x88\x01\x01\x12+\n" +
+	"\x0fnew_assignee_id\x18\x03 \x01(\tH\x01R\rnewAssigneeId\x88\x01\x01B\x17\n" +
+	"\x15_previous_assignee_idB\x12\n" +
+	"\x10_new_assignee_id\"R\n" +
+	"!ControlInScopeDetailsChangedEvent\x12-\n" +
+	"\x13control_in_scope_id\x18\x01 \x01(\tR\x10controlInScopeId\"\xa1\x02\n" +
 	"\x1bCreateControlInScopeRequest\x121\n" +
 	"\x0eaudit_scope_id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\fauditScopeId\x12*\n" +
 	"\n" +
 	"control_id\x18\x02 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\tcontrolId\x12B\n" +
 	"\x17target_of_evaluation_id\x18\x04 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x14targetOfEvaluationId\x12$\n" +
 	"\vassignee_id\x18\x03 \x01(\tH\x00R\n" +
-	"assigneeId\x88\x01\x01B\x0e\n" +
-	"\f_assignee_id\"7\n" +
+	"assigneeId\x88\x01\x01\x12\x1d\n" +
+	"\acomment\x18\x05 \x01(\tH\x01R\acomment\x88\x01\x01B\x0e\n" +
+	"\f_assignee_idB\n" +
+	"\n" +
+	"\b_comment\"7\n" +
 	"\x18GetControlInScopeRequest\x12\x1b\n" +
-	"\x02id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\xd5\x03\n" +
+	"\x02id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\x92\x04\n" +
 	"\x1aListControlsInScopeRequest\x12Z\n" +
 	"\x06filter\x18\x01 \x01(\v2=.confirmate.orchestrator.v1.ListControlsInScopeRequest.FilterH\x00R\x06filter\x88\x01\x01\x12\x1b\n" +
 	"\tpage_size\x18\n" +
@@ -1176,15 +1323,18 @@ const file_api_orchestrator_workflow_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\x1a\xe6\x01\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\x1a\xa3\x02\n" +
 	"\x06Filter\x123\n" +
 	"\x0eaudit_scope_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\fauditScopeId\x88\x01\x01\x12T\n" +
 	"\x05state\x18\x02 \x01(\x0e2/.confirmate.orchestrator.v1.ControlInScopeStateB\b\xbaH\x05\x82\x01\x02\x10\x01H\x01R\x05state\x88\x01\x01\x12$\n" +
 	"\vassignee_id\x18\x03 \x01(\tH\x02R\n" +
-	"assigneeId\x88\x01\x01B\x11\n" +
+	"assigneeId\x88\x01\x01\x12,\n" +
+	"\n" +
+	"control_id\x18\x04 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x03R\tcontrolId\x88\x01\x01B\x11\n" +
 	"\x0f_audit_scope_idB\b\n" +
 	"\x06_stateB\x0e\n" +
-	"\f_assignee_idB\t\n" +
+	"\f_assignee_idB\r\n" +
+	"\v_control_idB\t\n" +
 	"\a_filter\"\x9d\x01\n" +
 	"\x1bListControlsInScopeResponse\x12V\n" +
 	"\x11controls_in_scope\x18\x01 \x03(\v2*.confirmate.orchestrator.v1.ControlInScopeR\x0fcontrolsInScope\x12&\n" +
@@ -1200,9 +1350,12 @@ const file_api_orchestrator_workflow_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12Y\n" +
 	"\bto_state\x18\x02 \x01(\x0e2/.confirmate.orchestrator.v1.ControlInScopeStateB\r\xe0A\x02\xbaH\a\x82\x01\x04\x10\x01 \x00R\atoState\x12$\n" +
 	"\acomment\x18\x03 \x01(\tB\n" +
-	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\acomment\":\n" +
+	"\xe0A\x02\xbaH\x04r\x02\x10\x01R\acomment\"e\n" +
 	"\x1bRemoveControlInScopeRequest\x12\x1b\n" +
-	"\x02id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\xc4\x03\n" +
+	"\x02id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12\x1d\n" +
+	"\acomment\x18\x02 \x01(\tH\x00R\acomment\x88\x01\x01B\n" +
+	"\n" +
+	"\b_comment\"\xc4\x03\n" +
 	"\x1bListAuditTrailEventsRequest\x12[\n" +
 	"\x06filter\x18\x01 \x01(\v2>.confirmate.orchestrator.v1.ListAuditTrailEventsRequest.FilterH\x00R\x06filter\x88\x01\x01\x12\x1b\n" +
 	"\tpage_size\x18\n" +
@@ -1243,39 +1396,41 @@ func file_api_orchestrator_workflow_proto_rawDescGZIP() []byte {
 }
 
 var file_api_orchestrator_workflow_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_orchestrator_workflow_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_api_orchestrator_workflow_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_api_orchestrator_workflow_proto_goTypes = []any{
 	(ControlInScopeState)(0),                     // 0: confirmate.orchestrator.v1.ControlInScopeState
 	(*ControlInScope)(nil),                       // 1: confirmate.orchestrator.v1.ControlInScope
 	(*AuditTrailEvent)(nil),                      // 2: confirmate.orchestrator.v1.AuditTrailEvent
 	(*ControlScopingEvent)(nil),                  // 3: confirmate.orchestrator.v1.ControlScopingEvent
 	(*ControlInScopeTransitionEvent)(nil),        // 4: confirmate.orchestrator.v1.ControlInScopeTransitionEvent
-	(*CreateControlInScopeRequest)(nil),          // 5: confirmate.orchestrator.v1.CreateControlInScopeRequest
-	(*GetControlInScopeRequest)(nil),             // 6: confirmate.orchestrator.v1.GetControlInScopeRequest
-	(*ListControlsInScopeRequest)(nil),           // 7: confirmate.orchestrator.v1.ListControlsInScopeRequest
-	(*ListControlsInScopeResponse)(nil),          // 8: confirmate.orchestrator.v1.ListControlsInScopeResponse
-	(*UpdateControlInScopeRequest)(nil),          // 9: confirmate.orchestrator.v1.UpdateControlInScopeRequest
-	(*TransitionControlInScopeStateRequest)(nil), // 10: confirmate.orchestrator.v1.TransitionControlInScopeStateRequest
-	(*RemoveControlInScopeRequest)(nil),          // 11: confirmate.orchestrator.v1.RemoveControlInScopeRequest
-	(*ListAuditTrailEventsRequest)(nil),          // 12: confirmate.orchestrator.v1.ListAuditTrailEventsRequest
-	(*ListAuditTrailEventsResponse)(nil),         // 13: confirmate.orchestrator.v1.ListAuditTrailEventsResponse
-	(*ListControlsInScopeRequest_Filter)(nil),    // 14: confirmate.orchestrator.v1.ListControlsInScopeRequest.Filter
-	(*ListAuditTrailEventsRequest_Filter)(nil),   // 15: confirmate.orchestrator.v1.ListAuditTrailEventsRequest.Filter
-	(*timestamppb.Timestamp)(nil),                // 16: google.protobuf.Timestamp
-	(*anypb.Any)(nil),                            // 17: google.protobuf.Any
+	(*ControlInScopeAssigneeChangedEvent)(nil),   // 5: confirmate.orchestrator.v1.ControlInScopeAssigneeChangedEvent
+	(*ControlInScopeDetailsChangedEvent)(nil),    // 6: confirmate.orchestrator.v1.ControlInScopeDetailsChangedEvent
+	(*CreateControlInScopeRequest)(nil),          // 7: confirmate.orchestrator.v1.CreateControlInScopeRequest
+	(*GetControlInScopeRequest)(nil),             // 8: confirmate.orchestrator.v1.GetControlInScopeRequest
+	(*ListControlsInScopeRequest)(nil),           // 9: confirmate.orchestrator.v1.ListControlsInScopeRequest
+	(*ListControlsInScopeResponse)(nil),          // 10: confirmate.orchestrator.v1.ListControlsInScopeResponse
+	(*UpdateControlInScopeRequest)(nil),          // 11: confirmate.orchestrator.v1.UpdateControlInScopeRequest
+	(*TransitionControlInScopeStateRequest)(nil), // 12: confirmate.orchestrator.v1.TransitionControlInScopeStateRequest
+	(*RemoveControlInScopeRequest)(nil),          // 13: confirmate.orchestrator.v1.RemoveControlInScopeRequest
+	(*ListAuditTrailEventsRequest)(nil),          // 14: confirmate.orchestrator.v1.ListAuditTrailEventsRequest
+	(*ListAuditTrailEventsResponse)(nil),         // 15: confirmate.orchestrator.v1.ListAuditTrailEventsResponse
+	(*ListControlsInScopeRequest_Filter)(nil),    // 16: confirmate.orchestrator.v1.ListControlsInScopeRequest.Filter
+	(*ListAuditTrailEventsRequest_Filter)(nil),   // 17: confirmate.orchestrator.v1.ListAuditTrailEventsRequest.Filter
+	(*timestamppb.Timestamp)(nil),                // 18: google.protobuf.Timestamp
+	(*anypb.Any)(nil),                            // 19: google.protobuf.Any
 }
 var file_api_orchestrator_workflow_proto_depIdxs = []int32{
 	0,  // 0: confirmate.orchestrator.v1.ControlInScope.state:type_name -> confirmate.orchestrator.v1.ControlInScopeState
-	16, // 1: confirmate.orchestrator.v1.ControlInScope.created_at:type_name -> google.protobuf.Timestamp
-	16, // 2: confirmate.orchestrator.v1.ControlInScope.updated_at:type_name -> google.protobuf.Timestamp
-	16, // 3: confirmate.orchestrator.v1.AuditTrailEvent.created_at:type_name -> google.protobuf.Timestamp
-	17, // 4: confirmate.orchestrator.v1.AuditTrailEvent.event_data:type_name -> google.protobuf.Any
+	18, // 1: confirmate.orchestrator.v1.ControlInScope.created_at:type_name -> google.protobuf.Timestamp
+	18, // 2: confirmate.orchestrator.v1.ControlInScope.updated_at:type_name -> google.protobuf.Timestamp
+	18, // 3: confirmate.orchestrator.v1.AuditTrailEvent.created_at:type_name -> google.protobuf.Timestamp
+	19, // 4: confirmate.orchestrator.v1.AuditTrailEvent.event_data:type_name -> google.protobuf.Any
 	0,  // 5: confirmate.orchestrator.v1.ControlInScopeTransitionEvent.from_state:type_name -> confirmate.orchestrator.v1.ControlInScopeState
 	0,  // 6: confirmate.orchestrator.v1.ControlInScopeTransitionEvent.to_state:type_name -> confirmate.orchestrator.v1.ControlInScopeState
-	14, // 7: confirmate.orchestrator.v1.ListControlsInScopeRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsInScopeRequest.Filter
+	16, // 7: confirmate.orchestrator.v1.ListControlsInScopeRequest.filter:type_name -> confirmate.orchestrator.v1.ListControlsInScopeRequest.Filter
 	1,  // 8: confirmate.orchestrator.v1.ListControlsInScopeResponse.controls_in_scope:type_name -> confirmate.orchestrator.v1.ControlInScope
 	0,  // 9: confirmate.orchestrator.v1.TransitionControlInScopeStateRequest.to_state:type_name -> confirmate.orchestrator.v1.ControlInScopeState
-	15, // 10: confirmate.orchestrator.v1.ListAuditTrailEventsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditTrailEventsRequest.Filter
+	17, // 10: confirmate.orchestrator.v1.ListAuditTrailEventsRequest.filter:type_name -> confirmate.orchestrator.v1.ListAuditTrailEventsRequest.Filter
 	2,  // 11: confirmate.orchestrator.v1.ListAuditTrailEventsResponse.audit_trail_events:type_name -> confirmate.orchestrator.v1.AuditTrailEvent
 	0,  // 12: confirmate.orchestrator.v1.ListControlsInScopeRequest.Filter.state:type_name -> confirmate.orchestrator.v1.ControlInScopeState
 	13, // [13:13] is the sub-list for method output_type
@@ -1295,16 +1450,18 @@ func file_api_orchestrator_workflow_proto_init() {
 	file_api_orchestrator_workflow_proto_msgTypes[4].OneofWrappers = []any{}
 	file_api_orchestrator_workflow_proto_msgTypes[6].OneofWrappers = []any{}
 	file_api_orchestrator_workflow_proto_msgTypes[8].OneofWrappers = []any{}
-	file_api_orchestrator_workflow_proto_msgTypes[11].OneofWrappers = []any{}
+	file_api_orchestrator_workflow_proto_msgTypes[10].OneofWrappers = []any{}
+	file_api_orchestrator_workflow_proto_msgTypes[12].OneofWrappers = []any{}
 	file_api_orchestrator_workflow_proto_msgTypes[13].OneofWrappers = []any{}
-	file_api_orchestrator_workflow_proto_msgTypes[14].OneofWrappers = []any{}
+	file_api_orchestrator_workflow_proto_msgTypes[15].OneofWrappers = []any{}
+	file_api_orchestrator_workflow_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_orchestrator_workflow_proto_rawDesc), len(file_api_orchestrator_workflow_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/core/api/orchestrator/workflow.proto
+++ b/core/api/orchestrator/workflow.proto
@@ -140,6 +140,21 @@ message ControlInScopeTransitionEvent {
   ControlInScopeState to_state            = 3;
 }
 
+// ControlInScopeAssigneeChangedEvent is emitted when the assignee of a ControlInScope changes.
+message ControlInScopeAssigneeChangedEvent {
+  string control_in_scope_id = 1;
+  // previous_assignee_id is empty when there was no prior assignee.
+  optional string previous_assignee_id = 2;
+  // new_assignee_id is empty when the assignee is removed.
+  optional string new_assignee_id = 3;
+}
+
+// ControlInScopeDetailsChangedEvent is emitted when implementation_details is updated.
+// The content of the details is intentionally not included.
+message ControlInScopeDetailsChangedEvent {
+  string control_in_scope_id = 1;
+}
+
 // ── Request / Response messages ──────────────────────────────────────────────
 
 message CreateControlInScopeRequest {
@@ -162,6 +177,9 @@ message CreateControlInScopeRequest {
 
   // AssigneeId is the ID of the orchestrator User entity initially responsible for this control.
   optional string assignee_id = 3;
+
+  // Comment explains why this control is being brought into scope.
+  optional string comment = 5;
 }
 
 message GetControlInScopeRequest {
@@ -181,6 +199,9 @@ message ListControlsInScopeRequest {
 
     // Optional. Filter by assignee.
     optional string assignee_id = 3;
+
+    // Optional. Filter by control ID.
+    optional string control_id = 4 [(buf.validate.field).string.uuid = true];
   }
 
   optional Filter filter = 1;
@@ -231,6 +252,9 @@ message RemoveControlInScopeRequest {
     (buf.validate.field).string.uuid = true,
     (google.api.field_behavior) = REQUIRED
   ];
+
+  // Comment explains why this control is being removed from scope.
+  optional string comment = 2;
 }
 
 message ListAuditTrailEventsRequest {

--- a/core/buf.gen.yaml
+++ b/core/buf.gen.yaml
@@ -6,3 +6,7 @@ plugins:
   - remote: buf.build/connectrpc/go
     out: .
     opt: paths=source_relative
+  - remote: buf.build/community/google-gnostic-openapi
+    out: api
+    opt:
+      - enum_type=string

--- a/core/server/commands/confirmate.go
+++ b/core/server/commands/confirmate.go
@@ -117,7 +117,7 @@ func runConfirmate(ctx context.Context, cmd *cli.Command) (err error) {
 		evaluationOpts      []service.Option[evaluation.Service]
 		orchestratorSvc     orchestratorconnect.OrchestratorHandler
 		assessmentSvc       assessmentconnect.AssessmentHandler
-		evidenceSvc         evidenceconnect.EvidenceStoreHandler
+		evidenceSvc         *evidence.Service
 		evaluationSvc       evaluationconnect.EvaluationHandler
 		orchestratorClient  *http.Client
 		evaluationClient    *http.Client
@@ -261,6 +261,10 @@ func runConfirmate(ctx context.Context, cmd *cli.Command) (err error) {
 			connect.WithInterceptors(interceptors...),
 		)),
 		server.WithHandler(evidenceconnect.NewEvidenceStoreHandler(
+			evidenceSvc,
+			connect.WithInterceptors(interceptors...),
+		)),
+		server.WithHandler(evidenceconnect.NewResourcesHandler(
 			evidenceSvc,
 			connect.WithInterceptors(interceptors...),
 		)),

--- a/core/server/commands/evidence_store.go
+++ b/core/server/commands/evidence_store.go
@@ -136,6 +136,10 @@ var EvidenceCommand = &cli.Command{
 				svc,
 				connect.WithInterceptors(interceptors...),
 			)),
+			server.WithHandler(evidenceconnect.NewResourcesHandler(
+				svc,
+				connect.WithInterceptors(&server.LoggingInterceptor{}),
+			)),
 			server.WithReflection(),
 		)
 	},

--- a/core/server/commands/evidence_store.go
+++ b/core/server/commands/evidence_store.go
@@ -138,7 +138,7 @@ var EvidenceCommand = &cli.Command{
 			)),
 			server.WithHandler(evidenceconnect.NewResourcesHandler(
 				svc,
-				connect.WithInterceptors(&server.LoggingInterceptor{}),
+				connect.WithInterceptors(interceptors...),
 			)),
 			server.WithReflection(),
 		)

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -37,6 +37,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/lmittmann/tint"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -75,6 +76,7 @@ type Config struct {
 // Service is an implementation of the Confirmate req service (evidenceServer)
 type Service struct {
 	evidenceconnect.UnimplementedEvidenceStoreHandler
+	evidenceconnect.UnimplementedResourcesHandler
 
 	db  persistence.DB
 	cfg Config
@@ -247,7 +249,7 @@ func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evid
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
-	slog.Debug("evidence stored",
+	slog.Debug("Evidence stored",
 		slog.String("evidence_id", req.Msg.Evidence.Id),
 		slog.String("tool_id", req.Msg.Evidence.ToolId),
 		slog.String("target_of_evaluation_id", req.Msg.Evidence.TargetOfEvaluationId))
@@ -264,26 +266,26 @@ func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evid
 		req.Msg.Evidence.GetToolId(),
 	)
 	if err != nil {
-		// Only reveal limited information about the error to the client
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not convert resource (proto to DB): %w", err))
 	}
-	// Persist the latest state of the resource; Save already uses the primary key.
+	// Persist the latest snapshot of the resource; Save already uses the primary key.
 	err = svc.db.Save(r)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
-	slog.Debug("resource upserted for evidence",
+	slog.Debug("Resource snapshot upserted for evidence",
 		slog.String("resource_id", r.Id),
 		slog.String("resource_type", r.ResourceType),
 		slog.String("evidence_id", req.Msg.Evidence.Id))
 
 	go svc.informHooks(ctx, req.Msg.Evidence, nil)
 
-	// Send evidence to the channel for further processing and acknowledge receipt, without waiting for the processing to finish. This allows the sender to continue
-	// without waiting for the evidence to be processed.
+	// Send evidence to the channel for further processing and acknowledge receipt, without waiting
+	// for the processing to finish. This allows the sender to continue without waiting for the
+	// evidence to be processed.
 	svc.channelEvidence <- req.Msg.Evidence
 
-	slog.Debug("received and handled store evidence request",
+	slog.Debug("Received and handled store evidence request",
 		slog.String("evidence_id", req.Msg.Evidence.Id))
 	res = connect.NewResponse(&evidence.StoreEvidenceResponse{})
 	return
@@ -520,6 +522,70 @@ func (svc *Service) ListResources(_ context.Context, req *connect.Request[eviden
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
+
+	return
+}
+
+// ListGraphEdges returns edges between resources derived via [ontology.Related], which finds all
+// _id/_ids fields on each concrete ontology resource and matches them against known resource IDs.
+// This implements the [evidenceconnect.ResourcesHandler.ListGraphEdges] RPC method.
+func (svc *Service) ListGraphEdges(_ context.Context, req *connect.Request[evidence.ListGraphEdgesRequest]) (
+	res *connect.Response[evidence.ListGraphEdgesResponse], err error) {
+	var (
+		snapshots []*evidence.ResourceSnapshot
+		edges     []*evidence.GraphEdge
+	)
+
+	// Validate request
+	if err = service.Validate(req); err != nil {
+		return nil, err
+	}
+
+	if err = svc.db.List(&snapshots, "id", true, 0, -1); err != nil {
+		return nil, service.HandleDatabaseError(err)
+	}
+
+	// Build a set of all known resource IDs for fast lookup.
+	ids := make(map[string]struct{}, len(snapshots))
+	for _, s := range snapshots {
+		ids[s.Id] = struct{}{}
+	}
+
+	seen := make(map[string]struct{})
+
+	for _, s := range snapshots {
+		if s.Resource == nil {
+			continue
+		}
+		// The ontology Resource is a oneof — ranging over it visits only the set concrete field.
+		s.Resource.ProtoReflect().Range(func(_ protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+			concrete, ok := v.Message().Interface().(ontology.IsResource)
+			if !ok {
+				return true
+			}
+			for _, rel := range ontology.Related(concrete) {
+				if _, ok := ids[rel.Value]; !ok {
+					continue
+				}
+				edgeID := s.Id + "→" + rel.Value
+				if _, dup := seen[edgeID]; dup {
+					continue
+				}
+				seen[edgeID] = struct{}{}
+				edges = append(edges, &evidence.GraphEdge{
+					Id:     edgeID,
+					Source: s.Id,
+					Target: rel.Value,
+					Type:   rel.Property,
+				})
+			}
+			return true
+		})
+	}
+
+	res = connect.NewResponse(&evidence.ListGraphEdgesResponse{
+		Edges: edges,
+	})
 
 	return
 }

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -567,7 +567,7 @@ func (svc *Service) ListGraphEdges(_ context.Context, req *connect.Request[evide
 				if _, ok := ids[rel.Value]; !ok {
 					continue
 				}
-				edgeID := s.Id + "→" + rel.Value
+				edgeID := s.Id + "→" + rel.Value + "→" + rel.Property
 				if _, dup := seen[edgeID]; dup {
 					continue
 				}
@@ -583,9 +583,13 @@ func (svc *Service) ListGraphEdges(_ context.Context, req *connect.Request[evide
 		})
 	}
 
-	res = connect.NewResponse(&evidence.ListGraphEdgesResponse{
-		Edges: edges,
-	})
+	res = connect.NewResponse(&evidence.ListGraphEdgesResponse{})
+	res.Msg.Edges, res.Msg.NextPageToken, err = service.PaginateSlice(req.Msg, edges, func(a, b *evidence.GraphEdge) bool {
+		return a.Id < b.Id
+	}, service.DefaultPaginationOpts)
+	if err != nil {
+		return nil, err
+	}
 
 	return
 }

--- a/core/service/evidence/service.go
+++ b/core/service/evidence/service.go
@@ -268,12 +268,12 @@ func (svc *Service) StoreEvidence(ctx context.Context, req *connect.Request[evid
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not convert resource (proto to DB): %w", err))
 	}
-	// Persist the latest snapshot of the resource; Save already uses the primary key.
+	// Persist the latest state of the resource; Save already uses the primary key.
 	err = svc.db.Save(r)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}
-	slog.Debug("Resource snapshot upserted for evidence",
+	slog.Debug("Resource upserted for evidence",
 		slog.String("resource_id", r.Id),
 		slog.String("resource_type", r.ResourceType),
 		slog.String("evidence_id", req.Msg.Evidence.Id))

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -152,6 +152,16 @@ func (svc *Service) ListAssessmentResults(
 			whereClauses = append(whereClauses, "metric_id = ?")
 			args = append(args, req.Msg.Filter.GetMetricId())
 		}
+		if len(req.Msg.Filter.MetricIds) > 0 {
+			// Build IN clause dynamically to support ramsql (doesn't support array binding)
+			var placeholders string
+			placeholders = strings.Repeat("?,", len(req.Msg.Filter.MetricIds))
+			placeholders = placeholders[:len(placeholders)-1] // Remove trailing comma
+			whereClauses = append(whereClauses, "metric_id IN ("+placeholders+")")
+			for _, id := range req.Msg.Filter.MetricIds {
+				args = append(args, id)
+			}
+		}
 		if req.Msg.Filter.ToolId != nil {
 			whereClauses = append(whereClauses, "tool_id = ?")
 			args = append(args, req.Msg.Filter.GetToolId())

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -123,7 +123,7 @@ func (svc *Service) ListAssessmentResults(
 		npt          string
 		where        string
 		args         []any
-		whereClauses []string
+		query        []string
 		all          bool
 		toeIds       []string
 	)
@@ -142,37 +142,30 @@ func (svc *Service) ListAssessmentResults(
 	// Apply filters if provided
 	if req.Msg.Filter != nil {
 		if req.Msg.Filter.TargetOfEvaluationId != nil {
-			whereClauses = append(whereClauses, "target_of_evaluation_id = ?")
+			query = append(query, "target_of_evaluation_id = ?")
 			args = append(args, req.Msg.Filter.GetTargetOfEvaluationId())
 		}
 		if req.Msg.Filter.Compliant != nil {
-			whereClauses = append(whereClauses, "compliant = ?")
+			query = append(query, "compliant = ?")
 			args = append(args, req.Msg.Filter.GetCompliant())
 		}
 		if req.Msg.Filter.MetricId != nil {
-			whereClauses = append(whereClauses, "metric_id = ?")
+			query = append(query, "metric_id = ?")
 			args = append(args, req.Msg.Filter.GetMetricId())
 		}
 		if len(req.Msg.Filter.MetricIds) > 0 {
-			// Build IN clause dynamically to support ramsql (doesn't support array binding)
-			var placeholders string
-			placeholders = strings.Repeat("?,", len(req.Msg.Filter.MetricIds))
-			placeholders = placeholders[:len(placeholders)-1] // Remove trailing comma
-			whereClauses = append(whereClauses, "metric_id IN ("+placeholders+")")
-			for _, id := range req.Msg.Filter.MetricIds {
-				args = append(args, id)
-			}
+			query, args = persistence.AppendObjectIds(req.Msg.Filter.MetricIds, query, args, "metric_id")
 		}
 		if req.Msg.Filter.ToolId != nil {
-			whereClauses = append(whereClauses, "tool_id = ?")
+			query = append(query, "tool_id = ?")
 			args = append(args, req.Msg.Filter.GetToolId())
 		}
 		if len(req.Msg.Filter.AssessmentResultIds) > 0 {
 			// Build IN clause dynamically to support ramsql (doesn't support array binding)
-			whereClauses, args = persistence.AppendObjectIds(req.Msg.Filter.AssessmentResultIds, whereClauses, args, "id")
+			query, args = persistence.AppendObjectIds(req.Msg.Filter.AssessmentResultIds, query, args, "id")
 		}
 		if req.Msg.Filter.EvidenceId != nil {
-			whereClauses = append(whereClauses, "evidence_id = ?")
+			query = append(query, "evidence_id = ?")
 			args = append(args, req.Msg.Filter.GetEvidenceId())
 		}
 	}
@@ -192,15 +185,14 @@ func (svc *Service) ListAssessmentResults(
 	// Since all where clauses are combined with AND later, a requested ToE must also
 	// be part of the allowed toeIds; otherwise, the query returns no results.
 	if !all {
-		whereClauses, args = persistence.AppendObjectIds(toeIds, whereClauses, args, "target_of_evaluation_id")
+		query, args = persistence.AppendObjectIds(toeIds, query, args, "target_of_evaluation_id")
 	}
 
 	// Combine all WHERE clauses with AND
-	if len(whereClauses) > 0 {
-		where = strings.Join(whereClauses, " AND ")
-		conds = append(conds, where)
-		conds = append(conds, args...)
+	if len(query) > 0 {
+		where = strings.Join(query, " AND ")
 	}
+	conds = persistence.BuildConds(query, args)
 
 	// Handle latest_by_resource_id filter
 	// This returns only the most recent assessment result for each unique (resource_id, metric_id) pair

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -189,9 +189,7 @@ func (svc *Service) ListAssessmentResults(
 	}
 
 	// Combine all WHERE clauses with AND
-	if len(query) > 0 {
-		where = strings.Join(query, " AND ")
-	}
+	where = strings.Join(query, " AND ")
 	conds = persistence.BuildConds(query, args)
 
 	// Handle latest_by_resource_id filter

--- a/core/service/orchestrator/assessment_results.go
+++ b/core/service/orchestrator/assessment_results.go
@@ -118,14 +118,13 @@ func (svc *Service) ListAssessmentResults(
 	req *connect.Request[orchestrator.ListAssessmentResultsRequest],
 ) (res *connect.Response[orchestrator.ListAssessmentResultsResponse], err error) {
 	var (
-		results      []*assessment.AssessmentResult
-		conds        []any
-		npt          string
-		where        string
-		args         []any
-		query        []string
-		all          bool
-		toeIds       []string
+		results []*assessment.AssessmentResult
+		npt     string
+		where   string
+		args    []any
+		query   []string
+		all     bool
+		toeIds  []string
 	)
 
 	// Validate the request
@@ -188,29 +187,25 @@ func (svc *Service) ListAssessmentResults(
 		query, args = persistence.AppendObjectIds(toeIds, query, args, "target_of_evaluation_id")
 	}
 
-	// Combine all WHERE clauses with AND
-	where = strings.Join(query, " AND ")
-	conds = persistence.BuildConds(query, args)
-
 	// Handle latest_by_resource_id filter
 	// This returns only the most recent assessment result for each unique (resource_id, metric_id) pair
 	// Uses PostgreSQL's DISTINCT ON for efficient grouping
 	if req.Msg.LatestByResourceId != nil && req.Msg.GetLatestByResourceId() {
-		// Reuse the WHERE query and args directly.
+		// Combine all WHERE clauses with AND and reuse the query and args directly.
+		where = strings.Join(query, " AND ")
 		if where != "" {
 			where = "WHERE " + where
 		}
 
 		// Use PostgreSQL DISTINCT ON with ORDER BY to get latest result per (resource_id, metric_id)
-		var query string
-		query = fmt.Sprintf(`
+		rawQuery := fmt.Sprintf(`
 			SELECT DISTINCT ON (resource_id, metric_id) *
 			FROM assessment_results
 			%s
 			ORDER BY resource_id, metric_id, created_at DESC
 		`, where)
 
-		err = svc.db.Raw(&results, query, args...)
+		err = svc.db.Raw(&results, rawQuery, args...)
 		if err = service.HandleDatabaseError(err); err != nil {
 			return nil, err
 		}
@@ -224,7 +219,7 @@ func (svc *Service) ListAssessmentResults(
 		return
 	}
 
-	results, npt, err = service.PaginateStorage[*assessment.AssessmentResult](req.Msg, svc.db, service.DefaultPaginationOpts, conds...)
+	results, npt, err = service.PaginateStorage[*assessment.AssessmentResult](req.Msg, svc.db, service.DefaultPaginationOpts, persistence.BuildConds(query, args)...)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}

--- a/core/service/orchestrator/metrics.go
+++ b/core/service/orchestrator/metrics.go
@@ -548,12 +548,55 @@ func (svc *Service) loadMetricsFromRepository() (metrics []*assessment.Metric, e
 			return fmt.Errorf("error accessing path %s: %w", path, err)
 		}
 
-		// Skip directories and non-yaml files
-		if info.IsDir() || (!strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml")) {
+		// Skip directories and unsupported file types
+		if info.IsDir() {
 			return nil
 		}
 
-		// Read the YAML file
+		// JSON files: treat as an array of metrics
+		if strings.HasSuffix(info.Name(), ".json") {
+			b, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("error reading file %s: %w", path, err)
+			}
+			var batch []*assessment.Metric
+			if err = json.Unmarshal(b, &batch); err != nil {
+				slog.Warn("Could not parse metrics JSON file, skipping", "file", info.Name(), log.Err(err))
+				return nil
+			}
+			// Try to load Rego implementations from the security-metrics repo
+			// for metrics that have a matching directory. Look in both the
+			// configured metrics path and the standard security-metrics location.
+			for i := range batch {
+				metric := batch[i]
+				// Try to load Rego implementations and default configurations
+				// from the security-metrics repo for metrics that have a
+				// matching directory. Look in both the configured metrics path
+				// and the standard security-metrics location.
+				for _, base := range []string{svc.cfg.DefaultMetricsPath, filepath.Join("policies", "security-metrics", "metrics")} {
+					regoDir := filepath.Join(base, metric.Category, metric.Name)
+					metric.Implementation, err = loadMetricImplementation(metric.Id, regoDir)
+					if err != nil {
+						slog.Debug("Could not load metric implementation", "metric", metric.Id, log.Err(err))
+					}
+					// Load default configuration from data.json if it exists
+					if err = prepareMetric(metric, filepath.Join(regoDir, "dummy.yaml")); err != nil {
+						slog.Debug("Could not load metric configuration", "metric", metric.Id, log.Err(err))
+					}
+					if metric.Implementation != nil {
+						break
+					}
+				}
+			}
+			metrics = append(metrics, batch...)
+			return nil
+		}
+
+		// YAML files: single metric per file
+		if !strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml") {
+			return nil
+		}
+
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("error reading file %s: %w", path, err)

--- a/core/service/orchestrator/metrics.go
+++ b/core/service/orchestrator/metrics.go
@@ -548,55 +548,12 @@ func (svc *Service) loadMetricsFromRepository() (metrics []*assessment.Metric, e
 			return fmt.Errorf("error accessing path %s: %w", path, err)
 		}
 
-		// Skip directories and unsupported file types
-		if info.IsDir() {
+		// Skip directories and non-yaml files
+		if info.IsDir() || (!strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml")) {
 			return nil
 		}
 
-		// JSON files: treat as an array of metrics
-		if strings.HasSuffix(info.Name(), ".json") {
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("error reading file %s: %w", path, err)
-			}
-			var batch []*assessment.Metric
-			if err = json.Unmarshal(b, &batch); err != nil {
-				slog.Warn("Could not parse metrics JSON file, skipping", "file", info.Name(), log.Err(err))
-				return nil
-			}
-			// Try to load Rego implementations from the security-metrics repo
-			// for metrics that have a matching directory. Look in both the
-			// configured metrics path and the standard security-metrics location.
-			for i := range batch {
-				metric := batch[i]
-				// Try to load Rego implementations and default configurations
-				// from the security-metrics repo for metrics that have a
-				// matching directory. Look in both the configured metrics path
-				// and the standard security-metrics location.
-				for _, base := range []string{svc.cfg.DefaultMetricsPath, filepath.Join("policies", "security-metrics", "metrics")} {
-					regoDir := filepath.Join(base, metric.Category, metric.Name)
-					metric.Implementation, err = loadMetricImplementation(metric.Id, regoDir)
-					if err != nil {
-						slog.Debug("Could not load metric implementation", "metric", metric.Id, log.Err(err))
-					}
-					// Load default configuration from data.json if it exists
-					if err = prepareMetric(metric, filepath.Join(regoDir, "dummy.yaml")); err != nil {
-						slog.Debug("Could not load metric configuration", "metric", metric.Id, log.Err(err))
-					}
-					if metric.Implementation != nil {
-						break
-					}
-				}
-			}
-			metrics = append(metrics, batch...)
-			return nil
-		}
-
-		// YAML files: single metric per file
-		if !strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml") {
-			return nil
-		}
-
+		// Read the YAML file
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("error reading file %s: %w", path, err)

--- a/core/service/orchestrator/workflow.go
+++ b/core/service/orchestrator/workflow.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 
+	"confirmate.io/core/api/evaluation"
 	"confirmate.io/core/api/orchestrator"
 	"confirmate.io/core/auth"
 	"confirmate.io/core/persistence"
@@ -156,7 +157,7 @@ func (svc *Service) CreateControlInScope(
 		if err = tx.Create(cis); err != nil {
 			return service.HandleDatabaseError(err)
 		}
-		return createAuditTrailEvent(tx, actorFromContext(ctx), cis.AuditScopeId, cis.Id, "",
+		return createAuditTrailEvent(tx, actorFromContext(ctx), cis.AuditScopeId, cis.Id, req.Msg.GetComment(),
 			&orchestrator.ControlScopingEvent{
 				ControlInScopeId: cis.Id,
 				ControlId:        cis.ControlId,
@@ -262,6 +263,10 @@ func (svc *Service) ListControlsInScope(
 			query = append(query, "assignee_id = ?")
 			args = append(args, f.GetAssigneeId())
 		}
+		if f.ControlId != nil {
+			query = append(query, "control_id = ?")
+			args = append(args, f.GetControlId())
+		}
 	}
 
 	if len(query) > 0 {
@@ -312,11 +317,35 @@ func (svc *Service) UpdateControlInScope(
 		return nil, service.ErrPermissionDenied
 	}
 
+	prevAssigneeId := existing.GetAssigneeId()
+	prevDetails := existing.GetImplementationDetails()
 	existing.AssigneeId = req.Msg.AssigneeId
 	existing.ImplementationDetails = req.Msg.ImplementationDetails
 	existing.UpdatedAt = timestamppb.Now()
 
-	err = svc.db.Update(&existing, "id = ?", existing.Id)
+	err = svc.db.Transaction(func(tx persistence.DB) error {
+		if err := tx.Update(&existing, "id = ?", existing.Id); err != nil {
+			return service.HandleDatabaseError(err, service.ErrNotFound("control in scope"))
+		}
+		actor := actorFromContext(ctx)
+		if prevAssigneeId != req.Msg.GetAssigneeId() {
+			if err := createAuditTrailEvent(tx, actor, existing.AuditScopeId, existing.Id, "",
+				&orchestrator.ControlInScopeAssigneeChangedEvent{
+					ControlInScopeId:   existing.Id,
+					PreviousAssigneeId: &prevAssigneeId,
+					NewAssigneeId:      req.Msg.AssigneeId,
+				}); err != nil {
+				return err
+			}
+		}
+		if prevDetails != req.Msg.GetImplementationDetails() {
+			return createAuditTrailEvent(tx, actor, existing.AuditScopeId, existing.Id, "",
+				&orchestrator.ControlInScopeDetailsChangedEvent{
+					ControlInScopeId: existing.Id,
+				})
+		}
+		return nil
+	})
 	if err = service.HandleDatabaseError(err, service.ErrNotFound("control in scope")); err != nil {
 		return nil, err
 	}
@@ -419,18 +448,41 @@ func (svc *Service) RemoveControlInScope(
 		return nil, service.ErrPermissionDenied
 	}
 
+	actor := actorFromContext(ctx)
 	err = svc.db.Transaction(func(tx persistence.DB) error {
-		// control_in_scope_id is intentionally empty: the ControlInScope record is deleted
-		// in this same transaction, so linking to it would create a dangling reference.
-		if err = createAuditTrailEvent(tx, actorFromContext(ctx), cis.AuditScopeId, "", "",
-			&orchestrator.ControlScopingEvent{
-				ControlId:    cis.ControlId,
-				AuditScopeId: cis.AuditScopeId,
-				InScope:      false,
-			}); err != nil {
+		// Cascade: removing a parent control from scope also removes every
+		// descendant ControlInScope record so the subtree state stays consistent
+		// — a sub-control can't be "in scope" while its parent isn't.
+		victims, err := collectControlInScopeSubtree(tx, cis.AuditScopeId, cis.ControlId)
+		if err != nil {
 			return err
 		}
-		return tx.Delete(&cis, "id = ?", cis.Id)
+		victims = append([]*orchestrator.ControlInScope{&cis}, victims...)
+		for _, victim := range victims {
+			// control_in_scope_id is intentionally empty: the ControlInScope record
+			// is deleted in this same transaction, so linking to it would create a
+			// dangling reference.
+			if err := createAuditTrailEvent(tx, actor, victim.AuditScopeId, "", req.Msg.GetComment(),
+				&orchestrator.ControlScopingEvent{
+					ControlId:    victim.ControlId,
+					AuditScopeId: victim.AuditScopeId,
+					InScope:      false,
+				}); err != nil {
+				return err
+			}
+			if err := tx.Delete(&orchestrator.ControlInScope{}, "id = ?", victim.Id); err != nil {
+				return err
+			}
+			// Remove any existing evaluation results for this control so the UI
+			// shows it as "not evaluated" instead of a stale status. Ignore
+			// not-found — there may be no results to delete.
+			if err := tx.Delete(&evaluation.EvaluationResult{},
+				"control_id = ? AND audit_scope_id = ?", victim.ControlId, victim.AuditScopeId,
+			); err != nil && !errors.Is(err, persistence.ErrRecordNotFound) {
+				return err
+			}
+		}
+		return nil
 	})
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
@@ -438,6 +490,44 @@ func (svc *Service) RemoveControlInScope(
 
 	res = connect.NewResponse(&emptypb.Empty{})
 	return
+}
+
+// collectControlInScopeSubtree returns every ControlInScope record under the
+// given audit scope whose Control is a descendant of rootControlId, by walking
+// the Control.parent_control_id chain breadth-first. The root record itself is
+// not included.
+func collectControlInScopeSubtree(db persistence.DB, auditScopeId, rootControlId string) ([]*orchestrator.ControlInScope, error) {
+	var (
+		queue       = []string{rootControlId}
+		descendants []*orchestrator.ControlInScope
+		visited     = map[string]struct{}{rootControlId: {}}
+	)
+
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+
+		var children []*orchestrator.Control
+		if err := db.List(&children, "id", true, 0, -1, "parent_control_id = ?", parent); err != nil {
+			return nil, fmt.Errorf("list child controls of %q: %w", parent, err)
+		}
+		for _, c := range children {
+			if _, seen := visited[c.Id]; seen {
+				continue
+			}
+			visited[c.Id] = struct{}{}
+			queue = append(queue, c.Id)
+
+			var cis []*orchestrator.ControlInScope
+			if err := db.List(&cis, "id", true, 0, -1,
+				"audit_scope_id = ? AND control_id = ?", auditScopeId, c.Id); err != nil {
+				return nil, fmt.Errorf("list controls in scope for %q: %w", c.Id, err)
+			}
+			descendants = append(descendants, cis...)
+		}
+	}
+
+	return descendants, nil
 }
 
 // ListAuditTrailEvents lists audit trail events, optionally filtered by audit scope.
@@ -500,7 +590,7 @@ func (svc *Service) ListAuditTrailEvents(
 		conds = persistence.BuildConds(query, args)
 	}
 
-	events, npt, err = service.PaginateStorage[*orchestrator.AuditTrailEvent](req.Msg, svc.db, service.DefaultPaginationOpts, conds...)
+	events, npt, err = service.PaginateStorage[*orchestrator.AuditTrailEvent](req.Msg, svc.db, service.DefaultPaginationOpts, append(conds, persistence.WithoutPreload())...)
 	if err = service.HandleDatabaseError(err); err != nil {
 		return nil, err
 	}

--- a/core/service/orchestrator/workflow.go
+++ b/core/service/orchestrator/workflow.go
@@ -317,7 +317,7 @@ func (svc *Service) UpdateControlInScope(
 		return nil, service.ErrPermissionDenied
 	}
 
-	prevAssigneeId := existing.GetAssigneeId()
+	prevAssigneeId := existing.AssigneeId
 	prevDetails := existing.GetImplementationDetails()
 	existing.AssigneeId = req.Msg.AssigneeId
 	existing.ImplementationDetails = req.Msg.ImplementationDetails
@@ -328,11 +328,11 @@ func (svc *Service) UpdateControlInScope(
 			return service.HandleDatabaseError(err, service.ErrNotFound("control in scope"))
 		}
 		actor := actorFromContext(ctx)
-		if prevAssigneeId != req.Msg.GetAssigneeId() {
+		if !assigneeIdsEqual(prevAssigneeId, req.Msg.AssigneeId) {
 			if err := createAuditTrailEvent(tx, actor, existing.AuditScopeId, existing.Id, "",
 				&orchestrator.ControlInScopeAssigneeChangedEvent{
 					ControlInScopeId:   existing.Id,
-					PreviousAssigneeId: &prevAssigneeId,
+					PreviousAssigneeId: prevAssigneeId,
 					NewAssigneeId:      req.Msg.AssigneeId,
 				}); err != nil {
 				return err
@@ -352,6 +352,15 @@ func (svc *Service) UpdateControlInScope(
 
 	res = connect.NewResponse(&existing)
 	return
+}
+
+// assigneeIdsEqual reports whether two optional assignee IDs are equal, treating a nil pointer
+// (unset) as distinct from a pointer to an empty string (explicitly cleared).
+func assigneeIdsEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // TransitionControlInScopeState moves a ControlInScope to a new implementation state, enforcing


### PR DESCRIPTION
Re-opens the work from #407 against `main`.

#407 targeted `oxisto/backend-fixes` and was squash-merged there as `e98568c7`. Since `oxisto/backend-fixes` had already been merged into `main` (via #406, squashed as `887b0a74`) and was never merged back afterwards, those API additions never reached `main`. This PR carries them over.

The branch is rebased directly onto `main`, so it also preserves the commits `main` gained in the meantime (#433 Postgres fix, #427 background context, and the dependency/submodule bumps) — merging `oxisto/backend-fixes` into `main` instead would have reverted them.

## Commits

- `evidence: implement ListGraphEdges and register Resources handler`
- `orchestrator: extend control scoping workflow`
- `orchestrator: support MetricIds filter in ListAssessmentResults`
- `orchestrator: load metrics from JSON files in the metrics repository`
- `Address review comments on PR #407`

## Review feedback from #407

@anatheka's comments are addressed in the final commit:

- **`metrics.go`** — reverted the JSON metrics-array loading back to YAML-only. It had been carried over from the UI branch unintentionally and would break on every `data.json` in `security-metrics/metrics/**` (those are config objects, not metric arrays).
- **`evidence/service.go`** — reverted the "Resource snapshot" wording; it is a single-row upsert, not stored history.
- **`evidence.proto`** — dropped the `ListGraphEdges` route comment, since the `/graph/` nesting predates the PR.

Two threads on #407 (`evaluation.proto` conflict question, `service.go` permission-error wording) referred to a `TriggerEvaluation` RPC and a `scopeIds` permission check that no longer exist on this branch after an earlier rebase.

## Verification

`go build` and `go vet` clean. Test failures are identical to those on `main` at `c3452f8a` (5 pre-existing failures in `service/assessment` and `server/commands`) — no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)